### PR TITLE
Improve registry callbacks

### DIFF
--- a/docs/Overview.md
+++ b/docs/Overview.md
@@ -44,11 +44,6 @@ Pooled components are intended for types that are numerous and processed in bulk
 ### Free Component
 Free components should be used for types that appear in small numbers - an input handler, for example. They also have the advantage of being pointer stable. Free components are grouped according to the Entities they belong to and do not have the additional memory overhead of pooled components. This, however, results in random access times that are linear in terms of the number of free components attached to an Entity. User-defined free components should derive from [FreeComponent](../nc/include/ecs/component/Component.h).
 
-### Systems, Callbacks, and Storage Policies
-Pooled components usually want to be processed as a whole or in batches by an external system. This can be set up in whatever way best suits the scenario. A simple solution is to implement the systems as FreeComponents attached to a single persistent Entity, which can then be invoked by a [FrameLogic or FixedLogic](EngineComponents.md#logic) component.
-
-Callbacks can be set in the Registry to receive on add/remove notifications for a particular type. First, a specialization of storage_policy must be provided specifying which callbacks will be used. Then `Registry::RegisterOnAddCallback<T>(cb)` and/or `Registry::RegisterOnRemoveCallback<T>(cb)` can be used. The callback signatures are `void Func(T&)` for additions and `void Func(Entity)` for removals.
-
 ## Registry
 -----------
 The registry contains storage for all entities and components and manages the associations between them. In order for objects of these types to be recognized by NcEngine, they must be created through one of the registry's Add member functions. There are also functions for retreiving, removing, and viewing ranges of objects, among other things.
@@ -72,6 +67,9 @@ When removing an Entity:
 
 When removing a Component:
 * It is destroyed before returning from Remove and changes are immediately reflected in returned ranges.
+
+### Callbacks
+It is possible to subscribe to on add and on remove events through the `Registry`. This must be enabled on a per-type basis by providing a specialization of `StoragePolicy` and specifying the allowed callbacks. Once enabled, a `Signal` can be retrieved through `Registry::OnAdd<T>()` and `Registry::OnRemove<T>()`, which can be used to connect the desired callable(s). Callable signatures should match `void F(T&)` for on add events and `void F(Entity)` for on remove.
 
 ## Views
 --------

--- a/sdk/engine/include/ecs/Registry.h
+++ b/sdk/engine/include/ecs/Registry.h
@@ -89,7 +89,6 @@ namespace nc
             auto StorageFor() const -> const detail::EntityStorage*;
 
             void CommitStagedChanges();
-            void VerifyCallbacks();
             void Clear();
 
         private:

--- a/sdk/engine/include/ecs/Registry.h
+++ b/sdk/engine/include/ecs/Registry.h
@@ -70,10 +70,10 @@ namespace nc
             void RegisterComponentType();
 
             template<PooledComponent T>
-            void RegisterOnAddCallback(detail::SystemCallbacks<T>::on_add_type func);
+            auto OnAdd() -> Signal<T&>&;
 
             template<PooledComponent T>
-            void RegisterOnRemoveCallback(detail::SystemCallbacks<T>::on_remove_type func);
+            auto OnRemove() -> Signal<Entity>&;
 
             /** Engine Functions */
             template<PooledComponent T>
@@ -308,17 +308,15 @@ namespace nc
     }
 
     template<PooledComponent T>
-    void Registry::RegisterOnAddCallback(typename detail::SystemCallbacks<T>::on_add_type func)
+    auto Registry::OnAdd() -> Signal<T&>&
     {
-        static_assert(storage_policy<T>::requires_on_add_callback, "Cannot register an OnAdd callback unless specified by storage_policy<T>");
-        StorageFor<T>()->RegisterOnAddCallback(std::move(func));
+        return StorageFor<T>()->OnAdd();
     }
 
     template<PooledComponent T>
-    void Registry::RegisterOnRemoveCallback(typename detail::SystemCallbacks<T>::on_remove_type func)
+    auto Registry::OnRemove() -> Signal<Entity>&
     {
-        static_assert(storage_policy<T>::requires_on_remove_callback, "Cannot register an OnRemove callback unless specified by storage_policy<T>");
-        StorageFor<T>()->RegisterOnRemoveCallback(std::move(func));
+        return StorageFor<T>()->OnRemove();
     }
 
     inline void Registry::CommitStagedChanges()

--- a/sdk/engine/include/ecs/Registry.h
+++ b/sdk/engine/include/ecs/Registry.h
@@ -69,10 +69,10 @@ namespace nc
             template<PooledComponent T>
             void RegisterComponentType();
 
-            template<PooledComponent T>
+            template<PooledComponent T> requires StoragePolicy<T>::EnableOnAddCallbacks
             auto OnAdd() -> Signal<T&>&;
 
-            template<PooledComponent T>
+            template<PooledComponent T> requires StoragePolicy<T>::EnableOnRemoveCallbacks
             auto OnRemove() -> Signal<Entity>&;
 
             /** Engine Functions */
@@ -306,13 +306,13 @@ namespace nc
         m_registeredStorage.push_back(std::move(storage));
     }
 
-    template<PooledComponent T>
+    template<PooledComponent T> requires StoragePolicy<T>::EnableOnAddCallbacks
     auto Registry::OnAdd() -> Signal<T&>&
     {
         return StorageFor<T>()->OnAdd();
     }
 
-    template<PooledComponent T>
+    template<PooledComponent T> requires StoragePolicy<T>::EnableOnRemoveCallbacks
     auto Registry::OnRemove() -> Signal<Entity>&
     {
         return StorageFor<T>()->OnRemove();

--- a/sdk/engine/include/ecs/component/Component.h
+++ b/sdk/engine/include/ecs/component/Component.h
@@ -60,10 +60,10 @@ namespace nc
     struct DefaultStoragePolicy
     {
         /** @brief Allows OnAdd callbacks to be set in the registry. */
-        static constexpr bool enable_on_add_callbacks = false;
+        static constexpr bool EnableOnAddCallbacks = false;
 
         /** @brief Allows OnRemove callbacks to be set in the registry. */
-        static constexpr bool enable_on_remove_callbacks = false;
+        static constexpr bool EnableOnRemoveCallbacks = false;
     };
 
     /**

--- a/sdk/engine/include/ecs/component/Component.h
+++ b/sdk/engine/include/ecs/component/Component.h
@@ -57,13 +57,13 @@ namespace nc
                               !std::derived_from<T, FreeComponent>;
 
     /** @brief Default storage behavior for pooled components. */
-    struct default_storage_policy
+    struct DefaultStoragePolicy
     {
-        /** @brief Requires an OnAdd callback to be set in the registry. */
-        static constexpr bool requires_on_add_callback = false;
+        /** @brief Allows OnAdd callbacks to be set in the registry. */
+        static constexpr bool enable_on_add_callbacks = false;
 
-        /** @brief Requires an OnRemove callback to be set in the registry. */
-        static constexpr bool requires_on_remove_callback = false;
+        /** @brief Allows OnRemove callbacks to be set in the registry. */
+        static constexpr bool enable_on_remove_callbacks = false;
     };
 
     /**
@@ -73,7 +73,7 @@ namespace nc
      * @tparam T A component, which models PooledComponent, to customize.
      */
     template<PooledComponent T>
-    struct storage_policy : default_storage_policy {};
+    struct StoragePolicy : DefaultStoragePolicy {};
 
     #ifdef NC_EDITOR_ENABLED
     namespace internal

--- a/sdk/engine/include/ecs/component/ConcaveCollider.h
+++ b/sdk/engine/include/ecs/component/ConcaveCollider.h
@@ -17,10 +17,10 @@ namespace nc
     };
 
     template<>
-    struct storage_policy<ConcaveCollider> : default_storage_policy
+    struct StoragePolicy<ConcaveCollider> : DefaultStoragePolicy
     {
-        static constexpr bool requires_on_add_callback = true;
-        static constexpr bool requires_on_remove_callback = true;
+        static constexpr bool enable_on_add_callbacks = true;
+        static constexpr bool enable_on_remove_callbacks = true;
     };
 
     #ifdef NC_EDITOR_ENABLED

--- a/sdk/engine/include/ecs/component/ConcaveCollider.h
+++ b/sdk/engine/include/ecs/component/ConcaveCollider.h
@@ -19,8 +19,8 @@ namespace nc
     template<>
     struct StoragePolicy<ConcaveCollider> : DefaultStoragePolicy
     {
-        static constexpr bool enable_on_add_callbacks = true;
-        static constexpr bool enable_on_remove_callbacks = true;
+        static constexpr bool EnableOnAddCallbacks = true;
+        static constexpr bool EnableOnRemoveCallbacks = true;
     };
 
     #ifdef NC_EDITOR_ENABLED

--- a/sdk/engine/include/ecs/component/ParticleEmitter.h
+++ b/sdk/engine/include/ecs/component/ParticleEmitter.h
@@ -66,10 +66,10 @@ namespace nc
     };
 
     template<>
-    struct storage_policy<ParticleEmitter> : default_storage_policy
+    struct StoragePolicy<ParticleEmitter> : DefaultStoragePolicy
     {
-        static constexpr bool requires_on_add_callback = true;
-        static constexpr bool requires_on_remove_callback = true;
+        static constexpr bool enable_on_add_callbacks = true;
+        static constexpr bool enable_on_remove_callbacks = true;
     };
 
     #ifdef NC_EDITOR_ENABLED

--- a/sdk/engine/include/ecs/component/ParticleEmitter.h
+++ b/sdk/engine/include/ecs/component/ParticleEmitter.h
@@ -68,8 +68,8 @@ namespace nc
     template<>
     struct StoragePolicy<ParticleEmitter> : DefaultStoragePolicy
     {
-        static constexpr bool enable_on_add_callbacks = true;
-        static constexpr bool enable_on_remove_callbacks = true;
+        static constexpr bool EnableOnAddCallbacks = true;
+        static constexpr bool EnableOnRemoveCallbacks = true;
     };
 
     #ifdef NC_EDITOR_ENABLED

--- a/sdk/engine/include/ecs/component/PointLight.h
+++ b/sdk/engine/include/ecs/component/PointLight.h
@@ -59,8 +59,8 @@ namespace nc
     template<>
     struct StoragePolicy<PointLight> : DefaultStoragePolicy
     {
-        static constexpr bool enable_on_add_callbacks = true;
-        static constexpr bool enable_on_remove_callbacks = true;
+        static constexpr bool EnableOnAddCallbacks = true;
+        static constexpr bool EnableOnRemoveCallbacks = true;
     };
 
     #ifdef NC_EDITOR_ENABLED

--- a/sdk/engine/include/ecs/component/PointLight.h
+++ b/sdk/engine/include/ecs/component/PointLight.h
@@ -57,10 +57,10 @@ namespace nc
     static_assert(sizeof(PointLightInfo) == PointLightInfoSize, "PointLight::PointLight Size of m_info must be 128 bytes.");
     
     template<>
-    struct storage_policy<PointLight> : default_storage_policy
+    struct StoragePolicy<PointLight> : DefaultStoragePolicy
     {
-        static constexpr bool requires_on_add_callback = true;
-        static constexpr bool requires_on_remove_callback = true;
+        static constexpr bool enable_on_add_callbacks = true;
+        static constexpr bool enable_on_remove_callbacks = true;
     };
 
     #ifdef NC_EDITOR_ENABLED

--- a/sdk/engine/include/ecs/detail/PerComponentStorage.h
+++ b/sdk/engine/include/ecs/detail/PerComponentStorage.h
@@ -106,7 +106,7 @@ namespace nc::detail
         NC_ASSERT(!Contains(entity), "Cannot add multiple components of the same type");
         auto& [emplacedEntity, emplacedComponent] = m_stagingPool.emplace_back(entity, T{entity, std::forward<Args>(args)...});
 
-        if constexpr(StoragePolicy<T>::enable_on_add_callbacks)
+        if constexpr(StoragePolicy<T>::EnableOnAddCallbacks)
         {
             m_onAdd.Emit(emplacedComponent);
         }
@@ -134,7 +134,7 @@ namespace nc::detail
         if(sparseIndex != movedEntity.Index())
             sparseArray.at(movedEntity.Index()) = poolIndex;
 
-        if constexpr(StoragePolicy<T>::enable_on_remove_callbacks)
+        if constexpr(StoragePolicy<T>::EnableOnRemoveCallbacks)
         {
             m_onRemove.Emit(entity);
         }

--- a/sdk/engine/source/ecs/ParticleEmitterSystem.cpp
+++ b/sdk/engine/source/ecs/ParticleEmitterSystem.cpp
@@ -15,17 +15,10 @@ namespace nc::ecs
           m_dt{ dt },
           m_random{ Random() },
           m_getCamera{ getCamera },
-          m_registry{ registry }
+          m_registry{ registry },
+          m_onAddConnection{ registry->OnAdd<ParticleEmitter>().Connect(this, &ParticleEmitterSystem::Add) },
+          m_onRemoveConnection{ registry->OnRemove<ParticleEmitter>().Connect(this, &ParticleEmitterSystem::Remove)}
     {
-        registry->RegisterOnAddCallback<ParticleEmitter>
-        (
-            [this](ParticleEmitter& emitter) { this->Add(emitter); }
-        );
-
-        registry->RegisterOnRemoveCallback<ParticleEmitter>
-        (
-            [this](Entity entity) { this->Remove(entity); }
-        );
     }
 
     void ParticleEmitterSystem::Run()

--- a/sdk/engine/source/ecs/ParticleEmitterSystem.h
+++ b/sdk/engine/source/ecs/ParticleEmitterSystem.h
@@ -37,5 +37,7 @@ namespace nc::ecs
             Random m_random;
             std::function<nc::Camera* ()> m_getCamera;
             Registry* m_registry;
+            Connection<ParticleEmitter&> m_onAddConnection;
+            Connection<Entity> m_onRemoveConnection;
     };
 } // namespace nc::ecs

--- a/sdk/engine/source/ecs/PointLightSystem.cpp
+++ b/sdk/engine/source/ecs/PointLightSystem.cpp
@@ -5,18 +5,10 @@
 namespace nc::ecs
 {
     PointLightSystem::PointLightSystem(Registry* registry)
-        : m_registry{registry},
+        : m_onAddConnection{registry->OnAdd<PointLight>().Connect([this](PointLight&){ this->m_isSystemDirty = true; })},
+          m_onRemoveConnection{registry->OnRemove<PointLight>().Connect([this](Entity){ this->m_isSystemDirty = true; })},
           m_isSystemDirty{true}
     {
-        m_registry->RegisterOnAddCallback<PointLight>
-        (
-            [this](PointLight&) { m_isSystemDirty = true; }
-        );
-
-        m_registry->RegisterOnRemoveCallback<PointLight>
-        (
-            [this](Entity) { m_isSystemDirty = true; }
-        );
     }
 
     bool PointLightSystem::CheckDirtyAndReset()

--- a/sdk/engine/source/ecs/PointLightSystem.h
+++ b/sdk/engine/source/ecs/PointLightSystem.h
@@ -1,7 +1,11 @@
 #pragma once
 
+#include "utility/Signal.h"
+
 namespace nc
 {
+    class Entity;
+    class PointLight;
     class Registry;
 }
 
@@ -13,14 +17,15 @@ namespace nc::ecs
             PointLightSystem(Registry* registry);
             PointLightSystem(PointLightSystem&&) = delete;
             PointLightSystem(const PointLightSystem&) = delete;
-            PointLightSystem& operator = (PointLightSystem&&) = delete;
-            PointLightSystem& operator = (const PointLightSystem&) = delete;
+            PointLightSystem& operator=(PointLightSystem&&) = delete;
+            PointLightSystem& operator=(const PointLightSystem&) = delete;
 
             bool CheckDirtyAndReset();
             void Clear();
 
         private:
-            Registry* m_registry;
+            Connection<PointLight&> m_onAddConnection;
+            Connection<Entity> m_onRemoveConnection;
             bool m_isSystemDirty;
     };
 }

--- a/sdk/engine/source/ecs/Registry.cpp
+++ b/sdk/engine/source/ecs/Registry.cpp
@@ -56,10 +56,4 @@ namespace nc
             storage->Clear();
         }
     }
-
-    void Registry::VerifyCallbacks()
-    {
-        for(auto& storage : m_registeredStorage)
-            storage->VerifyCallbacks();
-    }
 }

--- a/sdk/engine/source/engine/Runtime.cpp
+++ b/sdk/engine/source/engine/Runtime.cpp
@@ -70,7 +70,6 @@ namespace nc
     void Runtime::Start(std::unique_ptr<nc::Scene> initialScene)
     {
         V_LOG("Runtime::Start()");
-        m_context.registry.VerifyCallbacks();
         m_modules.sceneModule->ChangeScene(std::move(initialScene));
         m_modules.sceneModule->DoSceneSwap(this);
         m_isRunning = true;

--- a/sdk/engine/source/graphics/GraphicsModuleImpl.cpp
+++ b/sdk/engine/source/graphics/GraphicsModuleImpl.cpp
@@ -14,9 +14,9 @@ namespace
     struct GraphicsModuleStub : nc::GraphicsModule
     {
         GraphicsModuleStub(nc::Registry* reg)
+            : onAddConnection{reg->OnAdd<nc::PointLight>().Connect([](nc::PointLight&){})},
+              onRemoveConnection{reg->OnRemove<nc::PointLight>().Connect([](nc::Entity){})}
         {
-            reg->RegisterOnAddCallback<nc::PointLight>([](nc::PointLight&){});
-            reg->RegisterOnRemoveCallback<nc::PointLight>([](nc::Entity){});
         }
 
         void SetCamera(nc::Camera*) noexcept override {}
@@ -28,6 +28,8 @@ namespace
         void Clear() noexcept override {}
         auto BuildWorkload() -> std::vector<nc::Job> { return {}; }
 
+        nc::Connection<nc::PointLight&> onAddConnection;
+        nc::Connection<nc::Entity> onRemoveConnection;
         /** @todo Debug renderer is becoming a problem... */
         #ifdef NC_DEBUG_RENDERING_ENABLED
         nc::graphics::DebugRenderer debugRenderer;

--- a/sdk/engine/source/physics/PhysicsModuleImpl.cpp
+++ b/sdk/engine/source/physics/PhysicsModuleImpl.cpp
@@ -8,20 +8,15 @@ namespace
     struct BspTreeStub
     {
         BspTreeStub(nc::Registry* registry)
+            : onAddConnection{registry->OnAdd<nc::ConcaveCollider>().Connect(this, &BspTreeStub::OnAdd)},
+              onRemoveConnection{registry->OnRemove<nc::ConcaveCollider>().Connect(this, &BspTreeStub::OnRemove)}
         {
-            registry->RegisterOnAddCallback<nc::ConcaveCollider>
-            (
-                [this](nc::ConcaveCollider& collider){ this->OnAdd(collider); }
-            );
-            
-            registry->RegisterOnRemoveCallback<nc::ConcaveCollider>
-            (
-                [this](nc::Entity entity) { this->OnRemove(entity); }
-            );
         }
 
         void OnAdd(nc::ConcaveCollider&) {}
         void OnRemove(nc::Entity) {}
+        nc::Connection<nc::ConcaveCollider&> onAddConnection;
+        nc::Connection<nc::Entity> onRemoveConnection;
     };
 
     class PhysicsModuleStub : public nc::PhysicsModule

--- a/sdk/engine/source/physics/collision/BspTree.cpp
+++ b/sdk/engine/source/physics/collision/BspTree.cpp
@@ -72,19 +72,11 @@ namespace nc::physics
         : m_registry{registry},
           m_nodes{},
           m_triMeshes{},
-          m_results{}
+          m_results{},
+          m_onAddConnection{registry->OnAdd<ConcaveCollider>().Connect(this, &BspTree::OnAdd)},
+          m_onRemoveConnection{registry->OnRemove<ConcaveCollider>().Connect(this, &BspTree::OnRemove)}
     {
         m_nodes.push_back(LeafNode{});
-
-        registry->RegisterOnAddCallback<ConcaveCollider>
-        (
-            [this](ConcaveCollider& collider){ this->OnAdd(collider); }
-        );
-        
-        registry->RegisterOnRemoveCallback<ConcaveCollider>
-        (
-            [this](Entity entity) { this->OnRemove(entity); }
-        );
     }
 
     void BspTree::OnAdd(ConcaveCollider& collider)

--- a/sdk/engine/source/physics/collision/BspTree.h
+++ b/sdk/engine/source/physics/collision/BspTree.h
@@ -67,6 +67,8 @@ namespace nc::physics
             std::vector<node_type> m_nodes;
             std::vector<TriMesh> m_triMeshes;
             NarrowPhysicsResult m_results;
+            Connection<ConcaveCollider&> m_onAddConnection;
+            Connection<Entity> m_onRemoveConnection;
 
             void AddToTree(const TriMesh& mesh, size_t meshIndex, size_t currentNodeIndex);
             void AddToInnerNode(const TriMesh& mesh, size_t meshIndex, InnerNode* innerNode);


### PR DESCRIPTION
Changed onAdd/onRemove callbacks in `Registry` and `PerComponentStorage` from `std::function` to `Signal`. The biggest improvement is now multiple subscribers can connect to the same event instead of just one.

Also fixed private member names in `PerComponentStorage`.