### PR TITLE
Component Sorting

### DIFF
--- a/nc/include/ECS.h
+++ b/nc/include/ECS.h
@@ -13,7 +13,8 @@
 
 namespace nc
 {
-    using registry_type = ecs::Registry<AutoComponentGroup, Collider, NetworkDispatcher, ParticleEmitter, PointLight, Renderer, Tag, Transform>;
+    using registry_type_list = ecs::RegistryTypeList<AutoComponentGroup, Collider, NetworkDispatcher, ParticleEmitter, PointLight, Renderer, Tag, Transform>;
+    using registry_type = ecs::Registry<registry_type_list>;
 
     auto ActiveRegistry() -> registry_type*;
 

--- a/nc/include/component/Camera.h
+++ b/nc/include/component/Camera.h
@@ -14,7 +14,7 @@ namespace nc
             Camera& operator=(Camera&&) = delete;
 
             #ifdef NC_EDITOR_ENABLED
-            void EditorGuiElement() override;
+            void ComponentGuiElement() override;
             #endif
     };
 }

--- a/nc/include/component/Collider.h
+++ b/nc/include/component/Collider.h
@@ -52,7 +52,6 @@ namespace nc
 
             #ifdef NC_EDITOR_ENABLED
             void UpdateWidget(graphics::FrameManager* frame);
-            void EditorGuiElement() override;
             void SetEditorSelection(bool state);
             #endif
 
@@ -80,4 +79,8 @@ namespace nc
         using requires_on_add_callback = std::true_type;
         using requires_on_remove_callback = std::true_type;
     };
+
+    #ifdef NC_EDITOR_ENABLED
+    template<> void ComponentGuiElement<Collider>(Collider*);
+    #endif
 }

--- a/nc/include/component/Component.h
+++ b/nc/include/component/Component.h
@@ -18,22 +18,15 @@ namespace nc
     class ComponentBase
     {
         public:
-            ComponentBase(Entity entity) noexcept
+            explicit ComponentBase(Entity entity) noexcept
                 : m_parentEntity{entity} {}
 
-            virtual ~ComponentBase() = default;
             ComponentBase(const ComponentBase&) = delete;
             ComponentBase(ComponentBase&&) = default;
             ComponentBase& operator=(const ComponentBase&) = delete;
             ComponentBase& operator=(ComponentBase&&) = default;
 
-            /** @todo Fix this naming - it is omega confusing in transform when parent
-             * means something else. */
             Entity GetParentEntity() const noexcept { return m_parentEntity; }
-
-            #ifdef NC_EDITOR_ENABLED
-            virtual void EditorGuiElement();
-            #endif
 
         private:
             Entity m_parentEntity;
@@ -43,8 +36,10 @@ namespace nc
     class AutoComponent : public ComponentBase
     {
         public:
-            AutoComponent(Entity entity) noexcept
+            explicit AutoComponent(Entity entity) noexcept
                 : ComponentBase{entity} {}
+
+            virtual ~AutoComponent() = default;
 
             virtual void FrameUpdate(float) {}
             virtual void FixedUpdate() {}
@@ -52,6 +47,10 @@ namespace nc
             virtual void OnCollisionEnter(Entity) {}
             virtual void OnCollisionStay(Entity) {};
             virtual void OnCollisionExit(Entity) {};
+
+            #ifdef NC_EDITOR_ENABLED
+            virtual void ComponentGuiElement();
+            #endif
     };
 
     /** Helper for configuring storage and allocation behavior. */
@@ -73,4 +72,19 @@ namespace nc
         /** Requires an OnRemove callback to be set in the registry. */
         using requires_on_remove_callback = std::false_type;
     };
+
+    /** Editor function that can be specialized to provide a custom widget.
+     *  AutoComponents must use override their member function instead. */
+    #ifdef NC_EDITOR_ENABLED
+    namespace internal
+    {
+        void DefaultComponentGuiElement();
+    }
+
+    template<class T>
+    void ComponentGuiElement(T*)
+    {
+        internal::DefaultComponentGuiElement();
+    }
+    #endif
 } //end namespace nc

--- a/nc/include/component/Component.h
+++ b/nc/include/component/Component.h
@@ -1,10 +1,18 @@
 #pragma once
 #include "Entity.h"
 
+#include <concepts>
 #include <type_traits>
 
 namespace nc
 {
+    class AutoComponent;
+
+    template<class T>
+    concept Component = std::movable<T> &&
+                        !std::same_as<Entity, T> &&
+                        !std::derived_from<T, AutoComponent>;
+
     /** Base class for all Components. Only Components associated with a system
      *  should derive directly from ComponentBase. */
     class ComponentBase

--- a/nc/include/component/NetworkDispatcher.h
+++ b/nc/include/component/NetworkDispatcher.h
@@ -23,11 +23,12 @@ namespace nc
             void Dispatch(net::PacketType packetType, uint8_t* data);
             void AddHandler(net::PacketType packetType, std::function<void(uint8_t* data)> func);
 
-            #ifdef NC_EDITOR_ENABLED
-            void EditorGuiElement() override;
-            #endif
-
         private:
             std::unordered_map<net::PacketType, std::function<void(uint8_t*)>> m_dispatchTable;
     };
+
+    #ifdef NC_EDITOR_ENABLED
+    template<>
+    void ComponentGuiElement<NetworkDispatcher>(NetworkDispatcher*);
+    #endif
 }

--- a/nc/include/component/ParticleEmitter.h
+++ b/nc/include/component/ParticleEmitter.h
@@ -58,10 +58,6 @@ namespace nc
         
             void RegisterSystem(ecs::ParticleEmitterSystem* system);
 
-            #ifdef NC_EDITOR_ENABLED
-            void EditorGuiElement() override;
-            #endif
-
         private:
             ParticleInfo m_info;
             ecs::ParticleEmitterSystem* m_emitterSystem;
@@ -75,4 +71,8 @@ namespace nc
         using requires_on_add_callback = std::true_type;
         using requires_on_remove_callback = std::true_type;
     };
+
+    #ifdef NC_EDITOR_ENABLED
+    template<> void ComponentGuiElement<ParticleEmitter>(ParticleEmitter*);
+    #endif
 } // namespace nc

--- a/nc/include/component/PerComponentStorage.h
+++ b/nc/include/component/PerComponentStorage.h
@@ -1,0 +1,259 @@
+#pragma once
+
+#include "Component.h"
+#include "debug/Utils.h"
+
+#include <algorithm>
+#include <functional>
+#include <span>
+#include <stdexcept>
+#include <vector>
+
+namespace nc::ecs
+{
+    template<Component T>
+    struct SystemCallbacks
+    {
+        using on_add_type = std::function<void(T&)>;
+        using on_remove_type = std::function<void(Entity)>;
+        on_add_type OnAdd = nullptr;
+        on_remove_type OnRemove = nullptr;
+    };
+
+    template<Component T>
+    class PerComponentStorage
+    {
+        using value_type = T;
+        using index_type = EntityTraits::index_type;
+        
+        struct StagedComponent
+        {
+            Entity entity;
+            T component;
+        };
+
+        public:
+            PerComponentStorage(size_t maxEntities);
+            ~PerComponentStorage() = default;
+            PerComponentStorage(PerComponentStorage&&) = default;
+            PerComponentStorage& operator=(PerComponentStorage&&) = default;
+
+            PerComponentStorage(const PerComponentStorage&) = delete;
+            PerComponentStorage& operator=(const PerComponentStorage&) = delete;
+
+            auto GetSparseArray() -> std::vector<index_type>& { return sparseArray; }
+            auto GetEntityPool() -> std::vector<index_type>& { return entityPool; }
+            auto GetComponentPool() -> std::vector<T>& { return componentPool; }
+
+            template<class... Args>
+            auto Add(Entity entity, Args&&... args) -> T*;
+
+            void Remove(Entity entity);
+            bool TryRemove(Entity entity);
+            bool Contains(Entity entity) const;
+            auto Get(Entity entity) -> T*;
+            auto Get(Entity entity) const -> const T*;
+            auto ViewAll() -> std::span<T>;
+            auto ViewAll() const -> std::span<const T>;
+
+            void RegisterOnAddCallback(SystemCallbacks<T>::on_add_type func);
+            void RegisterOnRemoveCallback(SystemCallbacks<T>::on_remove_type func);
+            void VerifyCallbacks();
+            void Swap(index_type firstEntity, index_type secondEntity);
+            void ReserveHeadroom(size_t additionalRequiredCount);
+            void CommitStagedComponents();
+            void Clear();
+
+        private:
+            std::vector<index_type> sparseArray;
+            std::vector<index_type> entityPool;
+            std::vector<T> componentPool;
+            std::vector<StagedComponent> stagingPool;
+            SystemCallbacks<T> callbacks;
+    };
+
+    template<Component T>
+    PerComponentStorage<T>::PerComponentStorage(size_t maxEntities)
+        : sparseArray(maxEntities, EntityTraits::NullIndex),
+          entityPool{},
+          componentPool{},
+          stagingPool{},
+          callbacks{}
+    {}
+
+    template<Component T>
+    template<class... Args>
+    auto PerComponentStorage<T>::Add(Entity entity, Args&&... args) -> T*
+    {
+        IF_THROW(Contains(entity), "PerComponentStorage::Add - Cannot add multiple components of the same type");
+        auto& [emplacedEntity, emplacedComponent] = stagingPool.emplace_back(entity, T{entity, std::forward<Args>(args)...});
+
+        if constexpr(StoragePolicy<T>::requires_on_add_callback::value)
+            callbacks.OnAdd(emplacedComponent);
+
+        return &emplacedComponent;
+    }
+
+    template<Component T>
+    void PerComponentStorage<T>::Remove(Entity entity)
+    {
+        auto sparseIndex = EntityUtils::Index(entity);
+        auto poolIndex = sparseArray.at(sparseIndex);
+
+        IF_THROW(poolIndex == EntityTraits::NullIndex, std::string{"Entity does not have component\n   "} + __PRETTY_FUNCTION__);
+        
+        componentPool.at(poolIndex) = std::move(componentPool.back());
+        componentPool.pop_back();
+
+        auto movedIndex = entityPool.back(); // need to store in case we're removing the last element
+        entityPool.at(poolIndex) = movedIndex;
+        entityPool.pop_back();
+
+        sparseArray.at(sparseIndex) = EntityTraits::NullIndex;
+
+        if(sparseIndex != movedIndex)
+            sparseArray.at(movedIndex) = poolIndex;
+
+        if constexpr(StoragePolicy<T>::requires_on_remove_callback::value)
+            callbacks.OnRemove(entity);
+    }
+
+    template<Component T>
+    bool PerComponentStorage<T>::TryRemove(Entity entity)
+    {
+        if(!Contains(entity))
+            return false;
+        
+        Remove(entity);
+        return true;
+    }
+
+    template<Component T>
+    bool PerComponentStorage<T>::Contains(Entity entity) const
+    {
+        if(EntityTraits::NullIndex != sparseArray.at(EntityUtils::Index(entity)))
+            return true;
+
+        auto pos = std::ranges::find_if(stagingPool, [entity](const auto& pair)
+        {
+            return entity == pair.entity;
+        });
+
+        return pos == stagingPool.cend() ? false : true;
+    }
+
+    template<Component T>
+    auto PerComponentStorage<T>::Get(Entity entity) -> T*
+    {
+        auto poolIndex = sparseArray.at(EntityUtils::Index(entity));
+        if(poolIndex != EntityTraits::NullIndex)
+            return &componentPool.at(poolIndex);
+
+        auto pos = std::ranges::find_if(stagingPool, [entity](const auto& pair)
+        {
+            return pair.entity == entity;
+        });
+
+        return pos == stagingPool.end() ? nullptr : &pos->component;
+    }
+
+    template<Component T>
+    auto PerComponentStorage<T>::Get(Entity entity) const -> const T*
+    {
+        auto poolIndex = sparseArray.at(EntityUtils::Index(entity));
+        if(poolIndex != EntityTraits::NullIndex)
+            return &componentPool.at(poolIndex);
+
+        const auto pos = std::ranges::find_if(stagingPool, [entity](const auto& pair)
+        {
+            return pair.entity == entity;
+        });
+
+        return pos == stagingPool.end() ? nullptr : &pos->component;
+    }
+
+    template<Component T>
+    auto PerComponentStorage<T>::ViewAll() -> std::span<T>
+    {
+        return std::span<T>{componentPool};
+    }
+    
+    template<Component T>
+    auto PerComponentStorage<T>::ViewAll() const -> std::span<const T>
+    {
+        return std::span<const T>{componentPool};
+    }
+
+    template<Component T>
+    void PerComponentStorage<T>::RegisterOnAddCallback(typename SystemCallbacks<T>::on_add_type func)
+    {
+        callbacks.OnAdd = std::move(func);
+    }
+
+    template<Component T>
+    void PerComponentStorage<T>::RegisterOnRemoveCallback(typename SystemCallbacks<T>::on_remove_type func)
+    {
+        callbacks.OnRemove = std::move(func);
+    }
+
+    template<Component T>
+    void PerComponentStorage<T>::VerifyCallbacks()
+    {
+        if constexpr(StoragePolicy<T>::requires_on_add_callback::value)
+        {
+            if(!callbacks.OnAdd)
+                throw std::runtime_error("OnAdd callback required but not set\n   " + std::string{__PRETTY_FUNCTION__});
+        }
+
+        if constexpr(StoragePolicy<T>::requires_on_remove_callback::value)
+        {
+            if(!callbacks.OnRemove)
+                throw std::runtime_error("OnRemove callback required but not set\n   " + std::string{__PRETTY_FUNCTION__});
+        }
+    }
+
+    template<Component T>
+    void PerComponentStorage<T>::Swap(index_type firstEntity, index_type secondEntity)
+    {
+        auto firstDenseIndex = sparseArray.at(firstEntity);
+        auto secondDenseIndex = sparseArray.at(secondEntity);
+        std::swap(entityPool.at(firstDenseIndex), entityPool.at(secondDenseIndex));
+        std::swap(componentPool.at(firstDenseIndex), componentPool.at(secondDenseIndex));
+        sparseArray.at(firstEntity) = secondDenseIndex;
+        sparseArray.at(secondEntity) = firstDenseIndex;
+    }
+
+    template<Component T>
+    void PerComponentStorage<T>::ReserveHeadroom(size_t additionalRequiredCount)
+    {
+        auto requiredSize = componentPool.size() + additionalRequiredCount;
+        componentPool.reserve(requiredSize);
+        entityPool.reserve(requiredSize);
+    }
+
+    template<Component T>
+    void PerComponentStorage<T>::CommitStagedComponents()
+    {
+        for(auto& [entity, component] : stagingPool)
+        {
+            componentPool.push_back(std::move(component));
+            auto sparseIndex = EntityUtils::Index(entity);
+            entityPool.push_back(sparseIndex);
+            sparseArray.at(sparseIndex) = componentPool.size() - 1;
+        }
+
+        stagingPool.clear();
+    }
+
+    template<Component T>
+    void PerComponentStorage<T>::Clear()
+    {
+        std::ranges::fill(sparseArray, EntityTraits::NullIndex);
+        entityPool.clear();
+        entityPool.shrink_to_fit();
+        componentPool.clear();
+        componentPool.shrink_to_fit();
+        stagingPool.clear();
+        stagingPool.shrink_to_fit();
+    }
+}

--- a/nc/include/component/PointLight.h
+++ b/nc/include/component/PointLight.h
@@ -34,10 +34,6 @@ namespace nc
 
             void Set(const PointLight::Properties& lightProperties);
             void SetPositionFromCameraProjection(const DirectX::FXMMATRIX& view);
-
-            #ifdef NC_EDITOR_ENABLED
-            void EditorGuiElement() override;
-            #endif
     };
 
     template<>
@@ -48,4 +44,8 @@ namespace nc
         using requires_on_add_callback = std::false_type;
         using requires_on_remove_callback = std::false_type;
     };
+
+    #ifdef NC_EDITOR_ENABLED
+    template<> void ComponentGuiElement<PointLight>(PointLight* light);
+    #endif
 }

--- a/nc/include/component/Registry.h
+++ b/nc/include/component/Registry.h
@@ -1,16 +1,10 @@
 #pragma once
 
-#include "Entity.h"
-#include "HandleManager.h"
 #include "AutoComponentGroup.h"
+#include "HandleManager.h"
+#include "PerComponentStorage.h"
 #include "Tag.h"
 #include "Transform.h"
-
-#include <algorithm>
-#include <functional>
-#include <span>
-#include <stdexcept>
-#include <vector>
 
 /** The regsitry is a collection of entity and component state.
  * 
@@ -58,76 +52,29 @@
  * 
  *  @todo
  *   - Finish re-fetching pointer?
- *   - Sorting
  *   - Buffering
  *   - Groups
  *   - Remove multiple?
- *   - Move entity exists IF_THROWs from Ecs to here?
- *   - more unit tests
- *   - tuple_cat to combine engine/user component lists
  */
 
 namespace nc::ecs
 {
-    template<class T>
-    struct SystemCallbacks
+    template<Component... Ts>
+    struct RegistryTypeList
     {
-        using on_add_type = std::function<void(T&)>;
-        using on_remove_type = std::function<void(Entity)>;
-        on_add_type OnAdd = nullptr;
-        on_remove_type OnRemove = nullptr;
-    };
+        using storage_type = std::tuple<PerComponentStorage<Ts>...>;
 
-    template<class T>
-    struct PerComponentStorage
-    {
-        using index_type = EntityTraits::index_type;
-        
-        struct StagedComponent
+        static storage_type Create(size_t maxEntities)
         {
-            Entity entity;
-            T component;
-        };
-
-        std::vector<index_type> sparseArray;
-        std::vector<index_type> entityPool;
-        std::vector<T> componentPool;
-        std::vector<StagedComponent> stagingPool;
-        SystemCallbacks<T> callbacks;
-
-        PerComponentStorage(size_t maxEntities)
-            : sparseArray(maxEntities, EntityTraits::NullIndex),
-              entityPool{},
-              componentPool{},
-              stagingPool{},
-              callbacks{}
-        {}
-
-        ~PerComponentStorage() = default;
-        PerComponentStorage(PerComponentStorage&&) = default;
-        PerComponentStorage& operator=(PerComponentStorage&&) = default;
-
-        PerComponentStorage(const PerComponentStorage&) = delete;
-        PerComponentStorage& operator=(const PerComponentStorage&) = delete;
-
-        void Clear()
-        {
-            std::ranges::fill(sparseArray, EntityTraits::NullIndex);
-            entityPool.clear();
-            entityPool.shrink_to_fit();
-            componentPool.clear();
-            componentPool.shrink_to_fit();
-            stagingPool.clear();
-            stagingPool.shrink_to_fit();
+            return storage_type{PerComponentStorage<Ts>(maxEntities)...};
         }
     };
 
-    template<class... Ts>
+    template<class TypeList>
     class Registry
     {
-        using storage_type = std::tuple<PerComponentStorage<Ts>...>;
+        using storage_type = TypeList::storage_type;
         using index_type = EntityTraits::index_type;
-        static constexpr size_t PoolCount = sizeof...(Ts);
 
         public:
             Registry(size_t maxEntities);
@@ -143,40 +90,40 @@ namespace nc::ecs
             auto Add(EntityInfo info) -> Entity;
 
             template<std::same_as<Entity> T>
-            bool Remove(Entity entity);
+            void Remove(Entity entity);
 
             template<std::same_as<Entity> T>
-            bool Contains(Entity entity);
+            bool Contains(Entity entity) const;
 
             template<std::same_as<Entity> T>
             auto ViewAll() -> std::span<Entity>;
 
             /** Component Functions */
-            template<class T, class... Args>
+            template<Component T, class... Args>
             auto Add(Entity entity, Args&&... args) -> T*;
 
-            template<class T>
-            bool Remove(Entity entity);
+            template<Component T>
+            void Remove(Entity entity);
 
-            template<class T>
+            template<Component T>
             bool Contains(Entity entity) const;
 
-            template<class T>
+            template<Component T>
             auto Get(Entity entity) -> T*;
 
-            template<class T>
+            template<Component T>
             auto Get(Entity entity) const -> const T*;
 
-            template<class T>
+            template<Component T>
             auto ViewAll() -> std::span<T>;
 
-            template<class T>
+            template<Component T>
             auto ViewAll() const -> std::span<const T>;
 
-            template<class T, class U>
-            void Sort();
+            template<Component T, Component U>
+            auto ViewGroup() -> std::pair<std::span<T>, std::span<U>>;
 
-            template<class T>
+            template<Component T>
             void ReserveHeadroom(size_t additionalRequiredCount);
 
             /** AutoComponent Functions */
@@ -184,7 +131,7 @@ namespace nc::ecs
             auto Add(Entity entity, Args&& ... args) -> T*;
 
             template<std::derived_from<AutoComponent> T>
-            bool Remove(Entity entity);
+            void Remove(Entity entity);
 
             template<std::derived_from<AutoComponent> T>
             bool Contains(Entity entity) const;
@@ -196,10 +143,10 @@ namespace nc::ecs
             auto Get(Entity entity) const -> const T*;
 
             /** System Functions */
-            template<class T>
+            template<Component T>
             void RegisterOnAddCallback(SystemCallbacks<T>::on_add_type func);
 
-            template<class T>
+            template<Component T>
             void RegisterOnRemoveCallback(SystemCallbacks<T>::on_remove_type func);
 
             /** Engine Functions */
@@ -214,19 +161,16 @@ namespace nc::ecs
             std::vector<Entity> m_toRemove;
             HandleManager m_handleManager;
 
-            template<class T>
-            void CommitStagedComponents();
-
-            template<class T>
+            template<Component T>
             auto GetStorageFor() -> PerComponentStorage<T>& { return std::get<PerComponentStorage<T>>(m_storage); }
 
-            template<class T>
+            template<Component T>
             auto GetStorageFor() const -> const PerComponentStorage<T>& { return std::get<PerComponentStorage<T>>(m_storage); }
     };
 
-    template<class... Ts>
-    Registry<Ts...>::Registry(size_t maxEntities)
-        : m_storage{PerComponentStorage<Ts>{maxEntities}...},
+    template<class TypeList>
+    Registry<TypeList>::Registry(size_t maxEntities)
+        : m_storage{TypeList::Create(maxEntities)},
           m_active{},
           m_toAdd{},
           m_toRemove{},
@@ -234,361 +178,236 @@ namespace nc::ecs
     {
     }
 
-    template<class... Ts>
-    template<class Reference, class Target>
-    void Registry<Ts...>::Sort()
-    {
-        // force committing changes?
-
-        auto& referenceStorage = GetStorageFor<Reference>();
-        auto& targetStorage = GetStorageFor<Target>();
-
-        auto& sortedSparseArray = referenceStorage.sparseArray;
-        auto& sortedEntityPool = referenceStorage.entityPool;
-        auto& sortedComponents = referenceStorage.componentPool;
-        auto& unsortedSparseArray = targetStorage.sparseArray;
-        auto& unsortedEntityPool = targetStorage.entityPool;
-        auto& unsortedComponents = targetStorage.componentPool;
-
-        size_t sortedSize = sortedEntityPool.size();
-        if(sortedSize == 0u || unsortedEntityPool.size() == 0u)
-            return;
-
-        size_t currentIndex = 0u;
-        size_t endIndex = sortedSize - 1;
-
-        while(currentIndex < endIndex)
-        {
-            auto entityIndex = sortedEntityPool.at(currentIndex);
-
-            auto unsortedIndex = unsortedSparseArray.at(entityIndex);
-
-            // both have entity
-            if(unsortedIndex != EntityTraits::NullIndex)
-            {
-                // check if sorted?
-
-
-                auto sortedIndex = sortedSparseArray.at(entityIndex);
-                
-                // swap entity
-                auto tempEntity = unsortedEntityPool.at(sortedIndex);
-                unsortedEntityPool.at(sortedIndex) = unsortedEntityPool.at(unsortedIndex);
-                unsortedEntityPool.at(unsortedIndex) = tempEntity;
-
-                // swap component
-                auto tempComponent = std::move(unsortedComponents.at(sortedIndex));
-                unsortedComponents.at(sortedIndex) = std::move(unsortedComponents.at(unsortedIndex));
-                unsortedComponents.at(unsortedIndex) = std::move(tempComponent);
-
-                // update sparse
-                unsortedSparseArray.at(entityIndex) = sortedIndex;
-                unsortedSparseArray.at(tempEntity) = unsortedIndex;
-
-                ++currentIndex;
-            }
-            // entity only in sorted
-            else
-            {
-                // swap entity to end
-                sortedEntityPool.at(currentIndex) = sortedEntityPool.at(endIndex);
-                sortedEntityPool.at(endIndex) = entityIndex;
-
-                // swap component to end
-                auto temp = std::move(sortedComponents.at(currentIndex));
-                sortedComponents.at(currentIndex) = std::move(sortedComponents.at(endIndex));
-                sortedComponents.at(endIndex) = std::move(temp);
-
-                // update sparse
-                sortedSparseArray.at(entityIndex) = endIndex;
-                auto movedEntityIndex = sortedEntityPool.at(currentIndex);
-                sortedSparseArray.at(movedEntityIndex) = currentIndex;
-
-                --endIndex;
-            }
-        }
-    }
-
-    template<class... Ts>
+    template<class TypeList>
     template<std::same_as<Entity> T>
-    auto Registry<Ts...>::Add(EntityInfo info) -> Entity
+    auto Registry<TypeList>::Add(EntityInfo info) -> Entity
     {
         auto handle = m_handleManager.GenerateNewHandle(info.layer, info.flags);
+        m_toAdd.push_back(handle);
         Add<Transform>(handle, info.position, info.rotation, info.scale, info.parent);
         Add<AutoComponentGroup>(handle);
         Add<Tag>(handle, std::move(info.tag));
-        m_toAdd.push_back(handle);
         return handle;
     }
 
-    template<class... Ts>
-    template<class T, class... Args>
-    auto Registry<Ts...>::Add(Entity entity, Args&&... args) -> T*
+    template<class TypeList>
+    template<Component T, class... Args>
+    auto Registry<TypeList>::Add(Entity entity, Args&&... args) -> T*
     {
-        if(Contains<T>(entity))
-            throw std::runtime_error("Registry::Add - Cannot add multiple components of the same type to a single entity");
-        
-        auto& storage = GetStorageFor<T>();
-        auto& [emplacedEntity, emplacedComponent] = storage.stagingPool.emplace_back(entity, T{entity, std::forward<Args>(args)...});
-
-        if constexpr(StoragePolicy<T>::requires_on_add_callback::value)
-        {
-            storage.callbacks.OnAdd(emplacedComponent);
-        }
-
-        return &emplacedComponent;
+        IF_THROW(!Contains<Entity>(entity), std::string{"Bad Entity\n   "} + __PRETTY_FUNCTION__);
+        return GetStorageFor<T>().Add(entity, std::forward<Args>(args)...);
     }
 
-    template<class... Ts>
+    template<class TypeList>
     template<std::derived_from<AutoComponent> T, class... Args>
-    auto Registry<Ts...>::Add(Entity entity, Args&&... args) -> T*
+    auto Registry<TypeList>::Add(Entity entity, Args&&... args) -> T*
     {
+        IF_THROW(!Contains<Entity>(entity), std::string{"Bad Entity\n   "} + __PRETTY_FUNCTION__);
         AutoComponentGroup* group = Get<AutoComponentGroup>(entity);
-        if(!group)
-            throw std::runtime_error("Registry::Add (AutoComponent) - Group does not exist");
-
         return group->Add<T>(entity, std::forward<Args>(args)...);
-
     }
 
-    template<class... Ts>
+    template<class TypeList>
     template<std::same_as<Entity> T>
-    bool Registry<Ts...>::Remove(Entity entity)
+    void Registry<TypeList>::Remove(Entity entity)
     {
+        IF_THROW(!Contains<Entity>(entity), std::string{"Bad Entity\n   "} + __PRETTY_FUNCTION__);
         auto pos = std::ranges::find(m_active, entity);
-
-        if(pos == m_active.end())
-            return false;
-        
         *pos = m_active.back();
         m_active.pop_back();
         m_toRemove.push_back(entity);
-        return true;
     }
 
-    template<class... Ts>
-    template<class T>
-    bool Registry<Ts...>::Remove(Entity entity)
+    template<class TypeList>
+    template<Component T>
+    void Registry<TypeList>::Remove(Entity entity)
     {
-        auto sparseIndex = EntityUtils::Index(entity);
-        auto& storage = GetStorageFor<T>();
-        auto poolIndex = storage.sparseArray.at(sparseIndex);
-        if(poolIndex == EntityTraits::NullIndex)
-            return false;
-        
-        auto& componentPool = storage.componentPool;
-        componentPool.at(poolIndex) = std::move(componentPool.back());
-        componentPool.pop_back();
-
-        auto& entityPool = storage.entityPool;
-        auto movedIndex = entityPool.back(); // need to store in case we're removing the last element
-        entityPool.at(poolIndex) = movedIndex;
-        entityPool.pop_back();
-
-        storage.sparseArray.at(sparseIndex) = EntityTraits::NullIndex;
-
-        if(sparseIndex != movedIndex)
-            storage.sparseArray.at(movedIndex) = poolIndex;
-
-        if constexpr(StoragePolicy<T>::requires_on_remove_callback::value)
-        {
-            storage.callbacks.OnRemove(entity);
-        }
-
-        return true;
+        IF_THROW(!Contains<Entity>(entity), std::string{"Bad Entity\n   "} + __PRETTY_FUNCTION__);
+        GetStorageFor<T>().Remove(entity);
     }
 
-    template<class... Ts>
+    template<class TypeList>
     template<std::derived_from<AutoComponent> T>
-    bool Registry<Ts...>::Remove(Entity entity)
+    void Registry<TypeList>::Remove(Entity entity)
     {
-        auto& storage = GetStorageFor<AutoComponentGroup>();
-        auto poolIndex = storage.sparseArray.at(EntityUtils::Index(entity));
-        if(poolIndex == EntityTraits::NullIndex)
-            return false;
-        
-        AutoComponentGroup& group = storage.componentPool.at(poolIndex);
-        return group.Remove<T>();
+        IF_THROW(!Contains<Entity>(entity), std::string{"Bad Entity\n   "} + __PRETTY_FUNCTION__);
+        AutoComponentGroup* group = GetStorageFor<AutoComponentGroup>().Get(entity);
+        group->Remove<T>();
     }
 
-    template<class... Ts>
+    template<class TypeList>
     template<std::same_as<Entity> T>
-    bool Registry<Ts...>::Contains(Entity entity)
+    bool Registry<TypeList>::Contains(Entity entity) const
     {
         return (m_active.cend() != std::ranges::find(m_active, entity)) ||
                (m_toAdd.cend() != std::ranges::find(m_toAdd, entity));
     }
 
-    template<class... Ts>
-    template<class T>
-    bool Registry<Ts...>::Contains(Entity entity) const
+    template<class TypeList>
+    template<Component T>
+    bool Registry<TypeList>::Contains(Entity entity) const
     {
-        auto& storage = GetStorageFor<T>();
-
-        if(EntityTraits::NullIndex != storage.sparseArray.at(EntityUtils::Index(entity)))
-            return true;
-
-        auto pos = std::ranges::find_if(storage.stagingPool, [entity](const auto& pair)
-        {
-            return entity == pair.entity;
-        });
-
-        return pos == storage.stagingPool.cend() ? false : true;
+        IF_THROW(!Contains<Entity>(entity), std::string{"Bad Entity\n   "} + __PRETTY_FUNCTION__);
+        return GetStorageFor<T>().Contains(entity);
     }
 
-    template<class... Ts>
+    template<class TypeList>
     template<std::derived_from<AutoComponent> T>
-    bool Registry<Ts...>::Contains(Entity entity) const
+    bool Registry<TypeList>::Contains(Entity entity) const
     {
-        if(const AutoComponentGroup* group = Get<AutoComponentGroup>(entity); group)
-            return group->Contains<T>();
-
-        return false;
+        IF_THROW(!Contains<Entity>(entity), std::string{"Bad Entity\n   "} + __PRETTY_FUNCTION__);
+        const AutoComponentGroup* group = Get<AutoComponentGroup>(entity);
+        return group->Contains<T>();
     }
 
-    template<class... Ts>
-    template<class T>
-    auto Registry<Ts...>::Get(Entity entity) -> T*
+    template<class TypeList>
+    template<Component T>
+    auto Registry<TypeList>::Get(Entity entity) -> T*
     {
-        auto& storage = GetStorageFor<T>();
-        auto poolIndex = storage.sparseArray.at(EntityUtils::Index(entity));
-        if(poolIndex != EntityTraits::NullIndex)
-            return &storage.componentPool.at(poolIndex);
-
-        auto pos = std::ranges::find_if(storage.stagingPool, [entity](const auto& pair)
-        {
-            return pair.entity == entity;
-        });
-
-        return pos == storage.stagingPool.end() ? nullptr : &pos->component;
+        return GetStorageFor<T>().Get(entity);
     }
 
-    template<class... Ts>
-    template<class T>
-    auto Registry<Ts...>::Get(Entity entity) const -> const T*
+    template<class TypeList>
+    template<Component T>
+    auto Registry<TypeList>::Get(Entity entity) const -> const T*
     {
-        const auto& storage = GetStorageFor<T>();
-        auto poolIndex = storage.sparseArray.at(EntityUtils::Index(entity));
-        if(poolIndex != EntityTraits::NullIndex)
-            return &storage.componentPool.at(poolIndex);
-
-        const auto pos = std::ranges::find_if(storage.stagingPool, [entity](const auto& pair)
-        {
-            return pair.entity == entity;
-        });
-
-        return pos == storage.stagingPool.end() ? nullptr : &pos->component;
+        return GetStorageFor<T>().Get(entity);
     }
 
-    template<class... Ts>
+    template<class TypeList>
     template<std::derived_from<AutoComponent> T>
-    auto Registry<Ts...>::Get(Entity entity) -> T*
+    auto Registry<TypeList>::Get(Entity entity) -> T*
     {
-        if(AutoComponentGroup* group = Get<AutoComponentGroup>(entity); group)
-            return group->Get<T>();
-        
-        return nullptr;
+        AutoComponentGroup* group = Get<AutoComponentGroup>(entity);
+        return group ? group->Get<T>() : nullptr;
     }
 
-    template<class... Ts>
+    template<class TypeList>
     template<std::derived_from<AutoComponent> T>
-    auto Registry<Ts...>::Get(Entity entity) const -> const T*
+    auto Registry<TypeList>::Get(Entity entity) const -> const T*
     {
-        if(const AutoComponentGroup* group = Get<AutoComponentGroup>(entity); group)
-            return group->Get<T>();
-        
-        return nullptr;
+        const AutoComponentGroup* group = Get<AutoComponentGroup>(entity);
+        return group ? group->Get<T>() : nullptr;
     }
 
-    template<class... Ts>
+    template<class TypeList>
     template<std::same_as<Entity> T>
-    auto Registry<Ts...>::ViewAll() -> std::span<Entity>
+    auto Registry<TypeList>::ViewAll() -> std::span<Entity>
     {
         return std::span<Entity>{m_active};
     }
 
-    template<class... Ts>
-    template<class T>
-    auto Registry<Ts...>::ViewAll() -> std::span<T>
+    template<class TypeList>
+    template<Component T>
+    auto Registry<TypeList>::ViewAll() -> std::span<T>
     {
-        return std::span<T>{GetStorageFor<T>().componentPool};
+        return GetStorageFor<T>().ViewAll();
     }
 
-    template<class... Ts>
-    template<class T>
-    auto Registry<Ts...>::ViewAll() const -> std::span<const T>
+    template<class TypeList>
+    template<Component T>
+    auto Registry<TypeList>::ViewAll() const -> std::span<const T>
     {
-        return std::span<const T>{GetStorageFor<T>().componentPool};
+        return GetStorageFor<T>().ViewAll();
     }
 
-    template<class... Ts>
-    template<class T>
-    void Registry<Ts...>::ReserveHeadroom(size_t additionalRequiredCount)
+    template<class TypeList>
+    template<Component T, Component U>
+    auto Registry<TypeList>::ViewGroup() -> std::pair<std::span<T>, std::span<U>>
     {
-        auto& storage = GetStorageFor<T>();
-        auto requiredSize = storage.componentPool.size() + additionalRequiredCount;
-        storage.componentPool.reserve(requiredSize);
-        storage.entityPool.reserve(requiredSize);
-    }
+        auto& referenceStorage = GetStorageFor<T>();
+        auto& targetStorage = GetStorageFor<U>();
+        auto& referenceEntities = referenceStorage.GetEntityPool();
+        auto& targetSparseArray = targetStorage.GetSparseArray();
+        auto& targetEntities = targetStorage.GetEntityPool();
 
-    template<class... Ts>
-    template<class T>
-    void Registry<Ts...>::RegisterOnAddCallback(typename SystemCallbacks<T>::on_add_type func)
-    {
-        static_assert(StoragePolicy<T>::requires_on_add_callback::value, "Cannot register an OnAdd callback unless specified in the StoragePolicy");
-        GetStorageFor<T>().callbacks.OnAdd = std::move(func);
-    }
+        size_t referenceSize = referenceEntities.size();
+        if(referenceSize == 0u || targetEntities.size() == 0u)
+            return{};
 
-    template<class... Ts>
-    template<class T>
-    void Registry<Ts...>::RegisterOnRemoveCallback(typename SystemCallbacks<T>::on_remove_type func)
-    {
-        static_assert(StoragePolicy<T>::requires_on_remove_callback::value, "Cannot register an OnRemove callback unless specified in the StoragePolicy");
-        GetStorageFor<T>().callbacks.OnRemove = std::move(func);
-    }
+        size_t current = 0u, end = referenceSize - 1;
 
-    template<class... Ts>
-    template<class T>
-    void Registry<Ts...>::CommitStagedComponents()
-    {
-        auto& storage = GetStorageFor<T>();
-
-        for(auto& [entity, component] : storage.stagingPool)
+        while(current <= end)
         {
-            storage.componentPool.push_back(std::move(component));
-            auto sparseIndex = EntityUtils::Index(entity);
-            storage.entityPool.push_back(sparseIndex);
-            storage.sparseArray.at(sparseIndex) = storage.componentPool.size() - 1;
+            auto entityIndex = referenceEntities.at(current);
+            auto indexInTarget = targetSparseArray.at(entityIndex);
+
+            if(indexInTarget != EntityTraits::NullIndex) // Entity has both components
+            {
+                if(indexInTarget != current)
+                {
+                    auto swapEntity = targetEntities.at(current);
+                    targetStorage.Swap(entityIndex, swapEntity);
+                }
+
+                ++current;
+            }
+            else // Entity does not have target component
+            {
+                auto swapEntity = referenceEntities.at(end);
+                referenceStorage.Swap(entityIndex, swapEntity);
+                --end;
+            }
         }
 
-        storage.stagingPool.clear();
+        auto& referenceComponents = referenceStorage.GetComponentPool();
+        auto& targetComponents = targetStorage.GetComponentPool();
+
+        // changes
+        if(referenceComponents.size() < current || targetComponents.size() < current)
+            throw std::runtime_error("ViewGroup - Invalid size");
+
+        auto sharedRangeSize = current > end ? current : end;
+
+        return std::pair<std::span<T>, std::span<U>>
+        {
+            std::span<T>{referenceComponents.begin(), sharedRangeSize},
+            std::span<U>{targetComponents.begin(), sharedRangeSize}
+        };
     }
 
-    template<class... Ts>
-    void Registry<Ts...>::CommitStagedChanges()
+    template<class TypeList>
+    template<Component T>
+    void Registry<TypeList>::ReserveHeadroom(size_t additionalRequiredCount)
+    {
+        GetStorageFor<T>().ReserveHeadroom();
+    }
+
+    template<class TypeList>
+    template<Component T>
+    void Registry<TypeList>::RegisterOnAddCallback(typename SystemCallbacks<T>::on_add_type func)
+    {
+        static_assert(StoragePolicy<T>::requires_on_add_callback::value, "Cannot register an OnAdd callback unless specified in the StoragePolicy");
+        GetStorageFor<T>().RegisterOnAddCallback(std::move(func));
+    }
+
+    template<class TypeList>
+    template<Component T>
+    void Registry<TypeList>::RegisterOnRemoveCallback(typename SystemCallbacks<T>::on_remove_type func)
+    {
+        static_assert(StoragePolicy<T>::requires_on_remove_callback::value, "Cannot register an OnRemove callback unless specified in the StoragePolicy");
+        GetStorageFor<T>().RegisterOnRemoveCallback(std::move(func));
+    }
+
+    template<class TypeList>
+    void Registry<TypeList>::CommitStagedChanges()
     {
         for(auto entity : m_toRemove)
         {
             Get<AutoComponentGroup>(entity)->SendOnDestroy();
-            (Remove<Ts>(entity), ...);
+            std::apply([entity](auto&&... storage) { (storage.TryRemove(entity), ...); }, m_storage);
             m_handleManager.ReclaimHandle(entity);
         }
 
         m_toRemove.clear();
-
-        // can just insert whole vector?
-        for(auto entity : m_toAdd)
-        {
-            m_active.push_back(entity);
-        }
-
+        m_active.reserve(m_active.size() + m_toAdd.size());
+        m_active.insert(m_active.end(), m_toAdd.cbegin(), m_toAdd.cend());
         m_toAdd.clear();
-
-        (CommitStagedComponents<Ts>(), ...);
+        std::apply([](auto&&... storage) { (storage.CommitStagedComponents(), ...); }, m_storage);
     }
 
-    template<class... Ts>
-    void Registry<Ts...>::Clear()
+    template<class TypeList>
+    void Registry<TypeList>::Clear()
     {
         for(auto entity : m_toAdd)
             Get<AutoComponentGroup>(entity)->SendOnDestroy();
@@ -607,24 +426,9 @@ namespace nc::ecs
         std::apply([](auto&&... data) { (data.Clear(), ...); }, m_storage);
     }
 
-    template<class... Ts>
-    void Registry<Ts...>::VerifyCallbacks()
+    template<class TypeList>
+    void Registry<TypeList>::VerifyCallbacks()
     {
-        auto CallbackCheck = [] <class T> (const PerComponentStorage<T>& data)
-        {
-            if constexpr(StoragePolicy<T>::requires_on_add_callback::value)
-            {
-                if(!data.callbacks.OnAdd)
-                    throw std::runtime_error("OnAdd callback required but not set\n   " + std::string{__PRETTY_FUNCTION__});
-            }
-
-            if constexpr(StoragePolicy<T>::requires_on_remove_callback::value)
-            {
-                if(!data.callbacks.OnRemove)
-                    throw std::runtime_error("OnRemove callback required but not set\n   " + std::string{__PRETTY_FUNCTION__});
-            }
-        };
-
-        std::apply([&CallbackCheck](auto&&... data) { (CallbackCheck(data), ...); }, m_storage);
+        std::apply([](auto&&... storage) { (storage.VerifyCallbacks(), ...); }, m_storage);
     }
 }

--- a/nc/include/component/Renderer.h
+++ b/nc/include/component/Renderer.h
@@ -24,16 +24,19 @@ namespace nc
             Renderer& operator=(const Renderer&) = delete;
             Renderer& operator=(Renderer&&) = default;
 
-            #ifdef NC_EDITOR_ENABLED
-            void EditorGuiElement() override;
-            #endif
-
             void SetMesh(const graphics::Mesh& mesh);
             void SetMaterial(const graphics::Material& material);
             void Update(graphics::FrameManager* frame);
 
         private:
             std::unique_ptr<graphics::Model> m_model;
+            
+            #ifdef NC_EDITOR_ENABLED
+            friend void ComponentGuiElement<Renderer>(Renderer*);
+            #endif
     };
-    
+
+    #ifdef NC_EDITOR_ENABLED
+    template<> void ComponentGuiElement<Renderer>(Renderer* renderer);
+    #endif
 }

--- a/nc/include/component/Transform.h
+++ b/nc/include/component/Transform.h
@@ -49,10 +49,6 @@ namespace nc
             Entity GetRoot() const;         // Get the root node relative to this transform
             Entity GetParent() const;        // Get the immediate parent of this transform - may be nullptr
             void SetParent(Entity parent);   // Make this transform the child of another - nullptr will detach from existing parent
-
-            #ifdef NC_EDITOR_ENABLED
-            void EditorGuiElement() override;
-            #endif
             
         private:
             void AddChild(Entity child);
@@ -63,5 +59,13 @@ namespace nc
             DirectX::XMMATRIX m_worldMatrix;
             Entity m_parent;
             std::vector<Entity> m_children;
+            
+            #ifdef NC_EDITOR_ENABLED
+            friend void ComponentGuiElement<Transform>(Transform*);
+            #endif
     };
+
+    #ifdef NC_EDITOR_ENABLED
+    template<> void ComponentGuiElement<Transform>(Transform* transform);
+    #endif
 } //end namespace nc

--- a/nc/source/component/Camera.cpp
+++ b/nc/source/component/Camera.cpp
@@ -4,8 +4,6 @@
 #include "imgui/imgui.h"
 #endif
 
-#include <string>
-
 namespace nc
 {
     Camera::Camera(Entity entity) noexcept
@@ -14,7 +12,7 @@ namespace nc
     }
 
     #ifdef NC_EDITOR_ENABLED
-    void Camera::EditorGuiElement()
+    void Camera::ComponentGuiElement()
     {
         ImGui::Text("Camera");
     }

--- a/nc/source/component/Collider.cpp
+++ b/nc/source/component/Collider.cpp
@@ -69,15 +69,15 @@ namespace nc
         m_widgetModel->Submit(frame);
     }
 
-    void Collider::EditorGuiElement()
-    {
-        ImGui::Text("Collider");
-        /** @todo put widgets back */
-    }
-
     void Collider::SetEditorSelection(bool state)
     {
         m_selectedInEditor = state;
+    }
+
+    template<> void ComponentGuiElement<Collider>(Collider*)
+    {
+        ImGui::Text("Collider");
+        /** @todo put widgets back */
     }
     #endif
 }

--- a/nc/source/component/Component.cpp
+++ b/nc/source/component/Component.cpp
@@ -2,14 +2,21 @@
 
 #ifdef NC_EDITOR_ENABLED
 #include "imgui/imgui.h"
-#endif
 
 namespace nc
 {
-    #ifdef NC_EDITOR_ENABLED
-    void ComponentBase::EditorGuiElement()
+    void AutoComponent::ComponentGuiElement()
     {
-        ImGui::Text("User Component");
+        ImGui::Text("User AutoComponent");
     }
-    #endif
-} //end namespace nc
+
+    namespace internal
+    {
+        void DefaultComponentGuiElement()
+        {
+            ImGui::Text("User Component");
+        }
+    }
+}
+
+#endif

--- a/nc/source/component/NetworkDispatcher.cpp
+++ b/nc/source/component/NetworkDispatcher.cpp
@@ -31,7 +31,8 @@ namespace nc
     }
 
     #ifdef NC_EDITOR_ENABLED
-    void NetworkDispatcher::EditorGuiElement()
+    template<>
+    void ComponentGuiElement<NetworkDispatcher>(NetworkDispatcher*)
     {
         ImGui::Text("NetworkDispatcher");
     }

--- a/nc/source/component/ParticleEmitter.cpp
+++ b/nc/source/component/ParticleEmitter.cpp
@@ -30,7 +30,7 @@ namespace nc
     }
 
     #ifdef NC_EDITOR_ENABLED
-    void ParticleEmitter::EditorGuiElement()
+    template<> void ComponentGuiElement<ParticleEmitter>(ParticleEmitter*)
     {
         ImGui::Text("Particle Emitter");
     }

--- a/nc/source/component/PointLight.cpp
+++ b/nc/source/component/PointLight.cpp
@@ -21,10 +21,19 @@ namespace nc
         PixelConstBufData = lightProperties;
     }
 
+    void PointLight::SetPositionFromCameraProjection(const DirectX::FXMMATRIX& view)
+    {
+        auto* transform = ActiveRegistry()->Get<Transform>(GetParentEntity());
+        PixelConstBufData.pos = transform->GetPosition();
+        const auto pos_v = DirectX::XMLoadVector3(&PixelConstBufData.pos);
+        DirectX::XMStoreVector3(&ProjectedPos, DirectX::XMVector3Transform(pos_v, view));
+    }
+
     #ifdef NC_EDITOR_ENABLED
-    void PointLight::EditorGuiElement()
+    template<> void ComponentGuiElement<PointLight>(PointLight* light)
     {
         const float dragSpeed = 1.0f;
+        auto& PixelConstBufData = light->PixelConstBufData;
 
         ImGui::Text("Point Light");
         ImGui::Indent();
@@ -43,12 +52,4 @@ namespace nc
         ImGui::Unindent();
     }
     #endif
-
-    void PointLight::SetPositionFromCameraProjection(const DirectX::FXMMATRIX& view)
-    {
-        auto* transform = ActiveRegistry()->Get<Transform>(GetParentEntity());
-        PixelConstBufData.pos = transform->GetPosition();
-        const auto pos_v = DirectX::XMLoadVector3(&PixelConstBufData.pos);
-        DirectX::XMStoreVector3(&ProjectedPos, DirectX::XMVector3Transform(pos_v, view));
-    }
 }

--- a/nc/source/component/Renderer.cpp
+++ b/nc/source/component/Renderer.cpp
@@ -18,14 +18,6 @@ namespace nc
           m_model{ std::make_unique<graphics::Model>(std::move(mesh), std::move(material)) }
     {
     }
-
-    #ifdef NC_EDITOR_ENABLED
-    void Renderer::EditorGuiElement()
-    {
-        ImGui::Text("Renderer");
-        m_model->GetMaterial()->EditorGuiElement();
-    }
-    #endif
     
     void Renderer::Update(graphics::FrameManager* frame)
     {
@@ -44,4 +36,11 @@ namespace nc
         m_model->SetMaterial(material);
     }
 
+    #ifdef NC_EDITOR_ENABLED
+    template<> void ComponentGuiElement<Renderer>(Renderer* renderer)
+    {
+        ImGui::Text("Renderer");
+        renderer->m_model->GetMaterial()->EditorGuiElement();
+    }
+    #endif
 }

--- a/nc/source/component/Transform.cpp
+++ b/nc/source/component/Transform.cpp
@@ -296,10 +296,12 @@ namespace nc
     }
 
     #ifdef NC_EDITOR_ENABLED
-    void Transform::EditorGuiElement()
+    template<> void ComponentGuiElement<Transform>(Transform* transform)
     {
+        auto& worldMatrix = transform->m_worldMatrix;
+
         DirectX::XMVECTOR scl_v, rot_v, pos_v;
-        DirectX::XMMatrixDecompose(&scl_v, &rot_v, &pos_v, m_worldMatrix);
+        DirectX::XMMatrixDecompose(&scl_v, &rot_v, &pos_v, worldMatrix);
         Vector3 scl, pos;
         auto rot = Quaternion::Identity();
         DirectX::XMStoreVector3(&scl, scl_v);
@@ -315,11 +317,11 @@ namespace nc
         auto sclResult = ui::editor::xyzWidget("Scl", "transformscl", &scl.x, &scl.y, &scl.z);
 
         if(posResult)
-            SetPosition(pos);
+            transform->SetPosition(pos);
         if(rotResult)
-            SetRotation(angles);
+            transform->SetRotation(angles);
         if(sclResult)
-            SetScale(scl);
+            transform->SetScale(scl);
     }
     #endif
 }

--- a/nc/source/ui/editor/EditorControls.h
+++ b/nc/source/ui/editor/EditorControls.h
@@ -20,7 +20,7 @@ namespace nc::ui::editor::controls
     inline void SceneGraphPanel(registry_type* registry, float windowHeight);
     inline void SceneGraphNode(registry_type* registry, Entity entity, Tag* tag, Transform* transform);
     inline void EntityPanel(registry_type* registry, Entity entity);
-    inline void Component(ComponentBase* comp);
+    inline void AutoComponentElement(AutoComponent* comp);
     inline void UtilitiesPanel(float* dtMult, registry_type* registry, unsigned drawCallCount, float windowWidth, float windowHeight);
     inline void GraphicsResourcePanel();
     inline void FrameData(float* dtMult, unsigned drawCallCount);
@@ -109,32 +109,38 @@ namespace nc::ui::editor::controls
         ImGui::Text("Version %d", EntityUtils::Version(entity));
         ImGui::Text("Layer   %d", EntityUtils::Layer(entity));
         ImGui::Text("Static  %s", EntityUtils::IsStatic(entity) ? "True" : "False");
-        controls::Component(registry->Get<Transform>(entity));
-        controls::Component(registry->Get<NetworkDispatcher>(entity));
-        controls::Component(registry->Get<ParticleEmitter>(entity));
-        controls::Component(registry->Get<Renderer>(entity));
-        if(auto col = registry->Get<Collider>(entity); col)
+
+        if(auto* transform = registry->Get<Transform>(entity); transform)
+            ComponentGuiElement(transform);
+        if(auto* renderer = registry->Get<Renderer>(entity))
+            ComponentGuiElement(renderer);
+        if(auto* emitter = registry->Get<ParticleEmitter>(entity))
+            ComponentGuiElement(emitter);
+        if(auto* dispatcher = registry->Get<NetworkDispatcher>(entity))
+            ComponentGuiElement(dispatcher);
+        if(auto* light = registry->Get<PointLight>(entity))
+            ComponentGuiElement(light);
+        if(auto* col = registry->Get<Collider>(entity); col)
         {
             // collider model doesn't update/submit unless we tell it to
             col->SetEditorSelection(true);
-            controls::Component(col);
+            ComponentGuiElement(col);
         }
-        controls::Component(registry->Get<PointLight>(entity));
-        
+
         for(const auto& comp : registry->Get<AutoComponentGroup>(entity)->GetAutoComponents())
-            controls::Component(comp);
+            controls::AutoComponentElement(comp);
 
         ImGui::Separator();
     }
 
-    void Component(ComponentBase* comp)
+    void AutoComponentElement(AutoComponent* comp)
     {
         if(!comp)
             return;
         ImGui::Separator();
         ImGui::BeginGroup();
             ImGui::Spacing();
-            comp->EditorGuiElement();
+            comp->ComponentGuiElement();
             ImGui::Spacing();
         ImGui::EndGroup();
     }

--- a/nc/test/unit/Registry_unit_tests.cpp
+++ b/nc/test/unit/Registry_unit_tests.cpp
@@ -59,7 +59,7 @@ const auto TestInfo = EntityInfo{};
 class Registry_unit_tests : public ::testing::Test
 {
     public:
-        size_t maxEntities = 5u;
+        size_t maxEntities = 10u;
         Registry<Transform, AutoComponentGroup, Tag, Fake1, Fake2> registry;
 
         Registry_unit_tests()
@@ -296,7 +296,6 @@ TEST_F(Registry_unit_tests, GetComponentConst_CallAfterRemoved_ReturnsNull)
     EXPECT_EQ(ptr, nullptr);
 }
 
-////
 TEST_F(Registry_unit_tests, AddAutoComponent_ValidCall_ConstructsObject)
 {
     auto handle = registry.Add<Entity>({});
@@ -478,6 +477,41 @@ TEST_F(Registry_unit_tests, GetAutoComponentConst_CallAfterRemoved_ReturnsNull)
     const auto* ptr = constRegistry.Get<FakeAutoComponent>(handle);
     EXPECT_EQ(ptr, nullptr);
 }
+
+TEST_F(Registry_unit_tests, Sort)
+{
+    auto handle1 = registry.Add<Entity>({});
+    auto handle2 = registry.Add<Entity>({});
+    auto handle3 = registry.Add<Entity>({});
+    auto handle4 = registry.Add<Entity>({});
+    auto handle5 = registry.Add<Entity>({});
+    auto handle6 = registry.Add<Entity>({});
+    auto handle7 = registry.Add<Entity>({});
+    auto handle8 = registry.Add<Entity>({});
+
+    registry.Add<Fake1>(handle1, 5);
+    registry.Add<Fake1>(handle8, 4);
+    registry.Add<Fake1>(handle4, 3);
+    registry.Add<Fake1>(handle5, 2);
+    registry.Add<Fake1>(handle2, 1);
+
+
+    //registry.Sort<Transform, Fake1>();
+    registry.Sort<Fake1, Transform>();
+
+    auto transforms = registry.ViewAll<Transform>();
+    auto fakes = registry.ViewAll<Fake1>();
+
+
+
+    for(size_t i = 0; i < fakes.size(); ++i)
+    {
+        EXPECT_EQ(transforms[i].GetParentEntity(), fakes[i].GetParentEntity());
+    }
+
+
+}
+
 
 int main(int argc, char ** argv)
 {

--- a/nc/test/unit/Registry_unit_tests.cpp
+++ b/nc/test/unit/Registry_unit_tests.cpp
@@ -36,7 +36,8 @@ struct Fake1 : public ComponentBase
 struct Fake2 : public ComponentBase
 {
     Fake2(Entity entity, int v)
-        : ComponentBase{entity}
+        : ComponentBase{entity},
+          value{v}
     {}
 
     int value;
@@ -538,42 +539,6 @@ TEST_F(Registry_unit_tests, GetAutoComponentConst_CallAfterRemoved_ReturnsNull)
     const auto& constRegistry = registry;
     const auto* ptr = constRegistry.Get<FakeAutoComponent>(handle);
     EXPECT_EQ(ptr, nullptr);
-}
-
-TEST_F(Registry_unit_tests, Sort)
-{
-    auto handle1 = registry.Add<Entity>({});
-    auto handle2 = registry.Add<Entity>({});
-    registry.Add<Entity>({});
-    auto handle4 = registry.Add<Entity>({});
-    auto handle5 = registry.Add<Entity>({});
-    registry.Add<Entity>({});
-    registry.Add<Entity>({});
-    auto handle8 = registry.Add<Entity>({});
-
-    registry.Add<Fake1>(handle1, 5);
-    registry.Add<Fake1>(handle8, 4);
-    registry.Add<Fake1>(handle4, 3);
-    registry.Add<Fake1>(handle5, 2);
-    registry.Add<Fake1>(handle2, 1);
-
-    registry.CommitStagedChanges();
-
-    auto [fakes, transforms] = registry.ViewGroup<Fake1, Transform>();
-
-    ASSERT_EQ(transforms.size(), fakes.size());
-    EXPECT_EQ(transforms.size(), 5u);
-
-    for(size_t i = 0; i < fakes.size(); ++i)
-    {
-        auto te = transforms[i].GetParentEntity();
-        auto fe = fakes[i].GetParentEntity();
-
-        auto ti = EntityUtils::Index(te);
-        auto fi = EntityUtils::Index(fe);
-
-        EXPECT_EQ(te, fe);
-    }
 }
 
 TEST_F(Registry_unit_tests, ViewGroup_FirstGroupLarger_ReturnsSortedViews)

--- a/nc/test/unit/Registry_unit_tests.cpp
+++ b/nc/test/unit/Registry_unit_tests.cpp
@@ -35,9 +35,11 @@ struct Fake1 : public ComponentBase
 
 struct Fake2 : public ComponentBase
 {
-    Fake2(Entity entity)
+    Fake2(Entity entity, int v)
         : ComponentBase{entity}
     {}
+
+    int value;
 };
 
 struct FakeAutoComponent : public AutoComponent
@@ -60,7 +62,8 @@ class Registry_unit_tests : public ::testing::Test
 {
     public:
         size_t maxEntities = 10u;
-        Registry<Transform, AutoComponentGroup, Tag, Fake1, Fake2> registry;
+        using type_list = RegistryTypeList<Transform, AutoComponentGroup, Tag, Fake1, Fake2>;
+        Registry<type_list> registry;
 
         Registry_unit_tests()
             : registry{maxEntities}
@@ -102,10 +105,9 @@ TEST_F(Registry_unit_tests, RemoveEntity_EntityExists_EntityRemovedFromActiveLis
     EXPECT_EQ(entities.size(), 0u);
 }
 
-TEST_F(Registry_unit_tests, RemoveEntity_DoesNotExist_ReturnsFalse)
+TEST_F(Registry_unit_tests, RemoveEntity_DoesNotExist_Throws)
 {
-    auto actual = registry.Remove<Entity>(Handle1);
-    EXPECT_FALSE(actual);
+    EXPECT_THROW(registry.Remove<Entity>(Handle1), std::runtime_error);
 }
 
 TEST_F(Registry_unit_tests, ContainsEntity_Exists_ReturnsTrue)
@@ -129,170 +131,210 @@ TEST_F(Registry_unit_tests, ContainsEntity_AfterRemove_ReturnsFalse)
 
 TEST_F(Registry_unit_tests, AddComponent_ValidCall_ConstructsObject)
 {
-    auto* ptr = registry.Add<Fake1>(Handle1, 1);
-    EXPECT_EQ(ptr->GetParentEntity(), Handle1);
+    auto handle = registry.Add<Entity>({});
+    auto* ptr = registry.Add<Fake1>(handle, 1);
+    EXPECT_EQ(ptr->GetParentEntity(), handle);
     EXPECT_EQ(ptr->value, 1);
+}
+
+TEST_F(Registry_unit_tests, AddComponent_BadEntity_Throws)
+{
+    EXPECT_THROW(registry.Add<Fake1>(Entity{0u}, 1), std::runtime_error);
 }
 
 TEST_F(Registry_unit_tests, AddComponent_ReplaceAfterRemove_ConstructsObject)
 {
-    registry.Add<Fake1>(Handle1, 1);
+    auto handle = registry.Add<Entity>({});
+    registry.Add<Fake1>(handle, 1);
     registry.CommitStagedChanges();
-    registry.Remove<Fake1>(Handle1);
-    auto* ptr = registry.Add<Fake1>(Handle1, 2);
-    EXPECT_EQ(ptr->GetParentEntity(), Handle1);
+    registry.Remove<Fake1>(handle);
+    auto* ptr = registry.Add<Fake1>(handle, 2);
+    EXPECT_EQ(ptr->GetParentEntity(), handle);
     EXPECT_EQ(ptr->value, 2);
 }
 
 TEST_F(Registry_unit_tests, AddComponent_DoubleCall_Throws)
 {
-    registry.Add<Fake1>(Handle1, 1);
-    EXPECT_THROW(registry.Add<Fake1>(Handle1, 1), std::runtime_error);
+    auto handle = registry.Add<Entity>({});
+    registry.Add<Fake1>(handle, 1);
+    EXPECT_THROW(registry.Add<Fake1>(handle, 1), std::runtime_error);
 }
 
-TEST_F(Registry_unit_tests, RemoveComponent_ComponentExists_ReturnsTrue)
+TEST_F(Registry_unit_tests, RemoveComponent_ComponentExists_Removes)
 {
-    registry.Add<Fake1>(Handle1, 1);
+    auto handle = registry.Add<Entity>({});
+    registry.Add<Fake1>(handle, 1);
     registry.CommitStagedChanges();
-    auto actual = registry.Remove<Fake1>(Handle1);
-    EXPECT_TRUE(actual);
-}
-
-TEST_F(Registry_unit_tests, RemoveComponent_EmptyRegistry_ReturnsFalse)
-{
-    auto actual = registry.Remove<Fake1>(Handle1);
+    registry.Remove<Fake1>(handle);
+    auto actual = registry.Contains<Fake1>(handle);
     EXPECT_FALSE(actual);
 }
 
-TEST_F(Registry_unit_tests, RemoveComponent_ComponentDoesNotExist_ReturnsFalse)
+TEST_F(Registry_unit_tests, RemoveComponent_BadEntity_Throws)
 {
-    registry.Add<Fake1>(Handle1, 1);
-    auto actual = registry.Remove<Fake1>(Handle2);
-    EXPECT_FALSE(actual);
+    EXPECT_THROW(registry.Remove<Fake1>(Entity{0u}), std::runtime_error);
 }
 
-TEST_F(Registry_unit_tests, RemoveComponent_DoubleCall_ReturnsFalse)
+TEST_F(Registry_unit_tests, RemoveComponent_ComponentDoesNotExist_Throws)
 {
-    registry.Add<Fake1>(Handle1, 1);
-    registry.Remove<Fake1>(Handle1);
-    auto actual = registry.Remove<Fake1>(Handle1);
-    EXPECT_FALSE(actual);
+    auto handle = registry.Add<Entity>({});
+    EXPECT_THROW(registry.Remove<Fake1>(handle), std::runtime_error);
 }
 
-TEST_F(Registry_unit_tests, RemoveComponent_AfterClear_ReturnsFalse)
+TEST_F(Registry_unit_tests, RemoveComponent_DoubleCall_Throws)
 {
-    registry.Add<Fake1>(Handle1, 1);
+    auto handle = registry.Add<Entity>({});
+    registry.Add<Fake1>(handle, 1);
+    registry.CommitStagedChanges();
+    registry.Remove<Fake1>(handle);
+    EXPECT_THROW(registry.Remove<Fake1>(handle), std::runtime_error);
+}
+
+TEST_F(Registry_unit_tests, RemoveComponent_AfterClear_Throws)
+{
+    auto handle = registry.Add<Entity>({});
+    registry.Add<Fake1>(handle, 1);
     registry.Clear();
-    auto actual = registry.Remove<Fake1>(Handle1);
-    EXPECT_FALSE(actual);
+    EXPECT_THROW(registry.Remove<Fake1>(handle), std::runtime_error);
 }
 
-TEST_F(Registry_unit_tests, RemoveComponent_IncorrectType_ReturnsFalse)
+TEST_F(Registry_unit_tests, RemoveComponent_IncorrectType_Throws)
 {
-    registry.Add<Fake1>(Handle1, 1);
-    auto actual = registry.Remove<Fake2>(Handle1);
-    EXPECT_FALSE(actual);
+    auto handle = registry.Add<Entity>({});
+    registry.Add<Fake1>(handle, 1);
+    registry.CommitStagedChanges();
+    EXPECT_THROW(registry.Remove<Fake2>(handle), std::runtime_error);
 }
 
 TEST_F(Registry_unit_tests, ContainsComponent_Exists_ReturnsTrue)
 {
-    registry.Add<Fake1>(Handle1, 1);
+    auto handle = registry.Add<Entity>({});
+    registry.Add<Fake1>(handle, 1);
     registry.CommitStagedChanges();
-    auto actual = registry.Contains<Fake1>(Handle1);
+    auto actual = registry.Contains<Fake1>(handle);
     EXPECT_TRUE(actual);
+}
+
+TEST_F(Registry_unit_tests, ContainsComponent_BadEntity_Throws)
+{
+    EXPECT_THROW(registry.Contains<Fake1>(Entity{0u}), std::runtime_error);
 }
 
 TEST_F(Registry_unit_tests, ContainsComponent_ExistsStaged_ReturnsTrue)
 {
-    registry.Add<Fake1>(Handle1, 1);
-    auto actual = registry.Contains<Fake1>(Handle1);
+    auto handle = registry.Add<Entity>({});
+    registry.Add<Fake1>(handle, 1);
+    auto actual = registry.Contains<Fake1>(handle);
     EXPECT_TRUE(actual);
 }
 
 TEST_F(Registry_unit_tests, ContainsComponent_DoesNotExist_ReturnsFalse)
 {
-    auto actual = registry.Contains<Fake1>(Handle1);
+    auto handle = registry.Add<Entity>({});
+    auto actual = registry.Contains<Fake1>(handle);
     EXPECT_FALSE(actual);
 }
 
 TEST_F(Registry_unit_tests, ContainsComponent_AfterRemoved_ReturnsFalse)
 {
-    registry.Add<Fake1>(Handle1, 1);
+    auto handle = registry.Add<Entity>({});
+    registry.Add<Fake1>(handle, 1);
     registry.CommitStagedChanges();
-    registry.Remove<Fake1>(Handle1);
-    auto actual = registry.Contains<Fake1>(Handle1);
+    registry.Remove<Fake1>(handle);
+    auto actual = registry.Contains<Fake1>(handle);
     EXPECT_FALSE(actual);
 }
 
 TEST_F(Registry_unit_tests, GetComponent_Exists_ReturnsPointer)
 {
+    auto handle = registry.Add<Entity>({});
     auto value = 10;
-    registry.Add<Fake1>(Handle1, value);
+    registry.Add<Fake1>(handle, value);
     registry.CommitStagedChanges();
-    auto* ptr = registry.Get<Fake1>(Handle1);
+    auto* ptr = registry.Get<Fake1>(handle);
     ASSERT_NE(ptr, nullptr);
     EXPECT_EQ(ptr->value, value);
 }
 
+TEST_F(Registry_unit_tests, GetComponent_BadEntity_ReturnsNull)
+{
+    auto* actual = registry.Get<Fake1>(Entity{0u});
+    EXPECT_EQ(actual, nullptr);
+}
+
 TEST_F(Registry_unit_tests, GetComponent_ExistsStaged_ReturnsPointer)
 {
+    auto handle = registry.Add<Entity>({});
     auto value = 10;
-    registry.Add<Fake1>(Handle1, value);
-    auto* ptr = registry.Get<Fake1>(Handle1);
+    registry.Add<Fake1>(handle, value);
+    auto* ptr = registry.Get<Fake1>(handle);
     ASSERT_NE(ptr, nullptr);
     EXPECT_EQ(ptr->value, value);
 }
 
 TEST_F(Registry_unit_tests, GetComponent_DoesNotExist_ReturnsNull)
 {
-    auto* ptr = registry.Get<Fake1>(Handle1);
+    auto handle = registry.Add<Entity>({});
+    auto* ptr = registry.Get<Fake1>(handle);
     EXPECT_EQ(ptr, nullptr);
 }
 
 TEST_F(Registry_unit_tests, GetComponent_CallAfterRemoved_ReturnsNull)
 {
-    registry.Add<Fake1>(Handle1, 1);
+    auto handle = registry.Add<Entity>({});
+    registry.Add<Fake1>(handle, 1);
     registry.CommitStagedChanges();
-    registry.Remove<Fake1>(Handle1);
-    auto* ptr = registry.Get<Fake1>(Handle1);
+    registry.Remove<Fake1>(handle);
+    auto* ptr = registry.Get<Fake1>(handle);
     EXPECT_EQ(ptr, nullptr);
 }
 
 TEST_F(Registry_unit_tests, GetComponentConst_Exists_ReturnsPointer)
 {
+    auto handle = registry.Add<Entity>({});
     auto value = 10;
-    registry.Add<Fake1>(Handle1, value);
+    registry.Add<Fake1>(handle, value);
     registry.CommitStagedChanges();
     const auto& constRegistry = registry;
-    const auto* ptr = constRegistry.Get<Fake1>(Handle1);
+    const auto* ptr = constRegistry.Get<Fake1>(handle);
     ASSERT_NE(ptr, nullptr);
     EXPECT_EQ(ptr->value, value);
 }
 
+TEST_F(Registry_unit_tests, GetComponentConst_BadEntity_ReturnsNull)
+{
+    const auto& constRegistry = registry;
+    const auto* actual = constRegistry.Get<Fake1>(Entity{0u});
+    EXPECT_EQ(actual, nullptr);
+}
+
 TEST_F(Registry_unit_tests, GetComponentConst_ExistsStaged_ReturnsPointer)
 {
+    auto handle = registry.Add<Entity>({});
     auto value = 10;
-    registry.Add<Fake1>(Handle1, value);
+    registry.Add<Fake1>(handle, value);
     const auto& constRegistry = registry;
-    const auto* ptr = constRegistry.Get<Fake1>(Handle1);
+    const auto* ptr = constRegistry.Get<Fake1>(handle);
     ASSERT_NE(ptr, nullptr);
     EXPECT_EQ(ptr->value, value);
 }
 
 TEST_F(Registry_unit_tests, GetComponentConst_DoesNotExist_ReturnsNull)
 {
+    auto handle = registry.Add<Entity>({});
     const auto& constRegistry = registry;
-    const auto* ptr = constRegistry.Get<Fake1>(Handle1);
+    const auto* ptr = constRegistry.Get<Fake1>(handle);
     EXPECT_EQ(ptr, nullptr);
 }
 
 TEST_F(Registry_unit_tests, GetComponentConst_CallAfterRemoved_ReturnsNull)
 {
-    registry.Add<Fake1>(Handle1, 1);
+    auto handle = registry.Add<Entity>({});
+    registry.Add<Fake1>(handle, 1);
     registry.CommitStagedChanges();
-    registry.Remove<Fake1>(Handle1);
+    registry.Remove<Fake1>(handle);
     const auto& constRegistry = registry;
-    const auto* ptr = constRegistry.Get<Fake1>(Handle1);
+    const auto* ptr = constRegistry.Get<Fake1>(handle);
     EXPECT_EQ(ptr, nullptr);
 }
 
@@ -302,6 +344,11 @@ TEST_F(Registry_unit_tests, AddAutoComponent_ValidCall_ConstructsObject)
     auto* ptr = registry.Add<FakeAutoComponent>(handle, 1);
     EXPECT_EQ(ptr->GetParentEntity(), handle);
     EXPECT_EQ(ptr->value, 1);
+}
+
+TEST_F(Registry_unit_tests, AddAutoComponent_BadEntity_Throws)
+{
+    EXPECT_THROW(registry.Add<FakeAutoComponent>(Entity{0u}, 1), std::runtime_error);
 }
 
 TEST_F(Registry_unit_tests, AddAutoComponent_ReplaceAfterRemove_ConstructsObject)
@@ -315,53 +362,50 @@ TEST_F(Registry_unit_tests, AddAutoComponent_ReplaceAfterRemove_ConstructsObject
     EXPECT_EQ(ptr->value, 2);
 }
 
-TEST_F(Registry_unit_tests, AddAutoComponent_DoubleCall_ReturnsNull)
+TEST_F(Registry_unit_tests, AddAutoComponent_DoubleCall_Throws)
 {
     auto handle = registry.Add<Entity>({});
     registry.Add<FakeAutoComponent>(handle, 1);
-    auto actual = registry.Add<FakeAutoComponent>(handle, 1);
-    EXPECT_EQ(actual, nullptr);
+    EXPECT_THROW(registry.Add<FakeAutoComponent>(handle, 1), std::runtime_error);
 }
 
-TEST_F(Registry_unit_tests, RemoveAutoComponent_ComponentExists_ReturnsTrue)
+TEST_F(Registry_unit_tests, RemoveAutoComponent_ComponentExists_Removes)
 {
     auto handle = registry.Add<Entity>({});
     registry.Add<FakeAutoComponent>(handle, 1);
     registry.CommitStagedChanges();
-    auto actual = registry.Remove<FakeAutoComponent>(handle);
-    EXPECT_TRUE(actual);
-}
-
-TEST_F(Registry_unit_tests, RemoveAutoComponent_EmptyRegistry_ReturnsFalse)
-{
-    auto handle = registry.Add<Entity>({});
-    auto actual = registry.Remove<FakeAutoComponent>(handle);
-    EXPECT_FALSE(actual);
-}
-
-TEST_F(Registry_unit_tests, RemoveAutoComponent_ComponentDoesNotExist_ReturnsFalse)
-{
-    auto handle = registry.Add<Entity>({});
-    auto actual = registry.Remove<FakeAutoComponent>(handle);
-    EXPECT_FALSE(actual);
-}
-
-TEST_F(Registry_unit_tests, RemoveAutoComponent_DoubleCall_ReturnsFalse)
-{
-    auto handle = registry.Add<Entity>({});
-    registry.Add<FakeAutoComponent>(handle, 1);
     registry.Remove<FakeAutoComponent>(handle);
-    auto actual = registry.Remove<FakeAutoComponent>(handle);
+    auto actual = registry.Contains<FakeAutoComponent>(handle);
     EXPECT_FALSE(actual);
 }
 
-TEST_F(Registry_unit_tests, RemoveAutoComponent_AfterClear_ReturnsFalse)
+TEST_F(Registry_unit_tests, RemoveAutoComponent_BadEntity_Throws)
+{
+    EXPECT_THROW(registry.Remove<FakeAutoComponent>(Entity{0u}), std::runtime_error);
+}
+
+TEST_F(Registry_unit_tests, RemoveAutoComponent_ComponentDoesNotExist_Throws)
+{
+    auto handle = registry.Add<Entity>({});
+    EXPECT_THROW(registry.Remove<FakeAutoComponent>(handle), std::runtime_error);
+}
+
+TEST_F(Registry_unit_tests, RemoveAutoComponent_DoubleCall_Throws)
 {
     auto handle = registry.Add<Entity>({});
     registry.Add<FakeAutoComponent>(handle, 1);
+    registry.CommitStagedChanges();
+    registry.Remove<FakeAutoComponent>(handle);
+    EXPECT_THROW(registry.Remove<FakeAutoComponent>(handle), std::runtime_error);
+}
+
+TEST_F(Registry_unit_tests, RemoveAutoComponent_AfterClear_Throws)
+{
+    auto handle = registry.Add<Entity>({});
+    registry.Add<FakeAutoComponent>(handle, 1);
+    registry.CommitStagedChanges();
     registry.Clear();
-    auto actual = registry.Remove<FakeAutoComponent>(handle);
-    EXPECT_FALSE(actual);
+    EXPECT_THROW(registry.Remove<FakeAutoComponent>(handle), std::runtime_error);
 }
 
 TEST_F(Registry_unit_tests, ContainsAutoComponent_Exists_ReturnsTrue)
@@ -371,6 +415,11 @@ TEST_F(Registry_unit_tests, ContainsAutoComponent_Exists_ReturnsTrue)
     registry.CommitStagedChanges();
     auto actual = registry.Contains<FakeAutoComponent>(handle);
     EXPECT_TRUE(actual);
+}
+
+TEST_F(Registry_unit_tests, ContainsAutoComponent_BadEntity_Throws)
+{
+    EXPECT_THROW(registry.Contains<FakeAutoComponent>(Entity{0u}), std::runtime_error);
 }
 
 TEST_F(Registry_unit_tests, ContainsAutoComponent_ExistsStaged_ReturnsTrue)
@@ -407,6 +456,12 @@ TEST_F(Registry_unit_tests, GetAutoComponent_Exists_ReturnsPointer)
     auto* ptr = registry.Get<FakeAutoComponent>(handle);
     ASSERT_NE(ptr, nullptr);
     EXPECT_EQ(ptr->value, value);
+}
+
+TEST_F(Registry_unit_tests, GetAutoComponent_BadEntity_Throws)
+{
+    auto* actual = registry.Get<FakeAutoComponent>(Entity{0u});
+    EXPECT_EQ(actual, nullptr);
 }
 
 TEST_F(Registry_unit_tests, GetAutoComponent_ExistsStaged_ReturnsPointer)
@@ -448,6 +503,13 @@ TEST_F(Registry_unit_tests, GetAutoComponentConst_Exists_ReturnsPointer)
     EXPECT_EQ(ptr->value, value);
 }
 
+TEST_F(Registry_unit_tests, GetAutoComponentConst_BadEntity_ReturnsNull)
+{
+    const auto& constRegistry = registry;
+    const auto* actual = constRegistry.Get<FakeAutoComponent>(Entity{8u});
+    EXPECT_EQ(actual, nullptr);
+}
+
 TEST_F(Registry_unit_tests, GetAutoComponentConst_ExistsStaged_ReturnsPointer)
 {
     auto handle = registry.Add<Entity>({});
@@ -482,11 +544,11 @@ TEST_F(Registry_unit_tests, Sort)
 {
     auto handle1 = registry.Add<Entity>({});
     auto handle2 = registry.Add<Entity>({});
-    auto handle3 = registry.Add<Entity>({});
+    registry.Add<Entity>({});
     auto handle4 = registry.Add<Entity>({});
     auto handle5 = registry.Add<Entity>({});
-    auto handle6 = registry.Add<Entity>({});
-    auto handle7 = registry.Add<Entity>({});
+    registry.Add<Entity>({});
+    registry.Add<Entity>({});
     auto handle8 = registry.Add<Entity>({});
 
     registry.Add<Fake1>(handle1, 5);
@@ -495,23 +557,90 @@ TEST_F(Registry_unit_tests, Sort)
     registry.Add<Fake1>(handle5, 2);
     registry.Add<Fake1>(handle2, 1);
 
+    registry.CommitStagedChanges();
 
-    //registry.Sort<Transform, Fake1>();
-    registry.Sort<Fake1, Transform>();
+    auto [fakes, transforms] = registry.ViewGroup<Fake1, Transform>();
 
-    auto transforms = registry.ViewAll<Transform>();
-    auto fakes = registry.ViewAll<Fake1>();
-
-
+    ASSERT_EQ(transforms.size(), fakes.size());
+    EXPECT_EQ(transforms.size(), 5u);
 
     for(size_t i = 0; i < fakes.size(); ++i)
     {
-        EXPECT_EQ(transforms[i].GetParentEntity(), fakes[i].GetParentEntity());
+        auto te = transforms[i].GetParentEntity();
+        auto fe = fakes[i].GetParentEntity();
+
+        auto ti = EntityUtils::Index(te);
+        auto fi = EntityUtils::Index(fe);
+
+        EXPECT_EQ(te, fe);
     }
-
-
 }
 
+TEST_F(Registry_unit_tests, ViewGroup_FirstGroupLarger_ReturnsSortedViews)
+{
+    auto h1 = registry.Add<Entity>({});
+    auto h2 = registry.Add<Entity>({});
+    auto h3 = registry.Add<Entity>({});
+    auto h4 = registry.Add<Entity>({});
+    auto h5 = registry.Add<Entity>({});
+
+    registry.Add<Fake1>(h2, 1);
+    registry.Add<Fake1>(h1, 1);
+    registry.Add<Fake1>(h3, 1);
+    registry.Add<Fake1>(h5, 1);
+    registry.Add<Fake1>(h4, 1);
+
+    registry.Add<Fake2>(h5, 1);
+    registry.Add<Fake2>(h4, 1);
+    registry.Add<Fake2>(h1, 1);
+
+    registry.CommitStagedChanges();
+
+    auto [fake1, fake2] = registry.ViewGroup<Fake1, Fake2>();
+
+    auto fake1Size = fake1.size();
+    auto fake2Size = fake2.size();
+    ASSERT_EQ(fake1Size, fake2Size);
+    EXPECT_EQ(fake1Size, 3u);
+
+    for(size_t i = 0u; i < fake1Size; ++i)
+    {
+        EXPECT_EQ(fake1[i].GetParentEntity(), fake2[i].GetParentEntity());
+    }
+}
+
+TEST_F(Registry_unit_tests, ViewGroup_SecondGroupLarger_ReturnsSortedViews)
+{
+    auto h1 = registry.Add<Entity>({});
+    auto h2 = registry.Add<Entity>({});
+    auto h3 = registry.Add<Entity>({});
+    auto h4 = registry.Add<Entity>({});
+    auto h5 = registry.Add<Entity>({});
+
+    registry.Add<Fake1>(h1, 1);
+    registry.Add<Fake1>(h2, 1);
+    registry.Add<Fake1>(h3, 1);
+
+    registry.Add<Fake2>(h5, 1);
+    registry.Add<Fake2>(h4, 1);
+    registry.Add<Fake2>(h1, 1);
+    registry.Add<Fake2>(h2, 1);
+    registry.Add<Fake2>(h3, 1);
+
+    registry.CommitStagedChanges();
+
+    auto [fake1, fake2] = registry.ViewGroup<Fake1, Fake2>();
+
+    auto fake1Size = fake1.size();
+    auto fake2Size = fake2.size();
+    ASSERT_EQ(fake1Size, fake2Size);
+    EXPECT_EQ(fake1Size, 3u);
+
+    for(size_t i = 0u; i < fake1Size; ++i)
+    {
+        EXPECT_EQ(fake1[i].GetParentEntity(), fake2[i].GetParentEntity());
+    }
+}
 
 int main(int argc, char ** argv)
 {


### PR DESCRIPTION
-Registry now gets its types from RegistryTypeList
-Some Registry functionality moved into PerComponentStorage
-Added ViewGroup to Registry - more or less a ViewAll<T, U> that sorts a range within pools T & U by entity and returns spans over that range.