### PR TITLE
Use PoolAdapter in more places

### DIFF
--- a/nc/include/ECS.h
+++ b/nc/include/ECS.h
@@ -17,7 +17,8 @@ namespace nc
 {
     /** Entity Functions */
     EntityHandle CreateEntity(EntityInfo info = EntityInfo{});
-    bool DestroyEntity(EntityHandle handle);
+    void DestroyEntity(EntityHandle handle);
+    bool EntityExists(EntityHandle handle);
     [[nodiscard]] Entity* GetEntity(EntityHandle handle);
     [[nodiscard]] Entity* GetEntity(const std::string& tag);
 

--- a/nc/source/ecs/ColliderTree.h
+++ b/nc/source/ecs/ColliderTree.h
@@ -1,11 +1,22 @@
 #pragma once
 
+#include "alloc/PoolAdapter.h"
 #include "physics/CollisionUtility.h"
-#include "alloc/Utility.h"
 
-#include <memory>
 #include <vector>
 #include <variant>
+
+namespace nc
+{
+    namespace ecs { struct StaticTreeEntry; }
+
+    template<>
+    struct StoragePolicy<ecs::StaticTreeEntry>
+    {
+        using allow_trivial_destruction = std::true_type;
+        using sort_dense_storage_by_address = std::true_type;
+    };
+}
 
 namespace nc::ecs
 {
@@ -70,7 +81,6 @@ namespace nc::ecs
     {
         public:
             ColliderTree(uint32_t maxStaticColliders, uint32_t densityThreshold, float minimumExtent, float worldspaceExtent);
-            ~ColliderTree() noexcept;
 
             void Add(EntityHandle handle, const ColliderInfo& info);
             void Remove(EntityHandle handle);
@@ -79,8 +89,7 @@ namespace nc::ecs
             std::vector<const StaticTreeEntry*> BroadCheck(const DirectX::BoundingSphere& volume) const;
 
         private:
-            using Allocator = alloc::PoolAllocator<StaticTreeEntry>;
-            std::vector<std::unique_ptr<StaticTreeEntry, alloc::basic_deleter<Allocator>>> m_staticEntries;
+            alloc::PoolAdapter<StaticTreeEntry> m_pool;
             Octant m_root;
     };
 } // namespace nc::ecs

--- a/nc/source/ecs/EcsApiImpl.cpp
+++ b/nc/source/ecs/EcsApiImpl.cpp
@@ -30,9 +30,14 @@ namespace nc
         return internal::g_ecsImpl->CreateEntity(std::move(info));
     }
 
-    bool DestroyEntity(EntityHandle handle)
+    void DestroyEntity(EntityHandle handle)
     {
         return internal::g_ecsImpl->DestroyEntity(handle);
+    }
+
+    bool EntityExists(EntityHandle handle)
+    {
+        return internal::g_ecsImpl->DoesEntityExist(handle);
     }
 
     Entity* GetEntity(EntityHandle handle)

--- a/nc/source/ecs/EcsApiImpl.cpp
+++ b/nc/source/ecs/EcsApiImpl.cpp
@@ -8,15 +8,17 @@ namespace nc
     {
         const auto DefaultEntityTag = std::string{"Entity"};
         ecs::EntityComponentSystem* g_ecsImpl = nullptr;
+        ecs::EntitySystem* g_entitySystem = nullptr;
         ecs::ColliderSystem* g_colliderSystem = nullptr;
         ecs::ComponentSystem<NetworkDispatcher>* g_networkDispatcherSystem = nullptr;
         ecs::ComponentSystem<PointLight>* g_pointLightSystem = nullptr;
         ecs::ComponentSystem<Renderer>* g_rendererSystem = nullptr;
         ecs::ComponentSystem<Transform>* g_transformSystem = nullptr;
-
+        
         void RegisterEcs(ecs::EntityComponentSystem* impl)
         {
             g_ecsImpl = impl;
+            g_entitySystem = impl->GetEntitySystem();
             g_colliderSystem = impl->GetColliderSystem();
             g_networkDispatcherSystem = impl->GetNetworkDispatcherSystem();
             g_pointLightSystem = impl->GetPointLightSystem();
@@ -27,27 +29,29 @@ namespace nc
 
     EntityHandle CreateEntity(EntityInfo info)
     {
-        return internal::g_ecsImpl->CreateEntity(std::move(info));
+        auto handle = internal::g_entitySystem->Add(info);
+        internal::g_transformSystem->Add(handle, info.position, info.rotation, info.scale, info.parent);
+        return handle;
     }
 
     void DestroyEntity(EntityHandle handle)
     {
-        return internal::g_ecsImpl->DestroyEntity(handle);
+        return internal::g_entitySystem->Remove(handle);
     }
 
     bool EntityExists(EntityHandle handle)
     {
-        return internal::g_ecsImpl->DoesEntityExist(handle);
+        return internal::g_entitySystem->Contains(handle);
     }
 
     Entity* GetEntity(EntityHandle handle)
     {
-        return internal::g_ecsImpl->GetEntity(handle);
+        return internal::g_entitySystem->Get(handle);
     }
 
     Entity* GetEntity(const std::string& tag)
     {
-        return internal::g_ecsImpl->GetEntity(tag);
+        return internal::g_entitySystem->Get(tag);
     }
 
     template<> ParticleEmitter* AddComponent<ParticleEmitter>(EntityHandle handle, ParticleInfo info)

--- a/nc/source/ecs/EntityComponentSystem.cpp
+++ b/nc/source/ecs/EntityComponentSystem.cpp
@@ -10,175 +10,169 @@
 
 namespace nc::ecs
 {
-#ifdef USE_VULKAN
-EntityComponentSystem::EntityComponentSystem()
-#else
-EntityComponentSystem::EntityComponentSystem(graphics::Graphics* graphics)
-#endif
-    : m_handleManager{},
-      m_activePool{config::GetMemorySettings().maxTransforms},
-      m_toDestroy{},
-      m_colliderSystem{nullptr},
-      m_lightSystem{ std::make_unique<ComponentSystem<PointLight>>(PointLightManager::MAX_POINT_LIGHTS) },
-      m_particleEmitterSystem{nullptr},
-      m_rendererSystem{nullptr},
-      m_transformSystem{nullptr},
-      m_networkDispatcherSystem{nullptr}
-{
-    const auto& memorySettings = config::GetMemorySettings();
-    const auto& physicsSettings = config::GetPhysicsSettings();
-
-    m_colliderSystem = std::make_unique<ColliderSystem>
-    (
-        memorySettings.maxDynamicColliders,
-        memorySettings.maxStaticColliders,
-        physicsSettings.octreeDensityThreshold,
-        physicsSettings.octreeMinimumExtent,
-        physicsSettings.worldspaceExtent
-    );
-
     #ifdef USE_VULKAN
-    m_particleEmitterSystem = std::make_unique<ParticleEmitterSystem>(memorySettings.maxParticleEmitters);
+    EntityComponentSystem::EntityComponentSystem()
     #else
-    m_particleEmitterSystem = std::make_unique<ParticleEmitterSystem>(memorySettings.maxParticleEmitters, graphics);
+    EntityComponentSystem::EntityComponentSystem(graphics::Graphics* graphics)
     #endif
-
-    m_rendererSystem = std::make_unique<ComponentSystem<Renderer>>(memorySettings.maxRenderers);
-    m_transformSystem = std::make_unique<ComponentSystem<Transform>>(memorySettings.maxTransforms);
-    m_networkDispatcherSystem = std::make_unique<ComponentSystem<NetworkDispatcher>>(memorySettings.maxNetworkDispatchers);
-
-    internal::RegisterEcs(this);
-}
-
-ColliderSystem* EntityComponentSystem::GetColliderSystem() const
-{
-    return m_colliderSystem.get();
-}
-
-ComponentSystem<NetworkDispatcher>* EntityComponentSystem::GetNetworkDispatcherSystem() const
-{
-    return m_networkDispatcherSystem.get();
-}
-
-ParticleEmitterSystem* EntityComponentSystem::GetParticleEmitterSystem()
-{
-    return m_particleEmitterSystem.get();
-}
-
-ComponentSystem<PointLight>* EntityComponentSystem::GetPointLightSystem() const
-{
-    return m_lightSystem.get();
-}
-
-ComponentSystem<Renderer>* EntityComponentSystem::GetRendererSystem() const
-{
-    return m_rendererSystem.get();
-}
-
-ComponentSystem<Transform>* EntityComponentSystem::GetTransformSystem() const
-{
-    return m_transformSystem.get();
-}
-
-Systems EntityComponentSystem::GetComponentSystems() const
-{
-    return Systems
+        : m_handleManager{},
+          m_activePool{config::GetMemorySettings().maxTransforms},
+          m_toDestroy{},
+          m_colliderSystem{nullptr},
+          m_lightSystem{ std::make_unique<ComponentSystem<PointLight>>(PointLightManager::MAX_POINT_LIGHTS) },
+          m_particleEmitterSystem{nullptr},
+          m_rendererSystem{nullptr},
+          m_transformSystem{nullptr},
+          m_networkDispatcherSystem{nullptr}
     {
-        .collider = m_colliderSystem->GetComponentSystem(),
-        .networkDispatcher = m_networkDispatcherSystem.get(),
-        .particleEmitter = m_particleEmitterSystem->GetComponentSystem(),
-        .pointLight = m_lightSystem.get(),
-        .renderer = m_rendererSystem.get(),
-        .transform = m_transformSystem.get()
-    };
-}
+        const auto& memorySettings = config::GetMemorySettings();
+        const auto& physicsSettings = config::GetPhysicsSettings();
 
-std::span<Entity*> EntityComponentSystem::GetActiveEntities() noexcept
-{
-    return m_activePool.GetActiveRange();
-}
+        m_colliderSystem = std::make_unique<ColliderSystem>
+        (
+            memorySettings.maxDynamicColliders,
+            memorySettings.maxStaticColliders,
+            physicsSettings.octreeDensityThreshold,
+            physicsSettings.octreeMinimumExtent,
+            physicsSettings.worldspaceExtent
+        );
 
-EntityHandle EntityComponentSystem::CreateEntity(EntityInfo info)
-{
-    auto entityHandle = m_handleManager.GenerateNewHandle();
-    m_transformSystem->Add(entityHandle, info.position, info.rotation, info.scale, info.parent);
-    m_activePool.Add(entityHandle, std::move(info.tag), info.layer, info.isStatic);
-    return entityHandle;
-}
+        #ifdef USE_VULKAN
+        m_particleEmitterSystem = std::make_unique<ParticleEmitterSystem>(memorySettings.maxParticleEmitters);
+        #else
+        m_particleEmitterSystem = std::make_unique<ParticleEmitterSystem>(memorySettings.maxParticleEmitters, graphics);
+        #endif
 
-bool EntityComponentSystem::DoesEntityExist(const EntityHandle handle) const noexcept
-{
-    return m_activePool.Contains([handle](auto* e) { return e->Handle == handle; });
-}
+        m_rendererSystem = std::make_unique<ComponentSystem<Renderer>>(memorySettings.maxRenderers);
+        m_transformSystem = std::make_unique<ComponentSystem<Transform>>(memorySettings.maxTransforms);
+        m_networkDispatcherSystem = std::make_unique<ComponentSystem<NetworkDispatcher>>(memorySettings.maxNetworkDispatchers);
 
-/** Friendly reminder - this invalidates m_active iterators */
-bool EntityComponentSystem::DestroyEntity(EntityHandle handle)
-{
-    auto* ptr = m_activePool.Get([handle](auto* e) { return e->Handle == handle; });
-    if(!ptr)
-        return false;
-
-    m_toDestroy.push_back(m_activePool.Extract([handle](auto* e) { return e->Handle == handle; }));
-    return true;
-}
-
-Entity* EntityComponentSystem::GetEntity(EntityHandle handle)
-{
-    return m_activePool.Get([handle](auto* e) { return e->Handle == handle; });
-}
-
-Entity* EntityComponentSystem::GetEntity(const std::string& tag)
-{
-    return m_activePool.Get([&tag](auto* e) { return e->Tag == tag; });
-
-}
-
-void EntityComponentSystem::SendFrameUpdate(float dt)
-{
-    for(auto* entity : m_activePool.GetActiveRange())
-        entity->SendFrameUpdate(dt);
-}
-
-void EntityComponentSystem::SendFixedUpdate()
-{
-    for(auto* entity : m_activePool.GetActiveRange())
-        entity->SendFixedUpdate();
-}
-
-void EntityComponentSystem::SendOnDestroy()
-{
-    for(auto& entity : m_toDestroy)
-    {
-        auto handle = entity.Handle;
-        entity.SendOnDestroy();
-        m_colliderSystem->Remove(handle, entity.IsStatic);
-        m_transformSystem->Remove(handle);
-        m_rendererSystem->Remove(handle);
-        m_lightSystem->Remove(handle);
-        m_networkDispatcherSystem->Remove(handle);
-        m_particleEmitterSystem->Remove(handle);
+        internal::RegisterEcs(this);
     }
 
-    m_toDestroy.clear();
-}
+    ColliderSystem* EntityComponentSystem::GetColliderSystem() const
+    {
+        return m_colliderSystem.get();
+    }
 
-void EntityComponentSystem::ClearState()
-{
-    // Don't do the full SendOnDestroy process as systems will be cleared anyway.
-    for(auto* entity : m_activePool.GetActiveRange())
-        entity->SendOnDestroy();
-    
-    for(auto& entity : m_toDestroy)
-        entity.SendOnDestroy();
+    ComponentSystem<NetworkDispatcher>* EntityComponentSystem::GetNetworkDispatcherSystem() const
+    {
+        return m_networkDispatcherSystem.get();
+    }
 
-    m_activePool.Clear();
-    m_toDestroy.clear();
-    m_handleManager.Reset();
-    m_colliderSystem->Clear();
-    m_transformSystem->Clear();
-    m_rendererSystem->Clear();
-    m_lightSystem->Clear();
-    m_networkDispatcherSystem->Clear();
-    m_particleEmitterSystem->Clear();
-}
+    ParticleEmitterSystem* EntityComponentSystem::GetParticleEmitterSystem()
+    {
+        return m_particleEmitterSystem.get();
+    }
+
+    ComponentSystem<PointLight>* EntityComponentSystem::GetPointLightSystem() const
+    {
+        return m_lightSystem.get();
+    }
+
+    ComponentSystem<Renderer>* EntityComponentSystem::GetRendererSystem() const
+    {
+        return m_rendererSystem.get();
+    }
+
+    ComponentSystem<Transform>* EntityComponentSystem::GetTransformSystem() const
+    {
+        return m_transformSystem.get();
+    }
+
+    Systems EntityComponentSystem::GetComponentSystems() const
+    {
+        return Systems
+        {
+            .collider = m_colliderSystem->GetComponentSystem(),
+            .networkDispatcher = m_networkDispatcherSystem.get(),
+            .particleEmitter = m_particleEmitterSystem->GetComponentSystem(),
+            .pointLight = m_lightSystem.get(),
+            .renderer = m_rendererSystem.get(),
+            .transform = m_transformSystem.get()
+        };
+    }
+
+    std::span<Entity*> EntityComponentSystem::GetActiveEntities() noexcept
+    {
+        return m_activePool.GetActiveRange();
+    }
+
+    EntityHandle EntityComponentSystem::CreateEntity(EntityInfo info)
+    {
+        auto entityHandle = m_handleManager.GenerateNewHandle();
+        m_transformSystem->Add(entityHandle, info.position, info.rotation, info.scale, info.parent);
+        m_activePool.Add(entityHandle, std::move(info.tag), info.layer, info.isStatic);
+        return entityHandle;
+    }
+
+    bool EntityComponentSystem::DoesEntityExist(const EntityHandle handle) const noexcept
+    {
+        return m_activePool.Contains([handle](auto* e) { return e->Handle == handle; });
+    }
+
+    /** Friendly reminder - this invalidates m_active iterators */
+    void EntityComponentSystem::DestroyEntity(EntityHandle handle)
+    {
+        m_toDestroy.push_back(m_activePool.Extract([handle](auto* e) { return e->Handle == handle; }));
+    }
+
+    Entity* EntityComponentSystem::GetEntity(EntityHandle handle)
+    {
+        return m_activePool.Get([handle](auto* e) { return e->Handle == handle; });
+    }
+
+    Entity* EntityComponentSystem::GetEntity(const std::string& tag)
+    {
+        return m_activePool.Get([&tag](auto* e) { return e->Tag == tag; });
+    }
+
+    void EntityComponentSystem::SendFrameUpdate(float dt)
+    {
+        for(auto* entity : m_activePool.GetActiveRange())
+            entity->SendFrameUpdate(dt);
+    }
+
+    void EntityComponentSystem::SendFixedUpdate()
+    {
+        for(auto* entity : m_activePool.GetActiveRange())
+            entity->SendFixedUpdate();
+    }
+
+    void EntityComponentSystem::SendOnDestroy()
+    {
+        for(auto& entity : m_toDestroy)
+        {
+            auto handle = entity.Handle;
+            entity.SendOnDestroy();
+            m_colliderSystem->Remove(handle, entity.IsStatic);
+            m_transformSystem->Remove(handle);
+            m_rendererSystem->Remove(handle);
+            m_lightSystem->Remove(handle);
+            m_networkDispatcherSystem->Remove(handle);
+            m_particleEmitterSystem->Remove(handle);
+        }
+
+        m_toDestroy.clear();
+    }
+
+    void EntityComponentSystem::ClearState()
+    {
+        // Don't do the full SendOnDestroy process as systems will be cleared anyway.
+        for(auto* entity : m_activePool.GetActiveRange())
+            entity->SendOnDestroy();
+        
+        for(auto& entity : m_toDestroy)
+            entity.SendOnDestroy();
+
+        m_activePool.Clear();
+        m_toDestroy.clear();
+        m_handleManager.Reset();
+        m_colliderSystem->Clear();
+        m_transformSystem->Clear();
+        m_rendererSystem->Clear();
+        m_lightSystem->Clear();
+        m_networkDispatcherSystem->Clear();
+        m_particleEmitterSystem->Clear();
+    }
 } // end namespace nc::ecs

--- a/nc/source/ecs/EntityComponentSystem.cpp
+++ b/nc/source/ecs/EntityComponentSystem.cpp
@@ -179,18 +179,13 @@ void EntityComponentSystem::SendOnDestroy()
 
 void EntityComponentSystem::ClearState()
 {
-    // We cannot call DestroyEntity while iterating m_active, so copy the handles
-    std::vector<EntityHandle> handles;
-    handles.reserve(m_active.size());
-    std::transform(m_active.cbegin(), m_active.cend(), std::back_inserter(handles), [](const auto& pair)
-    {
-        return pair.first;
-    });
+    // Don't do the full SendOnDestroy process as systems will be cleared anyway.
+    for(auto& [handle, entity] : m_active)
+        entity.SendOnDestroy();
+    
+    for(auto& [handle, entity] : m_toDestroy)
+        entity.SendOnDestroy();
 
-    for(const auto handle : handles)
-        DestroyEntity(handle);
-
-    SendOnDestroy();
     m_active.clear();
     m_toDestroy.clear();
     m_handleManager.Reset();

--- a/nc/source/ecs/EntityComponentSystem.cpp
+++ b/nc/source/ecs/EntityComponentSystem.cpp
@@ -1,178 +1,69 @@
 #include "EntityComponentSystem.h"
-#include "Ecs.h"
-#include "component/Collider.h"
-#include "component/NetworkDispatcher.h"
-#include "component/PointLight.h"
-#include "component/PointLightManager.h"
-#include "component/Renderer.h"
-#include "component/Transform.h"
-#include "config/Config.h"
 
 namespace nc::ecs
 {
     #ifdef USE_VULKAN
-    EntityComponentSystem::EntityComponentSystem()
+    EntityComponentSystem::EntityComponentSystem(const config::MemorySettings& memSettings,
+                                                 const config::PhysicsSettings& physSettings)
     #else
-    EntityComponentSystem::EntityComponentSystem(graphics::Graphics* graphics)
+    EntityComponentSystem::EntityComponentSystem(graphics::Graphics* graphics,
+                                                 const config::MemorySettings& memSettings,
+                                                 const config::PhysicsSettings& physSettings)
     #endif
-        : m_handleManager{},
-          m_activePool{config::GetMemorySettings().maxTransforms},
-          m_toDestroy{},
-          m_colliderSystem{nullptr},
-          m_lightSystem{ std::make_unique<ComponentSystem<PointLight>>(PointLightManager::MAX_POINT_LIGHTS) },
-          m_particleEmitterSystem{nullptr},
-          m_rendererSystem{nullptr},
-          m_transformSystem{nullptr},
-          m_networkDispatcherSystem{nullptr}
+        : m_entitySystem{memSettings.maxTransforms},
+          m_colliderSystem{memSettings.maxDynamicColliders,
+                           memSettings.maxStaticColliders,
+                           physSettings.octreeDensityThreshold,
+                           physSettings.octreeMinimumExtent,
+                           physSettings.worldspaceExtent},
+          m_lightSystem{PointLightManager::MAX_POINT_LIGHTS},
+          #ifdef USE_VULKAN
+          m_particleEmitterSystem{memSettings.maxParticleEmitters},
+          #else
+          m_particleEmitterSystem{memSettings.maxParticleEmitters, graphics},
+          #endif
+          m_rendererSystem{memSettings.maxRenderers},
+          m_transformSystem{memSettings.maxTransforms},
+          m_networkDispatcherSystem{memSettings.maxNetworkDispatchers}
     {
-        const auto& memorySettings = config::GetMemorySettings();
-        const auto& physicsSettings = config::GetPhysicsSettings();
-
-        m_colliderSystem = std::make_unique<ColliderSystem>
-        (
-            memorySettings.maxDynamicColliders,
-            memorySettings.maxStaticColliders,
-            physicsSettings.octreeDensityThreshold,
-            physicsSettings.octreeMinimumExtent,
-            physicsSettings.worldspaceExtent
-        );
-
-        #ifdef USE_VULKAN
-        m_particleEmitterSystem = std::make_unique<ParticleEmitterSystem>(memorySettings.maxParticleEmitters);
-        #else
-        m_particleEmitterSystem = std::make_unique<ParticleEmitterSystem>(memorySettings.maxParticleEmitters, graphics);
-        #endif
-
-        m_rendererSystem = std::make_unique<ComponentSystem<Renderer>>(memorySettings.maxRenderers);
-        m_transformSystem = std::make_unique<ComponentSystem<Transform>>(memorySettings.maxTransforms);
-        m_networkDispatcherSystem = std::make_unique<ComponentSystem<NetworkDispatcher>>(memorySettings.maxNetworkDispatchers);
-
         internal::RegisterEcs(this);
     }
 
-    ColliderSystem* EntityComponentSystem::GetColliderSystem() const
-    {
-        return m_colliderSystem.get();
-    }
-
-    ComponentSystem<NetworkDispatcher>* EntityComponentSystem::GetNetworkDispatcherSystem() const
-    {
-        return m_networkDispatcherSystem.get();
-    }
-
-    ParticleEmitterSystem* EntityComponentSystem::GetParticleEmitterSystem()
-    {
-        return m_particleEmitterSystem.get();
-    }
-
-    ComponentSystem<PointLight>* EntityComponentSystem::GetPointLightSystem() const
-    {
-        return m_lightSystem.get();
-    }
-
-    ComponentSystem<Renderer>* EntityComponentSystem::GetRendererSystem() const
-    {
-        return m_rendererSystem.get();
-    }
-
-    ComponentSystem<Transform>* EntityComponentSystem::GetTransformSystem() const
-    {
-        return m_transformSystem.get();
-    }
-
-    Systems EntityComponentSystem::GetComponentSystems() const
+    Systems EntityComponentSystem::GetComponentSystems() noexcept
     {
         return Systems
         {
-            .collider = m_colliderSystem->GetComponentSystem(),
-            .networkDispatcher = m_networkDispatcherSystem.get(),
-            .particleEmitter = m_particleEmitterSystem->GetComponentSystem(),
-            .pointLight = m_lightSystem.get(),
-            .renderer = m_rendererSystem.get(),
-            .transform = m_transformSystem.get()
+            .collider = m_colliderSystem.GetComponentSystem(),
+            .networkDispatcher = &m_networkDispatcherSystem,
+            .particleEmitter = m_particleEmitterSystem.GetComponentSystem(),
+            .pointLight = &m_lightSystem,
+            .renderer = &m_rendererSystem,
+            .transform = &m_transformSystem
         };
     }
 
-    std::span<Entity*> EntityComponentSystem::GetActiveEntities() noexcept
+    void EntityComponentSystem::FrameEnd()
     {
-        return m_activePool.GetActiveRange();
-    }
-
-    EntityHandle EntityComponentSystem::CreateEntity(EntityInfo info)
-    {
-        auto entityHandle = m_handleManager.GenerateNewHandle();
-        m_transformSystem->Add(entityHandle, info.position, info.rotation, info.scale, info.parent);
-        m_activePool.Add(entityHandle, std::move(info.tag), info.layer, info.isStatic);
-        return entityHandle;
-    }
-
-    bool EntityComponentSystem::DoesEntityExist(const EntityHandle handle) const noexcept
-    {
-        return m_activePool.Contains([handle](auto* e) { return e->Handle == handle; });
-    }
-
-    /** Friendly reminder - this invalidates m_active iterators */
-    void EntityComponentSystem::DestroyEntity(EntityHandle handle)
-    {
-        m_toDestroy.push_back(m_activePool.Extract([handle](auto* e) { return e->Handle == handle; }));
-    }
-
-    Entity* EntityComponentSystem::GetEntity(EntityHandle handle)
-    {
-        return m_activePool.Get([handle](auto* e) { return e->Handle == handle; });
-    }
-
-    Entity* EntityComponentSystem::GetEntity(const std::string& tag)
-    {
-        return m_activePool.Get([&tag](auto* e) { return e->Tag == tag; });
-    }
-
-    void EntityComponentSystem::SendFrameUpdate(float dt)
-    {
-        for(auto* entity : m_activePool.GetActiveRange())
-            entity->SendFrameUpdate(dt);
-    }
-
-    void EntityComponentSystem::SendFixedUpdate()
-    {
-        for(auto* entity : m_activePool.GetActiveRange())
-            entity->SendFixedUpdate();
-    }
-
-    void EntityComponentSystem::SendOnDestroy()
-    {
-        for(auto& entity : m_toDestroy)
+        m_entitySystem.CommitRemovals([this](const auto& entity)
         {
             auto handle = entity.Handle;
-            entity.SendOnDestroy();
-            m_colliderSystem->Remove(handle, entity.IsStatic);
-            m_transformSystem->Remove(handle);
-            m_rendererSystem->Remove(handle);
-            m_lightSystem->Remove(handle);
-            m_networkDispatcherSystem->Remove(handle);
-            m_particleEmitterSystem->Remove(handle);
-        }
-
-        m_toDestroy.clear();
+            m_colliderSystem.Remove(handle, entity.IsStatic);
+            m_transformSystem.Remove(handle);
+            m_rendererSystem.Remove(handle);
+            m_lightSystem.Remove(handle);
+            m_networkDispatcherSystem.Remove(handle);
+            m_particleEmitterSystem.Remove(handle);
+        });
     }
 
-    void EntityComponentSystem::ClearState()
+    void EntityComponentSystem::Clear()
     {
-        // Don't do the full SendOnDestroy process as systems will be cleared anyway.
-        for(auto* entity : m_activePool.GetActiveRange())
-            entity->SendOnDestroy();
-        
-        for(auto& entity : m_toDestroy)
-            entity.SendOnDestroy();
-
-        m_activePool.Clear();
-        m_toDestroy.clear();
-        m_handleManager.Reset();
-        m_colliderSystem->Clear();
-        m_transformSystem->Clear();
-        m_rendererSystem->Clear();
-        m_lightSystem->Clear();
-        m_networkDispatcherSystem->Clear();
-        m_particleEmitterSystem->Clear();
+        m_entitySystem.Clear();
+        m_colliderSystem.Clear();
+        m_transformSystem.Clear();
+        m_rendererSystem.Clear();
+        m_lightSystem.Clear();
+        m_networkDispatcherSystem.Clear();
+        m_particleEmitterSystem.Clear();
     }
 } // end namespace nc::ecs

--- a/nc/source/ecs/EntityComponentSystem.h
+++ b/nc/source/ecs/EntityComponentSystem.h
@@ -53,7 +53,7 @@ namespace nc::ecs
             std::span<Entity*> GetActiveEntities() noexcept;
 
             EntityHandle CreateEntity(EntityInfo info);
-            bool DestroyEntity(EntityHandle handle);
+            void DestroyEntity(EntityHandle handle);
             bool DoesEntityExist(const EntityHandle handle) const noexcept;
             Entity* GetEntity(EntityHandle handle);
             Entity* GetEntity(const std::string& tag);

--- a/nc/source/ecs/EntityComponentSystem.h
+++ b/nc/source/ecs/EntityComponentSystem.h
@@ -1,10 +1,10 @@
 #pragma once
 
+#include "alloc/PoolAdapter.h"
 #include "entity/Entity.h"
 #include "entity/EntityHandle.h"
 #include "entity/EntityInfo.h"
 #include "ColliderSystem.h"
-#include "EntityMap.h"
 #include "HandleManager.h"
 #include "ParticleEmitterSystem.h"
 
@@ -50,7 +50,7 @@ namespace nc::ecs
             ComponentSystem<Renderer>* GetRendererSystem() const;
             ComponentSystem<Transform>* GetTransformSystem() const;
             Systems GetComponentSystems() const;
-            EntityMap& GetActiveEntities() noexcept;
+            std::span<Entity*> GetActiveEntities() noexcept;
 
             EntityHandle CreateEntity(EntityInfo info);
             bool DestroyEntity(EntityHandle handle);
@@ -65,8 +65,8 @@ namespace nc::ecs
 
         private:
             HandleManager m_handleManager;
-            EntityMap m_active;
-            EntityMap m_toDestroy;
+            alloc::PoolAdapter<Entity> m_activePool;
+            std::vector<Entity> m_toDestroy;
             std::unique_ptr<ColliderSystem> m_colliderSystem;
             std::unique_ptr<ComponentSystem<PointLight>> m_lightSystem;
             std::unique_ptr<ParticleEmitterSystem> m_particleEmitterSystem;

--- a/nc/source/ecs/EntityComponentSystem.h
+++ b/nc/source/ecs/EntityComponentSystem.h
@@ -1,26 +1,18 @@
 #pragma once
 
-#include "alloc/PoolAdapter.h"
-#include "entity/Entity.h"
-#include "entity/EntityHandle.h"
-#include "entity/EntityInfo.h"
+#include "EntitySystem.h"
 #include "ColliderSystem.h"
-#include "HandleManager.h"
 #include "ParticleEmitterSystem.h"
+#include "alloc/PoolAdapter.h"
+#include "component/Collider.h"
+#include "component/NetworkDispatcher.h"
+#include "component/PointLight.h"
+#include "component/PointLightManager.h"
+#include "component/Renderer.h"
+#include "component/Transform.h"
+#include "config/Config.h"
 
-#include <memory>
-
-namespace nc
-{
-    class Collider;
-    class NetworkDispatcher;
-    class PointLight;
-    class Renderer;
-    class Vector3;
-    class Quaternion;
-    namespace graphics { class Graphics; }
-    namespace physics { class ColliderSystem; }
-}
+namespace nc::graphics { class Graphics; }
 
 namespace nc::ecs
 {
@@ -38,40 +30,33 @@ namespace nc::ecs
     {
         public:
             #ifdef USE_VULKAN
-            EntityComponentSystem();
+            EntityComponentSystem(const config::MemorySettings& memSettings,
+                                  const config::PhysicsSettings& physSettings);
             #else
-            EntityComponentSystem(graphics::Graphics* graphics);
+            EntityComponentSystem(graphics::Graphics* graphics,
+                                  const config::MemorySettings& memSettings,
+                                  const config::PhysicsSettings& physSettings);
             #endif
 
-            ColliderSystem* GetColliderSystem() const;
-            ComponentSystem<NetworkDispatcher>* GetNetworkDispatcherSystem() const;
-            ParticleEmitterSystem* GetParticleEmitterSystem();
-            ComponentSystem<PointLight>* GetPointLightSystem() const;
-            ComponentSystem<Renderer>* GetRendererSystem() const;
-            ComponentSystem<Transform>* GetTransformSystem() const;
-            Systems GetComponentSystems() const;
-            std::span<Entity*> GetActiveEntities() noexcept;
-
-            EntityHandle CreateEntity(EntityInfo info);
-            void DestroyEntity(EntityHandle handle);
-            bool DoesEntityExist(const EntityHandle handle) const noexcept;
-            Entity* GetEntity(EntityHandle handle);
-            Entity* GetEntity(const std::string& tag);
-
-            void SendFrameUpdate(float dt);
-            void SendFixedUpdate();
-            void SendOnDestroy();
-            void ClearState();
+            auto GetColliderSystem() noexcept { return &m_colliderSystem; }
+            auto GetNetworkDispatcherSystem() noexcept { return &m_networkDispatcherSystem; }
+            auto GetParticleEmitterSystem() noexcept { return &m_particleEmitterSystem; }
+            auto GetPointLightSystem() noexcept { return &m_lightSystem; }
+            auto GetRendererSystem()  noexcept { return &m_rendererSystem; }
+            auto GetTransformSystem() noexcept { return &m_transformSystem; }
+            auto GetEntitySystem() noexcept { return &m_entitySystem; }
+            auto GetActiveEntities() noexcept { return m_entitySystem.GetActiveEntities(); }
+            auto GetComponentSystems() noexcept -> Systems;
+            void FrameEnd();
+            void Clear();
 
         private:
-            HandleManager m_handleManager;
-            alloc::PoolAdapter<Entity> m_activePool;
-            std::vector<Entity> m_toDestroy;
-            std::unique_ptr<ColliderSystem> m_colliderSystem;
-            std::unique_ptr<ComponentSystem<PointLight>> m_lightSystem;
-            std::unique_ptr<ParticleEmitterSystem> m_particleEmitterSystem;
-            std::unique_ptr<ComponentSystem<Renderer>> m_rendererSystem;
-            std::unique_ptr<ComponentSystem<Transform>> m_transformSystem;
-            std::unique_ptr<ComponentSystem<NetworkDispatcher>> m_networkDispatcherSystem;
+            EntitySystem m_entitySystem;
+            ColliderSystem m_colliderSystem;
+            ComponentSystem<PointLight> m_lightSystem;
+            ParticleEmitterSystem m_particleEmitterSystem;
+            ComponentSystem<Renderer> m_rendererSystem;
+            ComponentSystem<Transform> m_transformSystem;
+            ComponentSystem<NetworkDispatcher> m_networkDispatcherSystem;
     };
 } // namespace nc::ecs

--- a/nc/source/ecs/EntityMap.h
+++ b/nc/source/ecs/EntityMap.h
@@ -1,8 +1,0 @@
-#pragma once
-#include "entity/Entity.h"
-#include <unordered_map>
-
-namespace nc::ecs
-{
-    using EntityMap = std::unordered_map<EntityHandle, Entity, EntityHandle::Hash>;
-}

--- a/nc/source/ecs/EntitySystem.h
+++ b/nc/source/ecs/EntitySystem.h
@@ -1,0 +1,98 @@
+#pragma once
+
+#include "HandleManager.h"
+#include "alloc/PoolAdapter.h"
+#include "entity/Entity.h"
+#include "entity/EntityInfo.h"
+
+#include <concepts>
+#include <span>
+#include <vector>
+
+namespace nc::ecs
+{
+    class EntitySystem
+    {
+        public:
+            EntitySystem(size_t count);
+
+            EntityHandle Add(const EntityInfo& info);
+            void Remove(EntityHandle handle);
+            bool Contains(EntityHandle handle);
+            Entity* Get(EntityHandle handle);
+            Entity* Get(const std::string& tag);
+            std::span<Entity*> GetActiveEntities();
+            void Clear();
+
+            template<std::invocable<const Entity&> UnaryFunc>
+            void CommitRemovals(UnaryFunc func);
+
+        private:
+            alloc::PoolAdapter<Entity> m_activePool;
+            std::vector<Entity> m_toRemove;
+            HandleManager m_handle;
+    };
+
+    inline EntitySystem::EntitySystem(size_t count)
+        : m_activePool{count},
+          m_toRemove{}
+    {
+    }
+
+    inline EntityHandle EntitySystem::Add(const EntityInfo& info)
+    {
+        auto handle = m_handle.GenerateNewHandle();
+        m_activePool.Add(handle, std::move(info.tag), info.layer, info.isStatic);
+        return handle;
+    }
+
+    inline void EntitySystem::Remove(EntityHandle handle)
+    {
+        m_toRemove.push_back(m_activePool.Extract([handle](auto* e) { return e->Handle == handle; }));
+    }
+
+    inline bool EntitySystem::Contains(EntityHandle handle)
+    {
+        return m_activePool.Contains([handle](auto* e) { return e->Handle == handle; });
+    }
+
+    inline Entity* EntitySystem::Get(EntityHandle handle)
+    {
+        return m_activePool.Get([handle](auto* e) { return e->Handle == handle; });
+    }
+
+    inline Entity* EntitySystem::Get(const std::string& tag)
+    {
+        return m_activePool.Get([&tag](auto* e) { return e->Tag == tag; });
+    }
+
+    inline std::span<Entity*> EntitySystem::GetActiveEntities()
+    {
+        return m_activePool.GetActiveRange();
+    }
+
+    inline void EntitySystem::Clear()
+    {
+        for(auto* entity : m_activePool.GetActiveRange())
+            entity->SendOnDestroy();
+
+        for(auto& entity : m_toRemove)
+            entity.SendOnDestroy();
+
+        m_activePool.Clear();
+        m_toRemove.clear();
+        m_handle.Reset();
+    }
+
+    template<std::invocable<const Entity&> UnaryFunc>
+    void EntitySystem::CommitRemovals(UnaryFunc func)
+    {
+        for(auto& entity : m_toRemove)
+        {
+            entity.SendOnDestroy();
+            func(entity);
+        }
+
+        m_toRemove.clear();
+    }
+} // namespace nc::ecs

--- a/nc/source/engine/Engine.h
+++ b/nc/source/engine/Engine.h
@@ -52,8 +52,8 @@ namespace nc::core
 
             void ClearState();
             void DoSceneSwap();
-            void FixedStepLogic();
-            void FrameLogic(float dt);
+            void FixedStepLogic(std::span<Entity*> activeEntities);
+            void FrameLogic(std::span<Entity*> activeEntities, float dt);
             void FrameRender();
             void FrameCleanup();
             void SetBindings();

--- a/nc/source/math/Quaternion.cpp
+++ b/nc/source/math/Quaternion.cpp
@@ -56,7 +56,7 @@ namespace nc
     {
         IF_THROW(axis == Vector3::Zero(), "Quaternion::FromAxisAngle - Axis cannot be zero");
         auto axis_v = DirectX::XMVectorSet(axis.x, axis.y, axis.z, 0.0f);
-        auto quat_v = DirectX::XMQuaternionRotationAxis(axis_v, angle);
+        auto quat_v = DirectX::XMQuaternionRotationAxis(axis_v, radians);
         auto out = Quaternion::Identity();
         DirectX::XMStoreQuaternion(&out, quat_v);
         return out;

--- a/nc/source/ui/UIImpl.cpp
+++ b/nc/source/ui/UIImpl.cpp
@@ -77,7 +77,7 @@ namespace nc::ui
     }
 
     #ifdef NC_EDITOR_ENABLED
-    void UIImpl::Frame(float* dt, ecs::EntityMap& activeEntities)
+    void UIImpl::Frame(float* dt, std::span<Entity*> activeEntities)
     {
         m_editor.Frame(dt, activeEntities);
         if(m_projectUI)

--- a/nc/source/ui/UIImpl.h
+++ b/nc/source/ui/UIImpl.h
@@ -28,7 +28,7 @@ namespace nc::ui
             void FrameBegin();
 
             #ifdef NC_EDITOR_ENABLED
-            void Frame(float* dt, ecs::EntityMap& activeEntities);
+            void Frame(float* dt, std::span<Entity*> activeEntities);
             #else
             void Frame();
             #endif

--- a/nc/source/ui/editor/Editor.cpp
+++ b/nc/source/ui/editor/Editor.cpp
@@ -30,7 +30,7 @@ namespace nc::ui::editor
     {
     }
 
-    void Editor::Frame(float* dt, ecs::EntityMap& activeEntities)
+    void Editor::Frame(float* dt, std::span<Entity*> activeEntities)
     {
         if(input::GetKeyDown(hotkey::Editor))
             m_openState_Editor = !m_openState_Editor;

--- a/nc/source/ui/editor/Editor.h
+++ b/nc/source/ui/editor/Editor.h
@@ -16,7 +16,7 @@ namespace nc::ui::editor
     {
         public:
             Editor(graphics::Graphics* graphics, const ecs::Systems& systems);
-            void Frame(float* dt, ecs::EntityMap& activeEntities);
+            void Frame(float* dt, std::span<Entity*> activeEntities);
 
         private:
             nc::graphics::Graphics* m_graphics;

--- a/nc/source/ui/editor/EditorControls.h
+++ b/nc/source/ui/editor/EditorControls.h
@@ -17,7 +17,7 @@ namespace nc::ui::editor::controls
     const auto GraphSize = ImVec2{128, 32};
     const auto Padding = 4.0f;
 
-    inline void SceneGraphPanel(ecs::EntityMap& entities, float windowHeight);
+    inline void SceneGraphPanel(std::span<Entity*> entities, float windowHeight);
     inline void SceneGraphNode(Entity* entity, Transform* transform);
     inline void EntityPanel(EntityHandle handle);
     inline void Component(ComponentBase* comp);
@@ -30,7 +30,7 @@ namespace nc::ui::editor::controls
     /**
      * Scene Graph Controls
      */
-    void SceneGraphPanel(ecs::EntityMap& entities, float windowHeight)
+    void SceneGraphPanel(std::span<Entity*> entities, float windowHeight)
     {
         ImGui::SetNextWindowPos({Padding, TitleBarHeight});
         auto sceneGraphHeight = windowHeight - TitleBarHeight;
@@ -47,16 +47,16 @@ namespace nc::ui::editor::controls
 
             if(ImGui::BeginChild("EntityList", {0, sceneGraphHeight / 2}, true))
             {
-                for(auto& [handle, entity] : entities)
+                for(auto* entity : entities)
                 {
-                    auto* transform = GetComponent<Transform>(handle);
+                    auto* transform = GetComponent<Transform>(entity->Handle);
                     if(transform->GetParent()) // only draw root nodes
                         continue;
 
-                    if(!filter.PassFilter(entity.Tag.c_str()))
+                    if(!filter.PassFilter(entity->Tag.c_str()))
                         continue;
                     
-                    SceneGraphNode(&entity, transform);
+                    SceneGraphNode(entity, transform);
                 }
             } ImGui::EndChild();
 

--- a/nc/source/ui/editor/EditorControls.h
+++ b/nc/source/ui/editor/EditorControls.h
@@ -251,13 +251,19 @@ namespace nc::ui::editor::controls
     template<class T>
     void ComponentSystemHeader(const char* name, ecs::ComponentSystem<T>* system)
     {
+        constexpr auto size = static_cast<unsigned>(sizeof(T));
+        constexpr auto destruction = StoragePolicy<T>::allow_trivial_destruction::value ? "False" : "True";
+        constexpr auto sorting = StoragePolicy<T>::sort_dense_storage_by_address::value ? "True" : "False";
+
         if(ImGui::CollapsingHeader(name))
         {
             ImGui::PushID(name);
             ImGui::Indent();
             auto components = system->GetComponents();
-            ImGui::Text("Component Size:  %u", static_cast<unsigned>(sizeof(T)));
-            ImGui::Text("Copmonent Count: %u", static_cast<unsigned>(components.size()));
+            ImGui::Text("Component Size:      %u", size);
+            ImGui::Text("Copmonent Count:     %u", static_cast<unsigned>(components.size()));
+            ImGui::Text("Require Destruction: %s", destruction);
+            ImGui::Text("Sort by Address:     %s", sorting);
             if(ImGui::CollapsingHeader("Components"))
             {
                 ImGui::Indent();


### PR DESCRIPTION
-ColliderTree uses PoolAdapter for tree entries.
-EntityMap was removed. Active entities are stored with a PoolAdapter, and those awaiting destruction can be extracted to a vector.
-Changed EntityComponentSystem.Clear() to be a quite a bit faster. We no longer attempt to remove each component individually. We just destroy the entities and do a per system clear.