### PR TITLE
fix warmstarting

### DIFF
--- a/nc/source/physics/PhysicsConstants.h
+++ b/nc/source/physics/PhysicsConstants.h
@@ -15,15 +15,15 @@ namespace nc::physics
     constexpr bool EnableJointWarmstarting  = true;  // Start joint resolution from the most recent impulse or 0
     constexpr float WarmstartFactor = 0.5f;          // Percentage of previous impulse used to initialize constraints
 
-    /** Contact Tolerance */
-    constexpr float ContactBreakDistance = -0.01f; // How aggressively contact points are removed/retained
-    constexpr float PenetrationSlop = 0.01f;       // How far objects are allowed to penetrate
-
-    /** Position Correction */
+    /** Contact Behavior */
+    constexpr float ContactBreakDistance = -0.01f;        // How aggressively contact points are removed/retained
+    constexpr float PenetrationSlop = 0.01f;              // How far objects are allowed to penetrate
     constexpr bool EnableBaumgarteStabilization = true;   // Enable velocity-based position correction
     constexpr bool EnableDirectPositionCorrection = true; // Enable translation-based position correction
-    constexpr float BaumgarteFactor = 0.05f;              // Bias factor for baumgarte stabilization [0, 1]
-    constexpr float PositionCorrectionFactor = 0.2f;      // Percentage of mtv to use for direct position correction
+    constexpr float BaumgarteFactor = 0.1f;               // Bias factor for baumgarte stabilization [0, 1]
+    constexpr float PositionCorrectionFactor = 0.333f;    // Percentage of mtv to use for direct position correction
+    constexpr bool EnableRestitutionSlop = true;          // Enabled zeroing of restitution below a threshold
+    constexpr float RestitutionSlop = 0.1f;               // Velocity threshold for applying restitution
 
     /** Sleeping Behavior */
     constexpr bool EnableSleeping = false;   // Allow disabling simulation of inactive bodies

--- a/nc/source/physics/PhysicsPipelineTypes.cpp
+++ b/nc/source/physics/PhysicsPipelineTypes.cpp
@@ -254,7 +254,7 @@ namespace nc::physics
                 continue;
             }
 
-            auto projectedPoint = contact.worldPointA - contact.normal * contact.depth;
+            auto projectedPoint = contact.worldPointA + contact.normal * contact.depth;
             auto projectedDifference = contact.worldPointB - projectedPoint;
             auto distance2d = SquareMagnitude(projectedDifference);
             if(distance2d > SquareContactBreakDistance)

--- a/nc/source/physics/dynamics/Constraint.h
+++ b/nc/source/physics/dynamics/Constraint.h
@@ -34,7 +34,6 @@ namespace nc::physics
     /** Velocity-based contact constraint. */
     struct ContactConstraint
     {
-        Entity entityA, entityB;
         PhysicsBody* physBodyA, *physBodyB;
         ConstraintMatrix jNormal, jTangent, jBitangent;
         DirectX::XMMATRIX invInertiaA, invInertiaB;

--- a/project/source/joints_test/ForceBasedController.h
+++ b/project/source/joints_test/ForceBasedController.h
@@ -9,16 +9,18 @@ namespace nc::sample
     class ForceBasedController : public AutoComponent
     {
         public:
-            ForceBasedController(Entity entity, Registry* registry);
+            ForceBasedController(Entity entity, Registry* registry, float force = 0.7f);
             void FixedUpdate() override;
 
         private:
             Registry* m_registry;
+            float m_force;
     };
 
-    inline ForceBasedController::ForceBasedController(Entity entity, Registry* registry)
+    inline ForceBasedController::ForceBasedController(Entity entity, Registry* registry, float force)
         : AutoComponent{entity},
-          m_registry{registry}
+          m_registry{registry},
+          m_force{force}
     {
     }
 
@@ -29,30 +31,25 @@ namespace nc::sample
         if(!body)
             return;
 
-        constexpr auto move = Vector3{0.0f, 0.0f, 0.7f};
-        constexpr auto sidestep = Vector3{0.7f, 0.0f, 0.0f};
-        constexpr auto jump = Vector3{0.0f, 4.0f, 0.0f};
-        constexpr auto rotate = Vector3{0.0f, 0.6f, 0.0f};
-
         if(input::GetKey(input::KeyCode::W))
-            body->ApplyImpulse(move);
+            body->ApplyImpulse(Vector3::Front() * m_force);
 
         if(input::GetKey(input::KeyCode::S))
-            body->ApplyImpulse(-move);
+            body->ApplyImpulse(Vector3::Back() * m_force);
 
         if(input::GetKey(input::KeyCode::A))
-            body->ApplyImpulse(-sidestep);
+            body->ApplyImpulse(Vector3::Left() * m_force);
         
         if(input::GetKey(input::KeyCode::D))
-            body->ApplyImpulse(sidestep);
+            body->ApplyImpulse(Vector3::Right() * m_force);
 
         if(input::GetKey(input::KeyCode::Space))
-            body->ApplyImpulse(jump);
+            body->ApplyImpulse(Vector3::Up() * 4.0f);
 
         if(input::GetKey(input::KeyCode::Q))
-            body->ApplyTorqueImpulse(-rotate);
+            body->ApplyTorqueImpulse(Vector3::Down() * 0.6f);
 
         if(input::GetKey(input::KeyCode::E))
-            body->ApplyTorqueImpulse(rotate);
+            body->ApplyTorqueImpulse(Vector3::Up() * 0.6f);
     }
 }


### PR DESCRIPTION
* Fixed warm starting only being applied to joints.
* Removed entities from ContactConstraint - they aren't used anymore.
* Added restitution slop so contact resolution can optionally skip adding restitution if the relative velocity between points is low.
* Changed resolve contact code a bit. The general idea is we can skip some calculations if one of the objects doesn't have a PhysicsBody
    - ComputeDeltas is now ComputeLinearVelocity and ComputeAngularVelocity
    - MultiplyJVContact is now ComputeLagrangeMultipliers. Clamping was moved into here.