### PR TITLE
Simplify Component Inheritance

### DIFF
--- a/nc/include/component/Camera.h
+++ b/nc/include/component/Camera.h
@@ -14,7 +14,7 @@ namespace nc
             Camera& operator=(Camera&&) = delete;
 
             #ifdef NC_EDITOR_ENABLED
-            void EditorGuiElement() override;
+            void ComponentGuiElement() override;
             #endif
     };
 }

--- a/nc/include/component/Collider.h
+++ b/nc/include/component/Collider.h
@@ -52,7 +52,6 @@ namespace nc
 
             #ifdef NC_EDITOR_ENABLED
             void UpdateWidget(graphics::FrameManager* frame);
-            void EditorGuiElement() override;
             void SetEditorSelection(bool state);
             #endif
 
@@ -80,4 +79,8 @@ namespace nc
         using requires_on_add_callback = std::true_type;
         using requires_on_remove_callback = std::true_type;
     };
+
+    #ifdef NC_EDITOR_ENABLED
+    template<> void ComponentGuiElement<Collider>(Collider*);
+    #endif
 }

--- a/nc/include/component/Component.h
+++ b/nc/include/component/Component.h
@@ -18,22 +18,15 @@ namespace nc
     class ComponentBase
     {
         public:
-            ComponentBase(Entity entity) noexcept
+            explicit ComponentBase(Entity entity) noexcept
                 : m_parentEntity{entity} {}
 
-            virtual ~ComponentBase() = default;
             ComponentBase(const ComponentBase&) = delete;
             ComponentBase(ComponentBase&&) = default;
             ComponentBase& operator=(const ComponentBase&) = delete;
             ComponentBase& operator=(ComponentBase&&) = default;
 
-            /** @todo Fix this naming - it is omega confusing in transform when parent
-             * means something else. */
             Entity GetParentEntity() const noexcept { return m_parentEntity; }
-
-            #ifdef NC_EDITOR_ENABLED
-            virtual void EditorGuiElement();
-            #endif
 
         private:
             Entity m_parentEntity;
@@ -43,8 +36,10 @@ namespace nc
     class AutoComponent : public ComponentBase
     {
         public:
-            AutoComponent(Entity entity) noexcept
+            explicit AutoComponent(Entity entity) noexcept
                 : ComponentBase{entity} {}
+
+            virtual ~AutoComponent() = default;
 
             virtual void FrameUpdate(float) {}
             virtual void FixedUpdate() {}
@@ -52,6 +47,10 @@ namespace nc
             virtual void OnCollisionEnter(Entity) {}
             virtual void OnCollisionStay(Entity) {};
             virtual void OnCollisionExit(Entity) {};
+
+            #ifdef NC_EDITOR_ENABLED
+            virtual void ComponentGuiElement();
+            #endif
     };
 
     /** Helper for configuring storage and allocation behavior. */
@@ -73,4 +72,19 @@ namespace nc
         /** Requires an OnRemove callback to be set in the registry. */
         using requires_on_remove_callback = std::false_type;
     };
+
+    /** Editor function that can be specialized to provide a custom widget.
+     *  AutoComponents must use override their member function instead. */
+    #ifdef NC_EDITOR_ENABLED
+    namespace internal
+    {
+        void DefaultComponentGuiElement();
+    }
+
+    template<class T>
+    void ComponentGuiElement(T*)
+    {
+        internal::DefaultComponentGuiElement();
+    }
+    #endif
 } //end namespace nc

--- a/nc/include/component/NetworkDispatcher.h
+++ b/nc/include/component/NetworkDispatcher.h
@@ -23,11 +23,12 @@ namespace nc
             void Dispatch(net::PacketType packetType, uint8_t* data);
             void AddHandler(net::PacketType packetType, std::function<void(uint8_t* data)> func);
 
-            #ifdef NC_EDITOR_ENABLED
-            void EditorGuiElement() override;
-            #endif
-
         private:
             std::unordered_map<net::PacketType, std::function<void(uint8_t*)>> m_dispatchTable;
     };
+
+    #ifdef NC_EDITOR_ENABLED
+    template<>
+    void ComponentGuiElement<NetworkDispatcher>(NetworkDispatcher*);
+    #endif
 }

--- a/nc/include/component/ParticleEmitter.h
+++ b/nc/include/component/ParticleEmitter.h
@@ -58,10 +58,6 @@ namespace nc
         
             void RegisterSystem(ecs::ParticleEmitterSystem* system);
 
-            #ifdef NC_EDITOR_ENABLED
-            void EditorGuiElement() override;
-            #endif
-
         private:
             ParticleInfo m_info;
             ecs::ParticleEmitterSystem* m_emitterSystem;
@@ -75,4 +71,8 @@ namespace nc
         using requires_on_add_callback = std::true_type;
         using requires_on_remove_callback = std::true_type;
     };
+
+    #ifdef NC_EDITOR_ENABLED
+    template<> void ComponentGuiElement<ParticleEmitter>(ParticleEmitter*);
+    #endif
 } // namespace nc

--- a/nc/include/component/PointLight.h
+++ b/nc/include/component/PointLight.h
@@ -34,10 +34,6 @@ namespace nc
 
             void Set(const PointLight::Properties& lightProperties);
             void SetPositionFromCameraProjection(const DirectX::FXMMATRIX& view);
-
-            #ifdef NC_EDITOR_ENABLED
-            void EditorGuiElement() override;
-            #endif
     };
 
     template<>
@@ -48,4 +44,8 @@ namespace nc
         using requires_on_add_callback = std::false_type;
         using requires_on_remove_callback = std::false_type;
     };
+
+    #ifdef NC_EDITOR_ENABLED
+    template<> void ComponentGuiElement<PointLight>(PointLight* light);
+    #endif
 }

--- a/nc/include/component/Renderer.h
+++ b/nc/include/component/Renderer.h
@@ -24,16 +24,19 @@ namespace nc
             Renderer& operator=(const Renderer&) = delete;
             Renderer& operator=(Renderer&&) = default;
 
-            #ifdef NC_EDITOR_ENABLED
-            void EditorGuiElement() override;
-            #endif
-
             void SetMesh(const graphics::Mesh& mesh);
             void SetMaterial(const graphics::Material& material);
             void Update(graphics::FrameManager* frame);
 
         private:
             std::unique_ptr<graphics::Model> m_model;
+            
+            #ifdef NC_EDITOR_ENABLED
+            friend void ComponentGuiElement<Renderer>(Renderer*);
+            #endif
     };
-    
+
+    #ifdef NC_EDITOR_ENABLED
+    template<> void ComponentGuiElement<Renderer>(Renderer* renderer);
+    #endif
 }

--- a/nc/include/component/Transform.h
+++ b/nc/include/component/Transform.h
@@ -49,10 +49,6 @@ namespace nc
             Entity GetRoot() const;         // Get the root node relative to this transform
             Entity GetParent() const;        // Get the immediate parent of this transform - may be nullptr
             void SetParent(Entity parent);   // Make this transform the child of another - nullptr will detach from existing parent
-
-            #ifdef NC_EDITOR_ENABLED
-            void EditorGuiElement() override;
-            #endif
             
         private:
             void AddChild(Entity child);
@@ -63,5 +59,13 @@ namespace nc
             DirectX::XMMATRIX m_worldMatrix;
             Entity m_parent;
             std::vector<Entity> m_children;
+            
+            #ifdef NC_EDITOR_ENABLED
+            friend void ComponentGuiElement<Transform>(Transform*);
+            #endif
     };
+
+    #ifdef NC_EDITOR_ENABLED
+    template<> void ComponentGuiElement<Transform>(Transform* transform);
+    #endif
 } //end namespace nc

--- a/nc/source/component/Camera.cpp
+++ b/nc/source/component/Camera.cpp
@@ -4,8 +4,6 @@
 #include "imgui/imgui.h"
 #endif
 
-#include <string>
-
 namespace nc
 {
     Camera::Camera(Entity entity) noexcept
@@ -14,7 +12,7 @@ namespace nc
     }
 
     #ifdef NC_EDITOR_ENABLED
-    void Camera::EditorGuiElement()
+    void Camera::ComponentGuiElement()
     {
         ImGui::Text("Camera");
     }

--- a/nc/source/component/Collider.cpp
+++ b/nc/source/component/Collider.cpp
@@ -69,15 +69,15 @@ namespace nc
         m_widgetModel->Submit(frame);
     }
 
-    void Collider::EditorGuiElement()
-    {
-        ImGui::Text("Collider");
-        /** @todo put widgets back */
-    }
-
     void Collider::SetEditorSelection(bool state)
     {
         m_selectedInEditor = state;
+    }
+
+    template<> void ComponentGuiElement<Collider>(Collider*)
+    {
+        ImGui::Text("Collider");
+        /** @todo put widgets back */
     }
     #endif
 }

--- a/nc/source/component/Component.cpp
+++ b/nc/source/component/Component.cpp
@@ -2,14 +2,21 @@
 
 #ifdef NC_EDITOR_ENABLED
 #include "imgui/imgui.h"
-#endif
 
 namespace nc
 {
-    #ifdef NC_EDITOR_ENABLED
-    void ComponentBase::EditorGuiElement()
+    void AutoComponent::ComponentGuiElement()
     {
-        ImGui::Text("User Component");
+        ImGui::Text("User AutoComponent");
     }
-    #endif
-} //end namespace nc
+
+    namespace internal
+    {
+        void DefaultComponentGuiElement()
+        {
+            ImGui::Text("User Component");
+        }
+    }
+}
+
+#endif

--- a/nc/source/component/NetworkDispatcher.cpp
+++ b/nc/source/component/NetworkDispatcher.cpp
@@ -31,7 +31,8 @@ namespace nc
     }
 
     #ifdef NC_EDITOR_ENABLED
-    void NetworkDispatcher::EditorGuiElement()
+    template<>
+    void ComponentGuiElement<NetworkDispatcher>(NetworkDispatcher*)
     {
         ImGui::Text("NetworkDispatcher");
     }

--- a/nc/source/component/ParticleEmitter.cpp
+++ b/nc/source/component/ParticleEmitter.cpp
@@ -30,7 +30,7 @@ namespace nc
     }
 
     #ifdef NC_EDITOR_ENABLED
-    void ParticleEmitter::EditorGuiElement()
+    template<> void ComponentGuiElement<ParticleEmitter>(ParticleEmitter*)
     {
         ImGui::Text("Particle Emitter");
     }

--- a/nc/source/component/PointLight.cpp
+++ b/nc/source/component/PointLight.cpp
@@ -21,10 +21,19 @@ namespace nc
         PixelConstBufData = lightProperties;
     }
 
+    void PointLight::SetPositionFromCameraProjection(const DirectX::FXMMATRIX& view)
+    {
+        auto* transform = ActiveRegistry()->Get<Transform>(GetParentEntity());
+        PixelConstBufData.pos = transform->GetPosition();
+        const auto pos_v = DirectX::XMLoadVector3(&PixelConstBufData.pos);
+        DirectX::XMStoreVector3(&ProjectedPos, DirectX::XMVector3Transform(pos_v, view));
+    }
+
     #ifdef NC_EDITOR_ENABLED
-    void PointLight::EditorGuiElement()
+    template<> void ComponentGuiElement<PointLight>(PointLight* light)
     {
         const float dragSpeed = 1.0f;
+        auto& PixelConstBufData = light->PixelConstBufData;
 
         ImGui::Text("Point Light");
         ImGui::Indent();
@@ -43,12 +52,4 @@ namespace nc
         ImGui::Unindent();
     }
     #endif
-
-    void PointLight::SetPositionFromCameraProjection(const DirectX::FXMMATRIX& view)
-    {
-        auto* transform = ActiveRegistry()->Get<Transform>(GetParentEntity());
-        PixelConstBufData.pos = transform->GetPosition();
-        const auto pos_v = DirectX::XMLoadVector3(&PixelConstBufData.pos);
-        DirectX::XMStoreVector3(&ProjectedPos, DirectX::XMVector3Transform(pos_v, view));
-    }
 }

--- a/nc/source/component/Renderer.cpp
+++ b/nc/source/component/Renderer.cpp
@@ -18,14 +18,6 @@ namespace nc
           m_model{ std::make_unique<graphics::Model>(std::move(mesh), std::move(material)) }
     {
     }
-
-    #ifdef NC_EDITOR_ENABLED
-    void Renderer::EditorGuiElement()
-    {
-        ImGui::Text("Renderer");
-        m_model->GetMaterial()->EditorGuiElement();
-    }
-    #endif
     
     void Renderer::Update(graphics::FrameManager* frame)
     {
@@ -44,4 +36,11 @@ namespace nc
         m_model->SetMaterial(material);
     }
 
+    #ifdef NC_EDITOR_ENABLED
+    template<> void ComponentGuiElement<Renderer>(Renderer* renderer)
+    {
+        ImGui::Text("Renderer");
+        renderer->m_model->GetMaterial()->EditorGuiElement();
+    }
+    #endif
 }

--- a/nc/source/component/Transform.cpp
+++ b/nc/source/component/Transform.cpp
@@ -296,10 +296,12 @@ namespace nc
     }
 
     #ifdef NC_EDITOR_ENABLED
-    void Transform::EditorGuiElement()
+    template<> void ComponentGuiElement<Transform>(Transform* transform)
     {
+        auto& worldMatrix = transform->m_worldMatrix;
+
         DirectX::XMVECTOR scl_v, rot_v, pos_v;
-        DirectX::XMMatrixDecompose(&scl_v, &rot_v, &pos_v, m_worldMatrix);
+        DirectX::XMMatrixDecompose(&scl_v, &rot_v, &pos_v, worldMatrix);
         Vector3 scl, pos;
         auto rot = Quaternion::Identity();
         DirectX::XMStoreVector3(&scl, scl_v);
@@ -315,11 +317,11 @@ namespace nc
         auto sclResult = ui::editor::xyzWidget("Scl", "transformscl", &scl.x, &scl.y, &scl.z);
 
         if(posResult)
-            SetPosition(pos);
+            transform->SetPosition(pos);
         if(rotResult)
-            SetRotation(angles);
+            transform->SetRotation(angles);
         if(sclResult)
-            SetScale(scl);
+            transform->SetScale(scl);
     }
     #endif
 }

--- a/nc/source/ui/editor/EditorControls.h
+++ b/nc/source/ui/editor/EditorControls.h
@@ -20,7 +20,7 @@ namespace nc::ui::editor::controls
     inline void SceneGraphPanel(registry_type* registry, float windowHeight);
     inline void SceneGraphNode(registry_type* registry, Entity entity, Tag* tag, Transform* transform);
     inline void EntityPanel(registry_type* registry, Entity entity);
-    inline void Component(ComponentBase* comp);
+    inline void AutoComponentElement(AutoComponent* comp);
     inline void UtilitiesPanel(float* dtMult, registry_type* registry, unsigned drawCallCount, float windowWidth, float windowHeight);
     inline void GraphicsResourcePanel();
     inline void FrameData(float* dtMult, unsigned drawCallCount);
@@ -109,32 +109,38 @@ namespace nc::ui::editor::controls
         ImGui::Text("Version %d", EntityUtils::Version(entity));
         ImGui::Text("Layer   %d", EntityUtils::Layer(entity));
         ImGui::Text("Static  %s", EntityUtils::IsStatic(entity) ? "True" : "False");
-        controls::Component(registry->Get<Transform>(entity));
-        controls::Component(registry->Get<NetworkDispatcher>(entity));
-        controls::Component(registry->Get<ParticleEmitter>(entity));
-        controls::Component(registry->Get<Renderer>(entity));
-        if(auto col = registry->Get<Collider>(entity); col)
+
+        if(auto* transform = registry->Get<Transform>(entity); transform)
+            ComponentGuiElement(transform);
+        if(auto* renderer = registry->Get<Renderer>(entity))
+            ComponentGuiElement(renderer);
+        if(auto* emitter = registry->Get<ParticleEmitter>(entity))
+            ComponentGuiElement(emitter);
+        if(auto* dispatcher = registry->Get<NetworkDispatcher>(entity))
+            ComponentGuiElement(dispatcher);
+        if(auto* light = registry->Get<PointLight>(entity))
+            ComponentGuiElement(light);
+        if(auto* col = registry->Get<Collider>(entity); col)
         {
             // collider model doesn't update/submit unless we tell it to
             col->SetEditorSelection(true);
-            controls::Component(col);
+            ComponentGuiElement(col);
         }
-        controls::Component(registry->Get<PointLight>(entity));
-        
+
         for(const auto& comp : registry->Get<AutoComponentGroup>(entity)->GetAutoComponents())
-            controls::Component(comp);
+            controls::AutoComponentElement(comp);
 
         ImGui::Separator();
     }
 
-    void Component(ComponentBase* comp)
+    void AutoComponentElement(AutoComponent* comp)
     {
         if(!comp)
             return;
         ImGui::Separator();
         ImGui::BeginGroup();
             ImGui::Spacing();
-            comp->EditorGuiElement();
+            comp->ComponentGuiElement();
             ImGui::Spacing();
         ImGui::EndGroup();
     }

--- a/nc/test/unit/Registry_unit_tests.cpp
+++ b/nc/test/unit/Registry_unit_tests.cpp
@@ -36,7 +36,8 @@ struct Fake1 : public ComponentBase
 struct Fake2 : public ComponentBase
 {
     Fake2(Entity entity, int v)
-        : ComponentBase{entity}
+        : ComponentBase{entity},
+          value{v}
     {}
 
     int value;
@@ -538,42 +539,6 @@ TEST_F(Registry_unit_tests, GetAutoComponentConst_CallAfterRemoved_ReturnsNull)
     const auto& constRegistry = registry;
     const auto* ptr = constRegistry.Get<FakeAutoComponent>(handle);
     EXPECT_EQ(ptr, nullptr);
-}
-
-TEST_F(Registry_unit_tests, Sort)
-{
-    auto handle1 = registry.Add<Entity>({});
-    auto handle2 = registry.Add<Entity>({});
-    registry.Add<Entity>({});
-    auto handle4 = registry.Add<Entity>({});
-    auto handle5 = registry.Add<Entity>({});
-    registry.Add<Entity>({});
-    registry.Add<Entity>({});
-    auto handle8 = registry.Add<Entity>({});
-
-    registry.Add<Fake1>(handle1, 5);
-    registry.Add<Fake1>(handle8, 4);
-    registry.Add<Fake1>(handle4, 3);
-    registry.Add<Fake1>(handle5, 2);
-    registry.Add<Fake1>(handle2, 1);
-
-    registry.CommitStagedChanges();
-
-    auto [fakes, transforms] = registry.ViewGroup<Fake1, Transform>();
-
-    ASSERT_EQ(transforms.size(), fakes.size());
-    EXPECT_EQ(transforms.size(), 5u);
-
-    for(size_t i = 0; i < fakes.size(); ++i)
-    {
-        auto te = transforms[i].GetParentEntity();
-        auto fe = fakes[i].GetParentEntity();
-
-        auto ti = EntityUtils::Index(te);
-        auto fi = EntityUtils::Index(fe);
-
-        EXPECT_EQ(te, fe);
-    }
 }
 
 TEST_F(Registry_unit_tests, ViewGroup_FirstGroupLarger_ReturnsSortedViews)


### PR DESCRIPTION
-Removed virtual functions from ComponentBase so that derived types have the option of being trivially copyable.
-Added a template version of the component editor widget that can be specialized for each component type.
-The virtual version of this (previously in ComponentBase) was moved to AutoComponent.