### PR TITLE
point light ctor takes properties

### DIFF
--- a/docs/todo.txt
+++ b/docs/todo.txt
@@ -9,7 +9,6 @@ IN PROGRESS
     -optimize collisions
     -add physics body
 
--PointLight ctor should be able to take PointLight::Properties
 -#ifdef editor stuff is getting out of hand; restore sanity
 -Mesh and Model may not need default ctors anymore - requires major changes to Prefab.cpp
 

--- a/nc/include/ECS.h
+++ b/nc/include/ECS.h
@@ -14,7 +14,9 @@
 namespace nc
 {
     EntityHandle CreateEntity();
+    EntityHandle CreateEntity(Vector3 pos);
     EntityHandle CreateEntity(std::string tag);
+    EntityHandle CreateEntity(Vector3 pos, std::string tag);
     EntityHandle CreateEntity(Vector3 pos, Quaternion rot, Vector3 scale, std::string tag); // scale must be nonzero
     bool DestroyEntity(EntityHandle handle);
     [[nodiscard]] Entity* GetEntity(EntityHandle handle);
@@ -33,6 +35,7 @@ namespace nc
     [[nodiscard]] bool HasComponent(EntityHandle handle);
 
     /** Specializations for engine components */
+    template<> PointLight* AddComponent<PointLight>(EntityHandle handle, PointLight::Properties properties);
     template<> PointLight* AddComponent<PointLight>(EntityHandle handle);
     template<> PointLight* GetComponent<PointLight>(EntityHandle handle);
     template<> bool HasComponent<PointLight>(EntityHandle handle);

--- a/nc/include/component/PointLight.h
+++ b/nc/include/component/PointLight.h
@@ -25,7 +25,7 @@ namespace nc
 
             alignas(16)Vector3 ProjectedPos;
 
-            PointLight(EntityHandle handle) noexcept;
+            PointLight(EntityHandle handle, Properties properties) noexcept;
             PointLight(PointLight&&) = delete;
             PointLight& operator=(PointLight&&) = delete;
             PointLight(const PointLight&) = delete;

--- a/nc/source/component/PointLight.cpp
+++ b/nc/source/component/PointLight.cpp
@@ -9,9 +9,9 @@
 
 namespace nc
 {
-    PointLight::PointLight(EntityHandle handle) noexcept
+    PointLight::PointLight(EntityHandle handle, Properties properties) noexcept
         : ComponentBase(handle),
-          PixelConstBufData{},
+          PixelConstBufData{properties},
           ProjectedPos{},
           m_transform{ GetComponent<Transform>(handle) }
     {

--- a/nc/source/ecs/EcsApiImpl.cpp
+++ b/nc/source/ecs/EcsApiImpl.cpp
@@ -19,9 +19,19 @@ namespace nc
         return CreateEntity(Vector3::Zero(), Quaternion::Identity(), Vector3::One(), internal::DefaultEntityTag);
     }
 
+    EntityHandle CreateEntity(Vector3 pos)
+    {
+        return CreateEntity(pos, Quaternion::Identity(), Vector3::One(), internal::DefaultEntityTag);
+    }
+
     EntityHandle CreateEntity(std::string tag)
     {
         return CreateEntity(Vector3::Zero(), Quaternion::Identity(), Vector3::One(), std::move(tag));
+    }
+
+    EntityHandle CreateEntity(Vector3 pos, std::string tag)
+    {
+        return CreateEntity(pos, Quaternion::Identity(), Vector3::One(), std::move(tag));
     }
 
     EntityHandle CreateEntity(Vector3 pos, Quaternion rot, Vector3 scale, std::string tag)
@@ -47,10 +57,15 @@ namespace nc
 
     template<> PointLight* AddComponent<PointLight>(EntityHandle handle)
     {
+        return AddComponent<PointLight>(handle, PointLight::Properties{});
+    }
+
+    template<> PointLight* AddComponent<PointLight>(EntityHandle handle, PointLight::Properties properties)
+    {
         IF_THROW(!GetEntity(handle), "AddComponent<PointLight> - Bad handle");
         IF_THROW(internal::g_impl->GetSystem<PointLight>()->Contains(handle), "AddComponent<PointLight> - entity already has a point light");
 
-        auto lightPtr = internal::g_impl->GetSystem<PointLight>()->Add(handle);
+        auto lightPtr = internal::g_impl->GetSystem<PointLight>()->Add(handle, properties);
         return lightPtr;
     }
 

--- a/project/source/click_events/ClickEvents.cpp
+++ b/project/source/click_events/ClickEvents.cpp
@@ -51,8 +51,10 @@ namespace nc::sample
 {
     void ClickEvents::Load()
     {
+        // Setup
         m_sceneHelper.Setup(true, false, Widget);
 
+        // Camera
         auto cameraHandle = CreateEntity(Vector3{0.0f, 6.1f, -9.5f}, Quaternion::FromEulerAngles(0.7f, 0.0f, 0.0f), Vector3::One(), "Main Camera");
         auto camera = AddComponent<EdgePanCamera>(cameraHandle);
         camera::SetMainCamera(camera);
@@ -60,16 +62,17 @@ namespace nc::sample
         LayerSelectCallback = std::bind(ClickHandler::SetLayer, clickHandler, std::placeholders::_1);
 
         // Lights
-        auto lvHandle = CreateEntity(Vector3{-2.4f, 12.1f, 0.0f}, Quaternion::Identity(), Vector3::One(), "Point Light");
+        auto lvHandle = CreateEntity(Vector3{-2.4f, 12.1f, 0.0f}, "Point Light");
         AddComponent<PointLight>(lvHandle);
-        auto lvHandle2 = CreateEntity(Vector3{12.1f, 14.5f, 7.3f}, Quaternion::Identity(), Vector3::One(), "Point Light");
+        auto lvHandle2 = CreateEntity(Vector3{12.1f, 14.5f, 7.3f}, "Point Light");
         AddComponent<PointLight>(lvHandle2);
-        auto lvHandle3 = CreateEntity(Vector3{4.1f, 14.5f, 3.3f}, Quaternion::Identity(), Vector3::One(), "Point Light");
+        auto lvHandle3 = CreateEntity(Vector3{4.1f, 14.5f, 3.3f}, "Point Light");
         AddComponent<PointLight>(lvHandle3);
 
-        // Objects
+        // Table
         prefab::Create(prefab::Resource::Table, Vector3{0.0f, -0.4f, 0.0f}, Quaternion::FromEulerAngles(1.5708f, 0.0f, 1.5708f), Vector3::Splat(7.5f), "Table");
         
+        // Coin Spawner
         SpawnBehavior behavior
         {
             .rotationOffset = Vector3{math::Pi / 2.0f, 0.0f, 0.0f},
@@ -86,6 +89,7 @@ namespace nc::sample
         auto coinSpawner = AddComponent<Spawner>(coinSpawnerHandle, prefab::Resource::Coin, behavior, coinExtension);
         coinSpawner->Spawn(20);
 
+        // Token Spawner
         auto tokenExtension = [](EntityHandle handle)
         {
             GetComponent<Transform>(handle)->SetScale(Vector3::Splat(2.0f));

--- a/project/source/collision_benchmark/CollisionBenchmark.cpp
+++ b/project/source/collision_benchmark/CollisionBenchmark.cpp
@@ -43,11 +43,14 @@ namespace nc::sample
 {
     void CollisionBenchmark::Load()
     {
+        // Setup
         m_sceneHelper.Setup(false, true, Widget);
 
+        // Camera
         auto camera = AddComponent<Camera>(CreateEntity("Main Camera"));
         camera::SetMainCamera(camera);
 
+        // Cube Spawner
         SpawnBehavior spawnBehavior
         {
             .positionOffset = Vector3{0.0f, 0.0f, 35.0f},
@@ -62,11 +65,12 @@ namespace nc::sample
         
         auto handle = CreateEntity("Spawner");
         auto spawner = AddComponent<Spawner>(handle, prefab::Resource::Cube, spawnBehavior, spawnExtension);
+        auto fpsTracker = AddComponent<FPSTracker>(handle);
+
+        // UI Callbacks
         GetObjectCountCallback = std::bind(Spawner::GetObjectCount, spawner);
         SpawnCallback = std::bind(Spawner::Spawn, spawner, std::placeholders::_1);
         DestroyCallback = std::bind(Spawner::Destroy, spawner, std::placeholders::_1);
-
-        auto fpsTracker = AddComponent<FPSTracker>(handle);
         GetFPSCallback = std::bind(FPSTracker::GetFPS, fpsTracker);
     }
 

--- a/project/source/collision_events/CollisionEvents.cpp
+++ b/project/source/collision_events/CollisionEvents.cpp
@@ -27,14 +27,15 @@ namespace nc::sample
 {
     void CollisionEvents::Load()
     {
+        // Setup
         m_sceneHelper.Setup(true, true, Widget);
 
-        //Camera
+        // Camera
         auto cameraHandle = CreateEntity(Vector3{3.6f, 6.1f, -6.5f}, Quaternion::FromEulerAngles(0.7f, 0.0f, 0.0f), Vector3::One(), "Main Camera");
         auto camera = AddComponent<EdgePanCamera>(cameraHandle);
         camera::SetMainCamera(camera);
 
-        // Objects
+        // Cubes
         auto rot = Quaternion::FromEulerAngles(math::DegreesToRadians(180.0f), 0.0f, 0.0f);
         auto cube1 = prefab::Create(prefab::Resource::CubeBlue, Vector3{2.0f, 0.0f, 0.4f}, rot, Vector3::One());
         AddComponent<Collider>(cube1, Vector3::One());

--- a/project/source/rendering_benchmark/RenderingBenchmark.cpp
+++ b/project/source/rendering_benchmark/RenderingBenchmark.cpp
@@ -45,13 +45,14 @@ namespace nc::sample
 {
     void RenderingBenchmark::Load()
     {
+        // Setup
         m_sceneHelper.Setup(false, true, Widget);
 
+        // Camera
         auto camera = AddComponent<Camera>(CreateEntity("Main Camera"));
         nc::camera::SetMainCamera(camera);
         
-        auto handle = CreateEntity("Spawner");
-
+        // Spawner
         SpawnBehavior spawnBehavior
         {
             .positionOffset = Vector3{0.0f, 0.0f, 35.0f},
@@ -59,12 +60,14 @@ namespace nc::sample
             .rotationRandomRange = Vector3::Splat(math::Pi / 2.0f)
         };
         
+        auto handle = CreateEntity("Spawner");
         auto spawner = AddComponent<Spawner>(handle, prefab::Resource::Cube, spawnBehavior);
+        auto fpsTracker = AddComponent<FPSTracker>(handle);
+
+        // UI Callbacks
         GetObjectCountCallback = std::bind(Spawner::GetObjectCount, spawner);
         SpawnCallback = std::bind(Spawner::Spawn, spawner, std::placeholders::_1);
         DestroyCallback = std::bind(Spawner::Destroy, spawner, std::placeholders::_1);
-
-        auto fpsTracker = AddComponent<FPSTracker>(handle);
         GetFPSCallback = std::bind(FPSTracker::GetFPS, fpsTracker);
     }
 

--- a/project/source/shared/SceneHelper.h
+++ b/project/source/shared/SceneHelper.h
@@ -37,7 +37,7 @@ namespace nc::sample
 
         if(createLight)
         {
-            auto lvHandle = CreateEntity(Vector3::Up() * 12.0f, Quaternion::Identity(), Vector3::One(), "Point Light");
+            auto lvHandle = CreateEntity(Vector3::Up() * 12.0f, "Point Light");
             AddComponent<PointLight>(lvHandle);
         }
     }

--- a/project/source/spawn_test/SpawnTest.cpp
+++ b/project/source/spawn_test/SpawnTest.cpp
@@ -24,10 +24,11 @@ namespace nc::sample
 {
     void SpawnTest::Load()
     {
+        // Setup
         m_sceneHelper.Setup(true, false, Widget);
 
         // Camera
-        auto cameraHandle = CreateEntity(Vector3{0.0f, -9.0f, -100.0f}, Quaternion::Identity(), Vector3::One(), "SceneNavigationCamera");
+        auto cameraHandle = CreateEntity(Vector3{0.0f, -9.0f, -100.0f}, "SceneNavigationCamera");
         auto camera = AddComponent<SceneNavigationCamera>(cameraHandle);
         camera::SetMainCamera(camera);
 
@@ -39,11 +40,10 @@ namespace nc::sample
             .attConst = 1.0f,
             .attLin = 0.0001f
         };
-        auto lvHandle = CreateEntity(Vector3::Zero(), Quaternion::Identity(), Vector3::One(), "Point Light");
-        auto pointLight = AddComponent<PointLight>(lvHandle);
-        pointLight->Set(lightProperties);
 
-        // Collider that destroys anything leaving its bounded area
+        AddComponent<PointLight>(CreateEntity("Point Light"), lightProperties);
+
+        // KillBox to destroy anything leaving its bounded area
         auto killBox = CreateEntity(Vector3::Zero(), Quaternion::Identity(), Vector3::Splat(60.0f), "KillBox");
         AddComponent<Collider>(killBox, Vector3::One());
         AddComponent<KillBox>(killBox);
@@ -54,11 +54,13 @@ namespace nc::sample
             .positionRandomRange = Vector3::Splat(55.0f),
             .rotationRandomRange = Vector3::Splat(math::Pi / 2.0f),
         };
+
         auto staticCubeExtension = [](EntityHandle handle)
         {
             GetComponent<Transform>(handle)->SetScale(Vector3::Splat(6.0f));
             AddComponent<Collider>(handle, Vector3::One());
         };
+
         auto staticCubeSpawnerHandle = CreateEntity("Static Cube Spawner");
         auto staticCubeSpawner = AddComponent<Spawner>(staticCubeSpawnerHandle, prefab::Resource::CubeBlue, staticCubeBehavior, staticCubeExtension);
         staticCubeSpawner->Spawn(5);
@@ -74,10 +76,12 @@ namespace nc::sample
             .rotationAxisRandomRange = Vector3::One(),
             .thetaRandomRange = 2.0f
         };
+
         auto dynamicCubeExtension = [](EntityHandle handle)
         {
             AddComponent<Collider>(handle, Vector3::One());
         };
+
         auto dynamicCubeSpawnerHandle = CreateEntity("Dynamic Cube Spawner");
         AddComponent<FixedIntervalSpawner>(dynamicCubeSpawnerHandle, prefab::Resource::CubeGreen, dynamicCubeBehavior, 0.2f, dynamicCubeExtension);
     }

--- a/project/source/worms/Worms.cpp
+++ b/project/source/worms/Worms.cpp
@@ -20,8 +20,6 @@ namespace nc::sample
         camera::SetMainCamera(camera);
 
         // Light
-        auto lvHandle = CreateEntity(Vector3::Zero(), Quaternion::Identity(), Vector3::One(), "Point Light");
-        auto pointLight = AddComponent<PointLight>(lvHandle);
         auto lightProperties = PointLight::Properties
         {
             .pos = Vector3::Zero(),
@@ -32,11 +30,12 @@ namespace nc::sample
             .attLin = 0.05f,
             .attQuad = 0.0f
         };
-        
-        pointLight->Set(lightProperties);
-        AddComponent<MouseFollower>(lvHandle);
 
-        // Worms
+        auto lightHandle = CreateEntity("Point Light");
+        AddComponent<PointLight>(lightHandle, lightProperties);
+        AddComponent<MouseFollower>(lightHandle);
+
+        // Worm Spawner
         SpawnBehavior spawnBehavior
         {
             .positionOffset = Vector3{0.0f, 0.0f, 25.0f},
@@ -48,7 +47,7 @@ namespace nc::sample
 
         auto spawnerHandle = CreateEntity("Spawner");
         auto spawner = AddComponent<Spawner>(spawnerHandle, prefab::Resource::Worm, spawnBehavior);
-        spawner->Spawn(1u);
+        spawner->Spawn(40u);
     }
 
     void Worms::Unload()


### PR DESCRIPTION
-PointLight constructor (and AddComponent) can take in PointLight::Properties rather than having to call Set after construction.
-Added a few CreateEntity overloads
-Fixed Worms scene only creating 1 worm
-Minor organization+comments in sample scenes