### PR TITLE
PoolAdapter

### DIFF
--- a/nc/include/component/Collider.h
+++ b/nc/include/component/Collider.h
@@ -65,4 +65,16 @@ namespace nc
             bool m_selectedInEditor;
             #endif
     };
+
+    template<>
+    struct StoragePolicy<Collider>
+    {
+        #ifdef NC_EDITOR_ENABLED
+        using allow_trivial_destruction = std::false_type;
+        #else
+        using allow_trivial_destruction = std::true_type;
+        #endif
+
+        using sort_dense_storage_by_address = std::true_type;
+    };
 }

--- a/nc/include/component/Component.h
+++ b/nc/include/component/Component.h
@@ -1,10 +1,14 @@
 #pragma once
 #include "entity/EntityHandle.h"
 
+#include <type_traits>
+
 namespace nc
 {
     class Entity;
 
+    /** Base class for all Components. Only Components associated with a system
+     *  should derive directly from ComponentBase. */
     class ComponentBase
     {
         public:
@@ -27,6 +31,7 @@ namespace nc
             EntityHandle m_parentHandle;
     };
 
+    /** Base class for user-defined Components. */
     class Component : public ComponentBase
     {
         public:
@@ -39,5 +44,19 @@ namespace nc
             virtual void OnCollisionEnter(Entity*) {}
             virtual void OnCollisionStay(Entity*) {};
             virtual void OnCollisionExit(Entity*) {};
+    };
+
+    /** Helper for configuring storage and allocation behavior. */
+    template<class T>
+    struct StoragePolicy
+    {
+        /** Allow destructor calls to be elided for types
+         *  that don't satisfy std::is_trivially_destructible. */
+        using allow_trivial_destruction = std::false_type;
+
+        /** Dense views over sparse sets can be optionally sorted.
+         *  This minimizes cache misses during iteration but results
+         *  in slower additions and deletions. */
+        using sort_dense_storage_by_address = std::true_type;
     };
 } //end namespace nc

--- a/nc/include/component/ParticleEmitter.h
+++ b/nc/include/component/ParticleEmitter.h
@@ -25,6 +25,13 @@ namespace nc
             ecs::ParticleEmitterSystem* m_emitterSystem;
     };
 
+    template<>
+    struct StoragePolicy<ParticleEmitter>
+    {
+        using allow_trivial_destruction = std::true_type;
+        using sort_dense_storage_by_address = std::true_type;
+    };
+
     struct ParticleEmissionInfo
     {
         unsigned maxParticleCount = 100u;

--- a/nc/include/component/PointLight.h
+++ b/nc/include/component/PointLight.h
@@ -42,4 +42,11 @@ namespace nc
         private:
             Transform * m_transform;
     };
+
+    template<>
+    struct StoragePolicy<PointLight>
+    {
+        using allow_trivial_destruction = std::true_type;
+        using sort_dense_storage_by_address = std::true_type;
+    };
 }

--- a/nc/source/alloc/PoolAdapter.h
+++ b/nc/source/alloc/PoolAdapter.h
@@ -1,0 +1,116 @@
+#pragma once
+
+#include "Allocator.h"
+
+#include <algorithm>
+#include <span>
+
+namespace nc::alloc
+{
+    /** potential todos
+     *  -could expose iterators
+     *  -could change from sorted/unsorted based on template parameter */
+
+    /** Helper base class for managing pool memory resource lifetime. */
+    template<class T>
+    class PoolResourceScope
+    {
+        protected:
+            using allocator_type = alloc::PoolAllocator<T>;
+            PoolResourceScope(size_t count) { allocator_type::create_memory_resource(sizeof(T) * count); }
+            ~PoolResourceScope() { allocator_type::destroy_memory_resource(); }
+    };
+
+    /** Provides a more container-like interface for memory pools. */
+    template<class T>
+    class PoolAdapter final : private PoolResourceScope<T>
+    {
+        public:
+            explicit PoolAdapter(size_t count);
+
+            template<class... Args>
+            T* Add(Args&&... args);
+
+            template<class Predicate>
+            bool RemoveIf(Predicate predicate);
+
+            template<class Predicate>
+            bool Contains(Predicate predicate) const;
+
+            template<class Predicate>
+            T* Get(Predicate predicate);
+            
+            std::span<T*> GetActiveRange() noexcept;
+            
+            void Clear();
+
+        private:
+            std::vector<T*> m_data;
+            PoolResourceScope<T>::allocator_type m_allocator;
+    };
+
+    template<class T>
+    PoolAdapter<T>::PoolAdapter(size_t count)
+        : PoolResourceScope<T>{count},
+          m_data{},
+          m_allocator{}
+    {
+    }
+
+    template<class T>
+    std::span<T*> PoolAdapter<T>::GetActiveRange() noexcept
+    {
+        return std::span<T*>{m_data};
+    }
+
+    template<class T>
+    void PoolAdapter<T>::Clear()
+    {
+        for(auto* item : m_data)
+            m_allocator.deallocate(item, 1u);
+
+        m_data.clear();
+        m_data.shrink_to_fit();
+        m_allocator.clear_memory_resource();
+    }
+
+    template<class T>
+    template<class ... Args>
+    T* PoolAdapter<T>::Add(Args&& ... args)
+    {
+        auto* ptr = m_allocator.allocate(1);
+        ptr = new(ptr) T{std::forward<Args>(args)...};
+        auto pos = std::ranges::upper_bound(m_data, ptr, [](T* add, T* existing) { return add < existing; });
+        m_data.insert(pos, ptr);
+        return ptr;
+    }
+
+    template<class T>
+    template<class Predicate>
+    bool PoolAdapter<T>::RemoveIf(Predicate predicate)
+    {
+        if(auto* ptr = Get(predicate))
+        {
+            m_allocator.deallocate(ptr, 1);
+            std::erase(m_data, ptr);
+            return true;
+        }
+
+        return false;
+    }
+
+    template<class T>
+    template<class Predicate>
+    T* PoolAdapter<T>::Get(Predicate predicate)
+    {
+        auto pos = std::ranges::find_if(m_data, predicate);
+        return pos == m_data.end() ? nullptr : *pos;
+    }
+
+    template<class T>
+    template<class Predicate>
+    bool PoolAdapter<T>::Contains(Predicate predicate) const
+    {
+        return m_data.end() != std::ranges::find_if(m_data, predicate);
+    }
+} // namespace nc::alloc

--- a/nc/source/ecs/ColliderSystem.cpp
+++ b/nc/source/ecs/ColliderSystem.cpp
@@ -79,7 +79,7 @@ namespace nc::ecs
         return m_componentSystem.GetPointerTo(handle);
     }
 
-    auto ColliderSystem::GetComponents() -> ecs::ComponentSystem<Collider>::ContainerType&
+    std::span<Collider*> ColliderSystem::GetComponents()
     {
         return m_componentSystem.GetComponents();
     }

--- a/nc/source/ecs/ColliderSystem.h
+++ b/nc/source/ecs/ColliderSystem.h
@@ -34,7 +34,7 @@ namespace nc::ecs
             void Clear();
             bool Contains(EntityHandle handle) const;
             Collider* GetPointerTo(EntityHandle handle);
-            auto GetComponents() -> ecs::ComponentSystem<Collider>::ContainerType&;
+            std::span<Collider*> GetComponents();
 
         private:
             ecs::ComponentSystem<Collider> m_componentSystem;

--- a/nc/source/ecs/ComponentSystem.h
+++ b/nc/source/ecs/ComponentSystem.h
@@ -1,115 +1,68 @@
 #pragma once
 
+#include "alloc/PoolAdapter.h"
 #include "entity/EntityHandle.h"
-#include "alloc/Utility.h"
-#include "debug/Utils.h"
-#include "debug/Profiler.h"
-
-#include <algorithm>
-#include <memory>
-#include <unordered_map>
-#include <vector>
 
 namespace nc::ecs
 {
     template<class T>
     class ComponentSystem
     {
-        using Allocator = alloc::PoolAllocator<T>;
-
         public:
-            using ContainerType = std::vector<std::unique_ptr<T, alloc::basic_deleter<Allocator>>>;
-
             ComponentSystem(uint32_t count);
-            virtual ~ComponentSystem() noexcept;
+            virtual ~ComponentSystem() = default;
 
             template<class ... Args> T* Add(EntityHandle parentHandle, Args&& ... args);
             bool Remove(EntityHandle parentHandle);
             bool Contains(EntityHandle parentHandle) const;
             T* GetPointerTo(EntityHandle parentHandle);
-            ContainerType& GetComponents();
+            std::span<T*> GetComponents();
             void Clear();
 
         private:
-            ContainerType m_components;
+            alloc::PoolAdapter<T> m_pool;
     };
 
     template<class T>
     ComponentSystem<T>::ComponentSystem(uint32_t count)
-        : m_components{}
+        : m_pool{count}
     {
-        Allocator::create_memory_resource(count * sizeof(T));
     }
 
     template<class T>
-    ComponentSystem<T>::~ComponentSystem() noexcept
+    std::span<T*> ComponentSystem<T>::GetComponents()
     {
-        Allocator::destroy_memory_resource();
-    }
-
-    template<class T>
-    ComponentSystem<T>::ContainerType& ComponentSystem<T>::GetComponents()
-    {
-        return m_components;
+        return m_pool.GetActiveRange();
     }
 
     template<class T>
     void ComponentSystem<T>::Clear()
     {
-        m_components.clear();
-        m_components.shrink_to_fit();
-        Allocator().clear_memory_resource();
+        m_pool.Clear();
     }
 
     template<class T>
     template<class ... Args>
     T* ComponentSystem<T>::Add(EntityHandle handle, Args&& ... args)
     {
-        if(Contains(handle))
-            return nullptr;
-
-        auto ptr = alloc::make_unique<T, Allocator>(handle, std::forward<Args>(args)...);
-        auto pos = m_components.insert
-        (
-            std::upper_bound(m_components.begin(), m_components.end(), ptr.get(), [](T* toAdd, auto& existing) { return toAdd < existing.get(); }),
-            std::move(ptr)
-        );
-
-        return pos->get();
+        return m_pool.Add(handle, std::forward<Args>(args)...);
     }
 
     template<class T>
     bool ComponentSystem<T>::Remove(EntityHandle handle)
     {
-        if (!Contains(handle))
-            return false;
-
-        std::erase_if(m_components, [handle](auto& c)
-        {
-            return handle == c->GetParentHandle();
-        });
-
-        return true;
+        return m_pool.RemoveIf([handle](auto* item) { return handle == item->GetParentHandle(); });
     }
 
     template<class T>
     bool ComponentSystem<T>::Contains(EntityHandle handle) const
     {
-        return m_components.cend() != std::ranges::find_if(m_components, [handle](auto& c)
-        {
-            return handle == c->GetParentHandle();
-        });
+        return m_pool.Contains([handle](auto* item) { return handle == item->GetParentHandle(); });
     }
 
     template<class T>
     T* ComponentSystem<T>::GetPointerTo(EntityHandle handle)
     {
-        for(auto& c : m_components)
-        {
-            if(handle == c->GetParentHandle())
-                return c.get();
-        }
-
-        return nullptr;
+        return m_pool.Get([handle](auto* item) { return handle == item->GetParentHandle(); });
     }
 } // namespace nc::ecs

--- a/nc/source/engine/Engine.cpp
+++ b/nc/source/engine/Engine.cpp
@@ -207,14 +207,14 @@ namespace nc::core
         auto camViewMatrix = camera::CalculateViewMatrix();
         m_graphics.SetViewMatrix(camViewMatrix);
 
-        for(auto& light : m_ecs.GetPointLightSystem()->GetComponents())
+        for(auto* light : m_ecs.GetPointLightSystem()->GetComponents())
         {
-            m_pointLightManager.AddPointLight(light.get(), camViewMatrix);
+            m_pointLightManager.AddPointLight(light, camViewMatrix);
         }
 
         m_pointLightManager.Bind();
 
-        for(auto& renderer : m_ecs.GetRendererSystem()->GetComponents())
+        for(auto* renderer : m_ecs.GetRendererSystem()->GetComponents())
         {
             renderer->Update(&m_frameManager);
         }

--- a/nc/source/ui/editor/EditorControls.h
+++ b/nc/source/ui/editor/EditorControls.h
@@ -255,14 +255,14 @@ namespace nc::ui::editor::controls
         {
             ImGui::PushID(name);
             ImGui::Indent();
-            auto& components = system->GetComponents();
+            auto components = system->GetComponents();
             ImGui::Text("Component Size:  %u", static_cast<unsigned>(sizeof(T)));
             ImGui::Text("Copmonent Count: %u", static_cast<unsigned>(components.size()));
             if(ImGui::CollapsingHeader("Components"))
             {
                 ImGui::Indent();
                 for(auto& component : components)
-                    ImGui::Text("Handle: %5u  |  Address: %p", static_cast<unsigned>(component->GetParentHandle()), static_cast<void*>(component.get()));
+                    ImGui::Text("Handle: %5u  |  Address: %p", static_cast<unsigned>(component->GetParentHandle()), static_cast<void*>(component));
                 ImGui::Unindent();
             }
             ImGui::Unindent();

--- a/nc/test/unit/ComponentSystem_unit_tests.cpp
+++ b/nc/test/unit/ComponentSystem_unit_tests.cpp
@@ -174,13 +174,13 @@ TEST_F(ComponentSystem_unit_tests, GetComponents_SequentiallyAdded_GetsAllCompon
     auto actualAddress2 = fakeSystem.Add(TestParentHandle2, TestVal2);
     auto actualAddress3 = fakeSystem.Add(TestParentHandle3, TestVal3);
 
-    auto& fakes = fakeSystem.GetComponents();
+    auto fakes = fakeSystem.GetComponents();
     auto actualSize = fakes.size();
     EXPECT_EQ(actualSize, 3);
 
-    EXPECT_EQ(actualAddress1, fakes[0].get());
-    EXPECT_EQ(actualAddress2, fakes[1].get());
-    EXPECT_EQ(actualAddress3, fakes[2].get());
+    EXPECT_EQ(actualAddress1, fakes[0]);
+    EXPECT_EQ(actualAddress2, fakes[1]);
+    EXPECT_EQ(actualAddress3, fakes[2]);
 
     EXPECT_EQ(TestVal1, fakes[0]->val);
     EXPECT_EQ(TestVal2, fakes[1]->val);
@@ -194,12 +194,12 @@ TEST_F(ComponentSystem_unit_tests, GetComponents_AddThroughFreeList_ReturnsInInc
     auto actualAddress3 = fakeSystem.Add(TestParentHandle3, TestVal3);
     fakeSystem.Remove(TestParentHandle2);
     auto actualAddress4 = fakeSystem.Add(TestParentHandle4, TestVal4);
-    auto& fakes = fakeSystem.GetComponents();
+    auto fakes = fakeSystem.GetComponents();
     auto actualSize = fakes.size();
     EXPECT_EQ(actualSize, 3);
-    EXPECT_EQ(actualAddress1, fakes[0].get());
-    EXPECT_EQ(actualAddress4, fakes[1].get());
-    EXPECT_EQ(actualAddress3, fakes[2].get());
+    EXPECT_EQ(actualAddress1, fakes[0]);
+    EXPECT_EQ(actualAddress4, fakes[1]);
+    EXPECT_EQ(actualAddress3, fakes[2]);
 }
 
 int main(int argc, char ** argv)


### PR DESCRIPTION
Pulled most of the functionality out of ComponentSystem into PoolAdapter, which manages a contiguous range of pointers mapping to active pool allocations. The primary purpose for this is to allow ComponentSystem-like management of memory pools with types that do not derive from Component. ComponentSystem now uses a PoolAdapter instead of directly dealing with the allocator.