### PR TITLE
Simplify Entity

### DIFF
--- a/nc/include/component/HandleManager.h
+++ b/nc/include/component/HandleManager.h
@@ -15,14 +15,14 @@ namespace nc::ecs
             {
             }
 
-            Entity GenerateNewHandle(EntityTraits::layer_type layer, EntityTraits::flags_type flags)
+            Entity GenerateNewHandle(Entity::layer_type layer, Entity::flags_type flags)
             {
                 if(m_freeHandles.empty())
-                    return Entity{EntityUtils::Join(m_nextIndex++, 0u, layer, flags)};
+                    return Entity{m_nextIndex++, layer, flags};
                 
                 auto out = m_freeHandles.back();
                 m_freeHandles.pop_back();
-                return EntityUtils::Recycle(out, layer, flags);
+                return Entity{out.Index(), layer, flags};
             }
 
             void ReclaimHandle(Entity handle)
@@ -39,6 +39,6 @@ namespace nc::ecs
         
         private:
             std::vector<Entity> m_freeHandles;
-            EntityTraits::index_type m_nextIndex;
+            Entity::index_type m_nextIndex;
     };
 }

--- a/nc/include/component/PerComponentStorage.h
+++ b/nc/include/component/PerComponentStorage.h
@@ -131,7 +131,7 @@ namespace nc::ecs
     template<Component T>
     bool PerComponentStorage<T>::Contains(Entity entity) const
     {
-        if(Entity::NullIndex != sparseArray.at(entity.Index()))
+        if(sparseArray.at(entity.Index()) != Entity::NullIndex)
             return true;
 
         auto pos = std::ranges::find_if(stagingPool, [entity](const auto& pair)

--- a/nc/include/component/Registry.h
+++ b/nc/include/component/Registry.h
@@ -74,7 +74,7 @@ namespace nc::ecs
     class Registry
     {
         using storage_type = TypeList::storage_type;
-        using index_type = EntityTraits::index_type;
+        using index_type = Entity::index_type;
 
         public:
             Registry(size_t maxEntities);
@@ -332,7 +332,7 @@ namespace nc::ecs
             auto entityIndex = referenceEntities.at(current);
             auto indexInTarget = targetSparseArray.at(entityIndex);
 
-            if(indexInTarget != EntityTraits::NullIndex) // Entity has both components
+            if(indexInTarget != Entity::NullIndex) // Entity has both components
             {
                 if(indexInTarget != current)
                 {

--- a/nc/include/physics/LayerMask.h
+++ b/nc/include/physics/LayerMask.h
@@ -7,7 +7,7 @@ namespace nc::physics
     /** Defined layers in project code as powers of 2 however desired - enum, constants, etc. */
     using LayerMask = uint64_t;
     using LayerMask32 = uint32_t;
-    constexpr EntityTraits::layer_type DefaultLayer = 1u;
+    constexpr Entity::layer_type DefaultLayer = 1u;
     constexpr LayerMask LayerMaskNone = 0u;
     constexpr LayerMask LayerMaskAll = ~LayerMaskNone;
     constexpr LayerMask32 LayerMask32None = 0u;

--- a/nc/source/component/ConcaveCollider.cpp
+++ b/nc/source/component/ConcaveCollider.cpp
@@ -12,7 +12,7 @@ namespace nc
         : ComponentBase(entity),
           m_path{std::move(assetPath)}
     {
-        if(!EntityUtils::IsStatic(entity))
+        if(!entity.IsStatic())
             throw std::runtime_error("ConcaveCollider - Cannot be added to a non-static entity");
     }
 

--- a/nc/source/component/PhysicsBody.cpp
+++ b/nc/source/component/PhysicsBody.cpp
@@ -90,7 +90,7 @@ namespace nc
         if(!collider)
             throw std::runtime_error("PhysicsBody added to Entity with no Collider");
 
-        if(EntityUtils::IsStatic(entity))
+        if(entity.IsStatic())
         {
             m_properties.mass = 0.0f;
         }
@@ -113,7 +113,7 @@ namespace nc
 
     void PhysicsBody::ApplyImpulse(DirectX::FXMVECTOR impulse)
     {
-        if(m_properties.isKinematic || EntityUtils::IsStatic(GetParentEntity()))
+        if(m_properties.isKinematic || GetParentEntity().IsStatic())
             return;
         
         m_linearVelocity += DirectX::XMVectorScale(impulse, m_properties.mass) * m_linearFreedom;
@@ -126,7 +126,7 @@ namespace nc
 
     void PhysicsBody::ApplyTorqueImpulse(DirectX::FXMVECTOR torque)
     {
-        if(m_properties.isKinematic || EntityUtils::IsStatic(GetParentEntity()))
+        if(m_properties.isKinematic || GetParentEntity().IsStatic())
             return;
 
         auto restrictedTorque = torque * m_angularFreedom;
@@ -135,7 +135,7 @@ namespace nc
 
     void PhysicsBody::ApplyVelocity(DirectX::FXMVECTOR delta)
     {
-        if(m_properties.isKinematic || EntityUtils::IsStatic(GetParentEntity()))
+        if(m_properties.isKinematic || GetParentEntity().IsStatic())
             return;
         
         m_linearVelocity += delta * m_linearFreedom;
@@ -143,7 +143,7 @@ namespace nc
 
     void PhysicsBody::ApplyVelocities(DirectX::FXMVECTOR velDelta, DirectX::FXMVECTOR angVelDelta)
     {
-        if(m_properties.isKinematic || EntityUtils::IsStatic(GetParentEntity()))
+        if(m_properties.isKinematic || GetParentEntity().IsStatic())
             return;
         
         m_linearVelocity += velDelta * m_linearFreedom;
@@ -152,7 +152,7 @@ namespace nc
 
     void PhysicsBody::UpdateWorldInertia(Transform* transform)
     {
-        if(EntityUtils::IsStatic(GetParentEntity()))
+        if(GetParentEntity().IsStatic())
             return;
 
         auto rot_v = transform->GetRotationXM();

--- a/nc/source/ui/editor/EditorControls.h
+++ b/nc/source/ui/editor/EditorControls.h
@@ -8,7 +8,7 @@
 
 namespace nc::ui::editor::controls
 {
-    auto SelectedEntity = EntityTraits::NullHandle;
+    auto SelectedEntity = Entity::Null();
     const auto TitleBarHeight = 40.0f;
     const auto DefaultItemWidth = 60.0f;
     const auto SceneGraphPanelWidth = 300;
@@ -62,8 +62,8 @@ namespace nc::ui::editor::controls
 
             if(ImGui::BeginChild("EntityPanel", {0,0}, true))
             {
-                if(SelectedEntity != EntityTraits::NullHandle)
-                    controls::EntityPanel(registry, static_cast<Entity>(SelectedEntity));
+                if(SelectedEntity.Valid())
+                    controls::EntityPanel(registry, SelectedEntity);
 
             } ImGui::EndChild();
 
@@ -72,16 +72,15 @@ namespace nc::ui::editor::controls
 
     void SceneGraphNode(registry_type* registry, Entity entity, Tag* tag, Transform* transform)
     {
-        auto handleValue = static_cast<EntityTraits::underlying_type>(entity);
-        ImGui::PushID(handleValue);
+        ImGui::PushID(entity.Index());
 
         auto flags = 0;
-        if(SelectedEntity == handleValue)
+        if(SelectedEntity == entity)
             flags = flags | ImGuiTreeNodeFlags_Framed;
 
         auto open = ImGui::TreeNodeEx(tag->Value().data(), flags);
         if(ImGui::IsItemClicked())
-            SelectedEntity = handleValue;
+            SelectedEntity = entity;
         
         if(open)
         {
@@ -98,16 +97,15 @@ namespace nc::ui::editor::controls
     {
         if(!registry->Contains<Entity>(entity)) // entity may have been deleted
         {
-            SelectedEntity = EntityTraits::NullHandle;
+            SelectedEntity = Entity::Null();
             return;
         }
 
         ImGui::Separator();
         ImGui::Text("Tag     %s", registry->Get<Tag>(entity)->Value().data());
-        ImGui::Text("Index   %d", EntityUtils::Index(entity));
-        ImGui::Text("Version %d", EntityUtils::Version(entity));
-        ImGui::Text("Layer   %d", EntityUtils::Layer(entity));
-        ImGui::Text("Static  %s", EntityUtils::IsStatic(entity) ? "True" : "False");
+        ImGui::Text("Index   %d", entity.Index());
+        ImGui::Text("Layer   %d", entity.Layer());
+        ImGui::Text("Static  %s", entity.IsStatic() ? "True" : "False");
 
         if (auto* transform = registry->Get<Transform>(entity); transform)
         {
@@ -298,7 +296,7 @@ namespace nc::ui::editor::controls
             {
                 ImGui::Indent();
                 for(const auto& component : components)
-                    ImGui::Text("Handle: %5u  |  Address: %p", EntityUtils::Index(component.GetParentEntity()), static_cast<const void*>(&component));
+                    ImGui::Text("Handle: %5u  |  Address: %p", component.GetParentEntity().Index(), static_cast<const void*>(&component));
                 ImGui::Unindent();
             }
             ImGui::Unindent();

--- a/nc/test/unit/Entity_unit_tests.cpp
+++ b/nc/test/unit/Entity_unit_tests.cpp
@@ -6,8 +6,8 @@ using namespace nc;
 TEST(Entity_unit_tests, Null_ReturnsNullHandle)
 {
     auto handle = Entity::Null();
-    auto actual = static_cast<EntityTraits::underlying_type>(handle);
-    auto expected = EntityTraits::NullHandle;
+    auto actual = static_cast<Entity::index_type>(handle);
+    auto expected = Entity::NullIndex;
     EXPECT_EQ(actual, expected);
 }
 
@@ -20,115 +20,61 @@ TEST(Entity_unit_tests, Valid_NullHandle_ReturnsFalse)
 
 TEST(Entity_unit_tests, Valid_NonNullHandle_ReturnsTrue)
 {
-    auto handle = Entity{0u};
+    auto handle = Entity{0u, 0u, Entity::Flags::None};
     auto actual = handle.Valid();
     EXPECT_TRUE(actual);
 }
 
 TEST(Entity_unit_tests, Equality_SameHandles_ReturnsTrue)
 {
-    auto h1 = Entity{0u};
+    auto h1 = Entity{0u, 0u, Entity::Flags::None};
     auto h2 = h1;
     EXPECT_EQ(h1, h2);
 }
 
 TEST(Entity_unit_tests, Equality_DifferentHandles_ReturnsFalse)
 {
-    auto h1 = Entity{0u};
-    auto h2 = Entity{1u};
+    auto h1 = Entity{0u, 0u, Entity::Flags::None};
+    auto h2 = Entity{1u, 0u, Entity::Flags::None};
     EXPECT_NE(h1, h2);
-}
-
-TEST(Entity_unit_tests, Join_ReturnsCorrectBitset)
-{
-    EntityTraits::index_type index = 1u;
-    EntityTraits::version_type version = 0u;
-    EntityTraits::layer_type layer = 2u;
-    EntityTraits::flags_type flags = 1u;
-    EntityTraits::underlying_type i_shift = static_cast<EntityTraits::underlying_type>(index);
-    EntityTraits::underlying_type v_shift = static_cast<EntityTraits::underlying_type>(version) << EntityTraits::VersionShift;
-    EntityTraits::underlying_type l_shift = static_cast<EntityTraits::underlying_type>(layer) << EntityTraits::LayerShift;
-    EntityTraits::underlying_type f_shift = static_cast<EntityTraits::underlying_type>(flags) << EntityTraits::FlagsShift;
-    EntityTraits::underlying_type expected = i_shift | v_shift | l_shift | f_shift;
-    EntityTraits::underlying_type actual = EntityUtils::Join(index, version, layer, flags);
-    EXPECT_EQ(actual, expected);
 }
 
 TEST(Entity_unit_tests, Index_ExtractsIndex)
 {
-    EntityTraits::index_type expected = 5u;
-    auto handle = Entity{EntityUtils::Join(expected, 1u, 2u, 3u)};
-    EntityTraits::index_type actual = EntityUtils::Index(handle);
-    EXPECT_EQ(actual, expected);
-}
-
-TEST(Entity_unit_tests, Version_ExtractsVersion)
-{
-    EntityTraits::version_type expected = 3u;
-    auto handle = Entity{EntityUtils::Join(1u, expected, 2u, 3u)};
-    EntityTraits::version_type actual = EntityUtils::Version(handle);
+    Entity::index_type expected = 5u;
+    auto handle = Entity{expected, 2u, 3u};
+    Entity::index_type actual = handle.Index();
     EXPECT_EQ(actual, expected);
 }
 
 TEST(Entity_unit_tests, Layer_ExtractsLayer)
 {
-    EntityTraits::layer_type expected = 2u;
-    auto handle = Entity{EntityUtils::Join(3u, 1u, expected, 3u)};
-    EntityTraits::layer_type actual = EntityUtils::Layer(handle);
+    Entity::layer_type expected = 2u;
+    auto handle = Entity{3u, expected, 3u};
+    Entity::layer_type actual = handle.Layer();
     EXPECT_EQ(actual, expected);
 }
 
 TEST(Entity_unit_tests, Flags_ExtractsFlags)
 {
-    EntityTraits::flags_type expected = 2u;
-    auto handle = Entity{EntityUtils::Join(0u, 1u, 2u, expected)};
-    EntityTraits::flags_type actual = EntityUtils::Flags(handle);
+    Entity::flags_type expected = 2u;
+    auto handle = Entity{0u, 1u, expected};
+    Entity::flags_type actual = handle.Flags();
     EXPECT_EQ(actual, expected);
 }
 
 TEST(Entity_unit_tests, IsStatic_FlagSet_ReturnsTrue)
 {
-    auto flags = EntityFlags::Static;
-    auto handle = Entity{EntityUtils::Join(1u, 1u, 1u, flags)};
-    EXPECT_TRUE(EntityUtils::IsStatic(handle));
+    auto flags = Entity::Flags::Static;
+    auto handle = Entity{1u, 1u, flags};
+    EXPECT_TRUE(handle.IsStatic());
 }
 
 TEST(Entity_unit_tests, IsStatic_FlagNotSet_ReturnsFalse)
 {
     auto flags = EntityFlags::None;
-    auto handle = Entity{EntityUtils::Join(1u, 1u, 1u, flags)};
-    EXPECT_FALSE(EntityUtils::IsStatic(handle));
-}
-
-TEST(Entity_unit_tests, SetVersion_OnlyVersionChanged)
-{
-    EntityTraits::index_type index = 1u;
-    EntityTraits::version_type version = 8u;
-    EntityTraits::layer_type layer = 3u;
-    EntityTraits::flags_type flags = 2u;
-    auto handle = Entity{EntityUtils::Join(index, version, layer, flags)};
-    EntityTraits::version_type newVersion = 1u;
-    auto updatedHandle = EntityUtils::SetVersion(handle, newVersion);
-    EXPECT_EQ(index, EntityUtils::Index(updatedHandle));
-    EXPECT_EQ(newVersion, EntityUtils::Version(updatedHandle));
-    EXPECT_EQ(layer, EntityUtils::Layer(updatedHandle));
-    EXPECT_EQ(flags, EntityUtils::Flags(updatedHandle));
-}
-
-TEST(Entity_unit_tests, Recyle_ValuesUpdated)
-{
-    EntityTraits::index_type index = 0u;
-    EntityTraits::version_type version = 2u;
-    EntityTraits::layer_type layer = 0u;
-    EntityTraits::flags_type flags = 1u;
-    auto handle = Entity{EntityUtils::Join(index, version, layer, flags)};
-    EntityTraits::layer_type newLayer = 1u;
-    EntityTraits::flags_type newFlags = 0u;
-    auto updatedHandle = EntityUtils::Recycle(handle, newLayer, newFlags);
-    EXPECT_EQ(index, EntityUtils::Index(updatedHandle));
-    EXPECT_EQ(version + 1u, EntityUtils::Version(updatedHandle));
-    EXPECT_EQ(newLayer, EntityUtils::Layer(updatedHandle));
-    EXPECT_EQ(newFlags, EntityUtils::Flags(updatedHandle));
+    auto handle = Entity{1u, 1u, flags)};
+    EXPECT_FALSE(handle.IsStatic());
 }
 
 int main(int argc, char ** argv)

--- a/nc/test/unit/Registry_unit_tests.cpp
+++ b/nc/test/unit/Registry_unit_tests.cpp
@@ -52,11 +52,11 @@ struct FakeAutoComponent : public AutoComponent
     int value;
 };
 
-constexpr auto Handle1 = Entity{EntityUtils::Join(0u, 0u, 0u, 0u)};
-constexpr auto Handle2 = Entity{EntityUtils::Join(1u, 0u, 0u, 0u)};
-constexpr auto Handle3 = Entity{EntityUtils::Join(2u, 0u, 0u, 0u)};
-constexpr auto Handle4 = Entity{EntityUtils::Join(3u, 0u, 0u, 0u)};
-constexpr auto Handle5 = Entity{EntityUtils::Join(4u, 0u, 0u, 0u)};
+constexpr auto Handle1 = Entity{0u, 0u, 0u};
+constexpr auto Handle2 = Entity{1u, 0u, 0u};
+constexpr auto Handle3 = Entity{2u, 0u, 0u};
+constexpr auto Handle4 = Entity{3u, 0u, 0u};
+constexpr auto Handle5 = Entity{4u, 0u, 0u};
 const auto TestInfo = EntityInfo{};
 
 class Registry_unit_tests : public ::testing::Test
@@ -140,7 +140,7 @@ TEST_F(Registry_unit_tests, AddComponent_ValidCall_ConstructsObject)
 
 TEST_F(Registry_unit_tests, AddComponent_BadEntity_Throws)
 {
-    EXPECT_THROW(registry.Add<Fake1>(Entity{0u}, 1), std::runtime_error);
+    EXPECT_THROW(registry.Add<Fake1>(Entity{0u, 0u, 0u}, 1), std::runtime_error);
 }
 
 TEST_F(Registry_unit_tests, AddComponent_ReplaceAfterRemove_ConstructsObject)

--- a/project/source/click_events/ClickEvents.cpp
+++ b/project/source/click_events/ClickEvents.cpp
@@ -13,8 +13,8 @@
 namespace
 {
     std::function<void(nc::physics::LayerMask)> LayerSelectCallback = nullptr;
-    const auto CoinLayer = nc::EntityTraits::layer_type{1u};
-    const auto TokenLayer = nc::EntityTraits::layer_type{2u};
+    const auto CoinLayer = nc::Entity::layer_type{1u};
+    const auto TokenLayer = nc::Entity::layer_type{2u};
     const auto MaskNone = nc::physics::LayerMask32None;
     const auto MaskAll = nc::physics::LayerMask32All;
     const auto MaskCoin = nc::physics::LayerMask32{1u};

--- a/project/source/click_events/Clickable.h
+++ b/project/source/click_events/Clickable.h
@@ -26,7 +26,7 @@ namespace nc::sample
           m_Tag{std::move(tag)}
     {
         physics::RegisterClickable(this);
-        auto layer = EntityUtils::Layer(entity);
+        auto layer = entity.Layer();
         IClickable::layers = physics::ToLayerMask(layer);
     }
 

--- a/project/source/collision_events/CollisionEvents.cpp
+++ b/project/source/collision_events/CollisionEvents.cpp
@@ -91,16 +91,16 @@ namespace nc::sample
         registry->Add<PhysicsBody>(greenDisc, PhysicsProperties{});
 
         // Static Objects
-        auto ground = prefab::Create(registry, prefab::Resource::CubeRed, {.position = Vector3{0.0f, -1.5f, 0.0f}, .scale = Vector3{25.0f, 1.0f, 25.0f}, .tag = "Ground", .flags = EntityFlags::Static});
+        auto ground = prefab::Create(registry, prefab::Resource::CubeRed, {.position = Vector3{0.0f, -1.5f, 0.0f}, .scale = Vector3{25.0f, 1.0f, 25.0f}, .tag = "Ground", .flags = Entity::Flags::Static});
         registry->Add<Collider>(ground, BoxProperties{}, false);
 
-        auto redCube = prefab::Create(registry, prefab::Resource::CubeRed, {.position = Vector3{3.5f, 0.0f, 4.5f}, .scale = Vector3::Splat(1.0f), .tag = "Big Red Cube", .flags = EntityFlags::Static});
+        auto redCube = prefab::Create(registry, prefab::Resource::CubeRed, {.position = Vector3{3.5f, 0.0f, 4.5f}, .scale = Vector3::Splat(1.0f), .tag = "Big Red Cube", .flags = Entity::Flags::Static});
         registry->Add<Collider>(redCube, BoxProperties{}, false);
 
-        auto bigRedSphere = prefab::Create(registry, prefab::Resource::SphereRed, {.position = Vector3{-4.5f, 0.0f, 5.0f}, .scale = Vector3::Splat(3.0f), .tag = "Big Red Sphere", .flags = EntityFlags::Static});
+        auto bigRedSphere = prefab::Create(registry, prefab::Resource::SphereRed, {.position = Vector3{-4.5f, 0.0f, 5.0f}, .scale = Vector3::Splat(3.0f), .tag = "Big Red Sphere", .flags = Entity::Flags::Static});
         registry->Add<Collider>(bigRedSphere, SphereProperties{}, false);
 
-        auto longRedBox = prefab::Create(registry, prefab::Resource::CubeRed, {.position = Vector3::Back() * 3.0f, .scale = Vector3{5.0f, 1.0f, 1.0f}, .tag = "Long Red Box", .flags = EntityFlags::Static});
+        auto longRedBox = prefab::Create(registry, prefab::Resource::CubeRed, {.position = Vector3::Back() * 3.0f, .scale = Vector3{5.0f, 1.0f, 1.0f}, .tag = "Long Red Box", .flags = Entity::Flags::Static});
         registry->Add<Collider>(longRedBox, BoxProperties{}, true);
     }
 

--- a/project/source/joints_test/JointsTest.cpp
+++ b/project/source/joints_test/JointsTest.cpp
@@ -69,7 +69,7 @@ namespace nc::sample
 
         // Ramp
         {
-            auto ramp = prefab::Create(registry, prefab::Resource::RampRed, {.position = Vector3{9.0f, 2.6f, 6.0f}, .scale = Vector3::Splat(3.0f), .flags = EntityFlags::Static});
+            auto ramp = prefab::Create(registry, prefab::Resource::RampRed, {.position = Vector3{9.0f, 2.6f, 6.0f}, .scale = Vector3::Splat(3.0f), .flags = Entity::Flags::Static});
             registry->Add<ConcaveCollider>(ramp, "project/assets/mesh_colliders/ramp.nca");
         }
 

--- a/project/source/shared/Spawner/SpawnBehavior.h
+++ b/project/source/shared/Spawner/SpawnBehavior.h
@@ -29,7 +29,7 @@ namespace nc::sample
         Vector3 rotationAxisRandomRange = Vector3::Zero();
         float thetaRandomRange = 0.0f;
 
-        EntityTraits::layer_type layer = 1u;
+        Entity::layer_type layer = 1u;
         bool spawnAsStaticEntity = false;
     };
 }

--- a/project/source/shared/Spawner/Spawner.h
+++ b/project/source/shared/Spawner/Spawner.h
@@ -37,7 +37,7 @@ namespace nc::sample
             prefab::Resource m_resource;
             bool m_applyConstantVelocity;
             bool m_applyConstantRotation;
-            EntityTraits::layer_type m_layer;
+            Entity::layer_type m_layer;
             bool m_spawnStaticEntities;
             size_t m_stagedAdditions;
             size_t m_stagedDeletions;

--- a/project/source/spawn_test/SpawnTest.cpp
+++ b/project/source/spawn_test/SpawnTest.cpp
@@ -58,14 +58,14 @@ namespace nc::sample
                                                                           });
 
         // Collider that destroys anything leaving its bounded area
-        auto killBox = registry->Add<Entity>({.scale = Vector3::Splat(100.0f), .tag = "KillBox", .flags = EntityFlags::Static});
+        auto killBox = registry->Add<Entity>({.scale = Vector3::Splat(100.0f), .tag = "KillBox", .flags = Entity::Flags::Static});
         registry->Add<Collider>(killBox, BoxProperties{}, true);
         registry->Add<KillBox>(killBox, registry);
 
-        auto platform = prefab::Create(registry, prefab::Resource::CubeBlue, {.position = Vector3{0.0f, -25.0f, 0.0f}, .scale = Vector3{35.0f, 6.0f, 35.0f}, .tag = "Platform", .flags = EntityFlags::Static});
+        auto platform = prefab::Create(registry, prefab::Resource::CubeBlue, {.position = Vector3{0.0f, -25.0f, 0.0f}, .scale = Vector3{35.0f, 6.0f, 35.0f}, .tag = "Platform", .flags = Entity::Flags::Static});
         registry->Add<Collider>(platform, BoxProperties{}, false);
 
-        auto bottomBox = prefab::Create(registry, prefab::Resource::CubeGreen, {.position = Vector3{0.0f, 0.0f, 0.0f}, .scale = Vector3::Splat(2.0f), .flags = EntityFlags::None});
+        auto bottomBox = prefab::Create(registry, prefab::Resource::CubeGreen, {.position = Vector3{0.0f, 0.0f, 0.0f}, .scale = Vector3::Splat(2.0f), .flags = Entity::Flags::None});
         registry->Add<Collider>(bottomBox, BoxProperties{}, false);
         registry->Add<PhysicsBody>(bottomBox, PhysicsProperties{.mass = 4.0f, .useGravity = true});
 


### PR DESCRIPTION
Entity was unnecessarily complicated due to a mistake I made at some point regarding x64 calling conventions. As long as Entity is 64 bits or less, it can be passed by register, so all the bit shifting stuff isn't needed. Also, version isn't used anymore, so it can be removed.