### PR TITLE
Cal/cleanup

### DIFF
--- a/docs/todo.txt
+++ b/docs/todo.txt
@@ -2,6 +2,7 @@
 IN PROGRESS
 ***********
 
+GfxResMan should try to get rid of strings as keys
 Mesh and Model may not need default ctors anymore - requires major changes to Prefab.cpp
 
 ***********

--- a/nc/include/ECS.h
+++ b/nc/include/ECS.h
@@ -26,16 +26,16 @@ namespace nc
             [[nodiscard]] static Entity* GetEntity(EntityHandle handle);
             [[nodiscard]] static Entity* GetEntity(std::string tag);
 
-            template<std::derived_from<Component> T, class ...Args>
+            template<std::derived_from<ComponentBase> T, class ...Args>
             static T* AddComponent(EntityHandle handle, Args ... args);
             
-            template<std::derived_from<Component> T>
+            template<std::derived_from<ComponentBase> T>
             static bool RemoveComponent(EntityHandle handle);
             
-            template<std::derived_from<Component> T>
+            template<std::derived_from<ComponentBase> T>
             [[nodiscard]] static T* GetComponent(EntityHandle handle);
             
-            template<std::derived_from<Component> T>
+            template<std::derived_from<ComponentBase> T>
             [[nodiscard]] static bool HasComponent(EntityHandle handle);
 
         private:
@@ -64,7 +64,7 @@ namespace nc
     template<> bool Ecs::HasComponent<Collider>(EntityHandle handle);
     template<> bool Ecs::RemoveComponent<Collider>(EntityHandle handle);
 
-    template<std::derived_from<Component> T, class ... Args>
+    template<std::derived_from<ComponentBase> T, class ... Args>
     T * Ecs::AddComponent(const EntityHandle handle, Args ... args)
     {
         auto ptr = GetEntity(handle);
@@ -72,7 +72,7 @@ namespace nc
         return ptr->AddUserComponent<T>(std::forward<Args>(args)...);
     }
 
-    template<std::derived_from<Component> T>
+    template<std::derived_from<ComponentBase> T>
     bool Ecs::RemoveComponent(const EntityHandle handle)
     {
         auto ptr = GetEntity(handle);
@@ -80,7 +80,7 @@ namespace nc
         return ptr->RemoveUserComponent<T>();
     }
 
-    template<std::derived_from<Component> T>
+    template<std::derived_from<ComponentBase> T>
     T * Ecs::GetComponent(const EntityHandle handle)
     {
         auto ptr = GetEntity(handle);
@@ -88,7 +88,7 @@ namespace nc
         return ptr->GetUserComponent<T>();
     }
 
-    template<std::derived_from<Component> T>
+    template<std::derived_from<ComponentBase> T>
     bool Ecs::HasComponent(const EntityHandle handle)
     {
         auto ptr = GetEntity(handle);

--- a/nc/source/component/Collider.cpp
+++ b/nc/source/component/Collider.cpp
@@ -15,7 +15,7 @@ namespace
 namespace nc
 {
     Collider::Collider(EntityHandle handle, Vector3 scale)
-        : Component(handle),
+        : ComponentBase(handle),
           m_transform{Ecs::GetComponent<Transform>(handle)},
           m_scale{scale},
           m_model{ColliderMesh, GetColliderMaterial()}

--- a/nc/source/component/Collider.h
+++ b/nc/source/component/Collider.h
@@ -6,7 +6,7 @@
 
 namespace nc
 {
-    class Collider : public Component
+    class Collider final : public ComponentBase
     {
         public:
             Collider(EntityHandle handle, Vector3 scale);

--- a/nc/source/component/Component.cpp
+++ b/nc/source/component/Component.cpp
@@ -4,12 +4,10 @@
 #include "imgui/imgui.h"
 #endif
 
-#include <string>
-
 namespace nc
 {
     #ifdef NC_EDITOR_ENABLED
-    void Component::EditorGuiElement()
+    void ComponentBase::EditorGuiElement()
     {
         ImGui::PushItemWidth(60.0f);
             ImGui::Spacing();

--- a/nc/source/component/Component.h
+++ b/nc/source/component/Component.h
@@ -15,13 +15,13 @@ namespace nc
             ComponentBase& operator=(const ComponentBase&) = delete;
             ComponentBase& operator=(ComponentBase&&) = delete;
 
-            EntityHandle GetParentHandle() noexcept { return m_parentHandle; }
+            EntityHandle GetParentHandle() const noexcept { return m_parentHandle; }
 
             #ifdef NC_EDITOR_ENABLED
             virtual void EditorGuiElement();
             #endif
 
-        protected:
+        private:
             EntityHandle m_parentHandle;
     };
 

--- a/nc/source/component/Component.h
+++ b/nc/source/component/Component.h
@@ -3,32 +3,39 @@
 
 namespace nc
 {
-    class Component
+    class ComponentBase
     {
         public:
-            Component(EntityHandle handle) noexcept
-                : m_parentHandle{handle}
-            {}
-            virtual ~Component() = default;
-            Component(const Component&) = delete;
-            Component(Component&&) = delete;
-            Component& operator=(const Component&) = delete;
-            Component& operator=(Component&&) = delete;
+            ComponentBase(EntityHandle handle) noexcept
+                : m_parentHandle{handle} {}
+
+            virtual ~ComponentBase() = default;
+            ComponentBase(const ComponentBase&) = delete;
+            ComponentBase(ComponentBase&&) = delete;
+            ComponentBase& operator=(const ComponentBase&) = delete;
+            ComponentBase& operator=(ComponentBase&&) = delete;
 
             EntityHandle GetParentHandle() noexcept { return m_parentHandle; }
 
-            virtual void FrameUpdate(float dt) { (void) dt; }
-            virtual void FixedUpdate() {}
-            virtual void OnDestroy() {}
-            virtual void OnCollisionEnter(EntityHandle other) { (void)other; }
-            virtual void OnCollisionStay() {};
-            virtual void OnCollisionExit() {};
-        
             #ifdef NC_EDITOR_ENABLED
             virtual void EditorGuiElement();
             #endif
 
         protected:
             EntityHandle m_parentHandle;
+    };
+
+    class Component : public ComponentBase
+    {
+        public:
+            Component(EntityHandle handle) noexcept
+                : ComponentBase{handle} {}
+
+            virtual void FrameUpdate(float) {}
+            virtual void FixedUpdate() {}
+            virtual void OnDestroy() {}
+            virtual void OnCollisionEnter(EntityHandle) {}
+            virtual void OnCollisionStay() {};
+            virtual void OnCollisionExit() {};
     };
 } //end namespace nc

--- a/nc/source/component/NetworkDispatcher.cpp
+++ b/nc/source/component/NetworkDispatcher.cpp
@@ -9,7 +9,7 @@
 namespace nc
 {
     NetworkDispatcher::NetworkDispatcher(EntityHandle handle) noexcept
-        : Component(handle)
+        : ComponentBase(handle)
     {
     }
 

--- a/nc/source/component/NetworkDispatcher.h
+++ b/nc/source/component/NetworkDispatcher.h
@@ -8,7 +8,7 @@
 
 namespace nc
 {
-    class NetworkDispatcher final : public Component
+    class NetworkDispatcher final : public ComponentBase
     {
         public:
             net::NetworkHandle networkHandle;

--- a/nc/source/component/PointLight.cpp
+++ b/nc/source/component/PointLight.cpp
@@ -10,7 +10,7 @@
 namespace nc
 {
     PointLight::PointLight(EntityHandle handle) noexcept
-        : Component(handle),
+        : ComponentBase(handle),
           m_transform{ Ecs::GetComponent<Transform>(handle) }
     {
         PixelConstBufData.pos              = {0,0,0};

--- a/nc/source/component/PointLight.h
+++ b/nc/source/component/PointLight.h
@@ -9,7 +9,7 @@ namespace nc
 {
     class Transform;
 
-    class PointLight final: public Component
+    class PointLight final: public ComponentBase
     {
         public:
             PointLight(EntityHandle handle) noexcept;

--- a/nc/source/component/Renderer.cpp
+++ b/nc/source/component/Renderer.cpp
@@ -14,7 +14,7 @@ namespace nc
     Renderer::~Renderer() = default;
 
     Renderer::Renderer(EntityHandle handle, graphics::Mesh mesh, graphics::Material material) noexcept
-        : Component(handle),
+        : ComponentBase(handle),
           m_model{ std::make_unique<graphics::Model>(std::move(mesh), std::move(material)) },
           m_transform{ Ecs::GetComponent<Transform>(handle) }
     {

--- a/nc/source/component/Renderer.h
+++ b/nc/source/component/Renderer.h
@@ -14,7 +14,7 @@ namespace nc
 {
     class Transform;
 
-    class Renderer final: public Component
+    class Renderer final: public ComponentBase
     {
         public:
             Renderer(EntityHandle handle, graphics::Mesh mesh, graphics::Material material) noexcept;

--- a/nc/source/component/Transform.cpp
+++ b/nc/source/component/Transform.cpp
@@ -9,7 +9,7 @@
 namespace nc
 {
     Transform::Transform(EntityHandle handle, const Vector3& pos, const Vector3& rot, const Vector3& scl) noexcept
-        : Component(handle),
+        : ComponentBase(handle),
           m_position { pos },
           m_rotation { rot },
           m_scale { scl }

--- a/nc/source/component/Transform.h
+++ b/nc/source/component/Transform.h
@@ -12,7 +12,7 @@ namespace nc
         Local
     };
 
-    class Transform final : public Component
+    class Transform final : public ComponentBase
     {
         public:
             Transform(EntityHandle handle, const Vector3& pos, const Vector3& rot, const Vector3& scl) noexcept;

--- a/nc/source/ecs/ECSImpl.h
+++ b/nc/source/ecs/ECSImpl.h
@@ -25,7 +25,7 @@ namespace ecs
         public:
             EcsImpl();
 
-            template<std::derived_from<Component> T>
+            template<std::derived_from<ComponentBase> T>
             ComponentSystem<T>* GetSystem();
 
             void SendFrameUpdate(float dt);

--- a/nc/source/ecs/Entity.cpp
+++ b/nc/source/ecs/Entity.cpp
@@ -5,7 +5,7 @@ namespace nc
 Entity::Entity(const EntityHandle handle, const std::string& tag) noexcept
     : Handle{ handle }, 
       Tag{ tag },
-      m_userComponents{ }
+      m_userComponents{}
 {
 }
 

--- a/nc/source/ecs/Entity.h
+++ b/nc/source/ecs/Entity.h
@@ -21,8 +21,8 @@ namespace nc
             Entity& operator=(Entity&& other) = default;
             ~Entity() = default;
 
-            mutable EntityHandle Handle;
-            mutable std::string Tag;
+            const EntityHandle Handle;
+            const std::string Tag;
             
             void SendFrameUpdate(float dt) noexcept;
             void SendFixedUpdate() noexcept;

--- a/nc/source/graphics/d3dresource/GraphicsResourceManager.h
+++ b/nc/source/graphics/d3dresource/GraphicsResourceManager.h
@@ -70,8 +70,10 @@ namespace nc::graphics::d3dresource
                 const auto i = m_resources.find(key);
                 if(i == m_resources.end())
                 {
-                    m_resources[key] = std::make_unique<T>(std::forward<Params>(p)...);
-                    return m_resources[key].get();
+                    auto [it, result] = m_resources.emplace(key, std::make_unique<T>(std::forward<Params>(p)...));
+                    if(!result)
+                        throw std::runtime_error("GraphicsResourceManager::Acquire_ - failed to emplace ");
+                    return it->second.get();
                 }
                 return i->second.get();
             }

--- a/nc/test/unit/ComponentSystem_unit_tests.cpp
+++ b/nc/test/unit/ComponentSystem_unit_tests.cpp
@@ -13,10 +13,10 @@ int TestVal1 = 5;
 int TestVal2 = 6;
 int TestVal3 = 7;
 
-struct Fake : public Component
+struct Fake : public ComponentBase
 {
     Fake(EntityHandle handle, int in)
-        : Component(handle),
+        : ComponentBase(handle),
           val{in}
     {}
 


### PR DESCRIPTION
-Change some Entity members from mutable to const
-GfxResMan uses emplace to add pairs
-Added ComponentBase type to stop engine components from inheriting unused methods