### PR TITLE
Queue indices cleanup

### DIFF
--- a/source/engine/graphics/api/vulkan/FrameManager.cpp
+++ b/source/engine/graphics/api/vulkan/FrameManager.cpp
@@ -1,21 +1,28 @@
 #include "FrameManager.h"
+#include "core/Device.h"
+
+#include <algorithm>
 
 namespace
 {
-std::vector<nc::graphics::PerFrameGpuContext> CreatePerFrameGpuContextVector(vk::Device logicalDevice, vk::PhysicalDevice physicalDevice, vk::SurfaceKHR surface)
+auto CreatePerFrameGpuContextVector(const nc::graphics::Device& device) -> std::vector<nc::graphics::PerFrameGpuContext>
 {
     auto out = std::vector<nc::graphics::PerFrameGpuContext>{};
     out.reserve(nc::graphics::MaxFramesInFlight);
-    std::generate_n(std::back_inserter(out), nc::graphics::MaxFramesInFlight, [logicalDevice, physicalDevice, surface](){ return nc::graphics::PerFrameGpuContext(logicalDevice, physicalDevice, surface); } );
+    std::generate_n(std::back_inserter(out), nc::graphics::MaxFramesInFlight, [&device]()
+    {
+        return nc::graphics::PerFrameGpuContext(device);
+    });
+
     return out;
 }
-}
+} // anonymous namespace
 
 namespace nc::graphics
 {
-FrameManager::FrameManager(vk::Device logicalDevice, vk::PhysicalDevice physicalDevice, vk::SurfaceKHR surface)
-    : m_currentFrameIndex{0},
-      m_perFrameGpuContext{CreatePerFrameGpuContextVector(logicalDevice, physicalDevice, surface)}
+FrameManager::FrameManager(const Device& device)
+    : m_perFrameGpuContext{::CreatePerFrameGpuContextVector(device)},
+      m_currentFrameIndex{0}
 {
 }
 
@@ -31,4 +38,4 @@ void FrameManager::End()
 {
     m_currentFrameIndex = (m_currentFrameIndex + 1) % MaxFramesInFlight;
 }
-}
+} // namespace nc::graphics

--- a/source/engine/graphics/api/vulkan/FrameManager.h
+++ b/source/engine/graphics/api/vulkan/FrameManager.h
@@ -2,7 +2,6 @@
 
 #include "PerFrameGpuContext.h"
 
-#include <memory>
 #include <vector>
 
 namespace nc::graphics
@@ -10,18 +9,28 @@ namespace nc::graphics
 /** How many frames can be rendered concurrently. */
 constexpr uint32_t MaxFramesInFlight = 2u;
 
+class Device;
+
 class FrameManager
 {
     public:
-        FrameManager(vk::Device logicalDevice, vk::PhysicalDevice physicalDevice, vk::SurfaceKHR surface);
+        FrameManager(const Device& device);
 
         void Begin();
         void End();
-        uint32_t Index() const noexcept { return m_currentFrameIndex; };
-        PerFrameGpuContext* CurrentFrameContext() noexcept { return &(m_perFrameGpuContext[m_currentFrameIndex]); }
+
+        auto Index() const noexcept -> uint32_t
+        {
+            return m_currentFrameIndex;
+        };
+
+        auto CurrentFrameContext() noexcept -> PerFrameGpuContext*
+        {
+            return &(m_perFrameGpuContext[m_currentFrameIndex]);
+        }
 
     private:
-        uint32_t m_currentFrameIndex; // Used to select which PerFrameGpuContext to use. Each frame in MaxFramesInFlight requires its own PerFrameGpuContext.
         std::vector<PerFrameGpuContext> m_perFrameGpuContext;
+        uint32_t m_currentFrameIndex; // Used to select which PerFrameGpuContext to use. Each frame in MaxFramesInFlight requires its own PerFrameGpuContext.
 };
-}
+} // namespace nc::graphics

--- a/source/engine/graphics/api/vulkan/PerFrameGpuContext.h
+++ b/source/engine/graphics/api/vulkan/PerFrameGpuContext.h
@@ -4,6 +4,8 @@
 
 namespace nc::graphics
 {
+class Device;
+
 /** This class will hold all the GPU synchronizaton and Vulkan interface data required for a single frame. (Semaphores, command buffers, etc.). 
  * The semaphores deal solely with the GPU. Since rendering to an image taken from the swapchain and returning that image back to the swap chain are both asynchronous, the semaphores below tell the GPU when either step can begin for a single image.
  * The fence synchronizes GPU - CPU and limits Vulkan to submitting only N frame-render jobs to the command queues. (where N is count of PerFrameGpuContext objects parent owns)
@@ -11,7 +13,7 @@ namespace nc::graphics
 class PerFrameGpuContext
 {
     public:
-        PerFrameGpuContext(vk::Device logicalDevice, vk::PhysicalDevice physicalDevice, vk::SurfaceKHR surface);
+        PerFrameGpuContext(const Device& device);
 
         void WaitForSync(); // Waits until the fence has signaled
         void ResetSync() noexcept; // Resets the fence

--- a/source/engine/graphics/api/vulkan/Swapchain.h
+++ b/source/engine/graphics/api/vulkan/Swapchain.h
@@ -15,19 +15,18 @@ namespace nc::graphics
 
     auto QuerySwapChainSupport(const vk::PhysicalDevice& device, const vk::SurfaceKHR& surface) -> SwapChainSupportDetails;
 
+    class Device;
     class PerFrameGpuContext;
-
     class Swapchain
     {
         public:
-            Swapchain(vk::Device device, vk::PhysicalDevice physicalDevice,
-                      vk::SurfaceKHR surface, const Vector2& dimensions);
+            Swapchain(const Device& device, vk::SurfaceKHR surface, const Vector2& dimensions);
             ~Swapchain() noexcept;
 
             // Swap chain
             void Present(PerFrameGpuContext* currentFrame, vk::Queue queue, uint32_t imageIndex, bool& isSwapChainValid);
             void Cleanup() noexcept;
-            void Resize(const Vector2 &dimensions);
+            void Resize(const Device& device, const Vector2& dimensions);
 
             auto GetExtent() const noexcept -> const vk::Extent2D &;
             auto GetFormat() const noexcept -> const vk::Format&;
@@ -38,10 +37,9 @@ namespace nc::graphics
             void WaitForNextImage(PerFrameGpuContext* currentFrame, uint32_t imageIndex);
 
         private:
-            void Create(vk::PhysicalDevice physicalDevice, vk::SurfaceKHR surface, Vector2 dimensions);
+            void Create(const Device& device, vk::SurfaceKHR surface, Vector2 dimensions);
 
             vk::Device m_device;
-            vk::PhysicalDevice m_physicalDevice;
             vk::SurfaceKHR m_surface;
             vk::UniqueSwapchainKHR m_swapChain;
             std::vector<vk::Image> m_swapChainImages;

--- a/source/engine/graphics/api/vulkan/VulkanGraphics.cpp
+++ b/source/engine/graphics/api/vulkan/VulkanGraphics.cpp
@@ -34,14 +34,14 @@ VulkanGraphics::VulkanGraphics(const config::ProjectSettings& projectSettings,
     : m_instance{std::make_unique<Instance>(projectSettings.projectName, 1, apiVersion, graphicsSettings.useValidationLayers)},
       m_surface{m_instance->CreateSurface(hwnd, hinstance)},
       m_device{Device::Create(*m_instance, m_surface.get(), g_requiredDeviceExtensions)},
-      m_swapchain{ std::make_unique<Swapchain>(m_device->VkDevice(), m_device->VkPhysicalDevice(), m_surface.get(), dimensions)},
+      m_swapchain{ std::make_unique<Swapchain>(*m_device, m_surface.get(), dimensions)},
       m_allocator{ std::make_unique<GpuAllocator>(m_device.get(), *m_instance)},
       m_shaderDescriptorSets{ std::make_unique<ShaderDescriptorSets>(m_device->VkDevice())},
       m_shaderResources{ std::make_unique<ShaderResources>(m_device->VkDevice(), m_shaderDescriptorSets.get(), m_allocator.get(), config::GetMemorySettings())},
       m_gpuAssetsStorage{ std::make_unique<GpuAssetsStorage>(m_device->VkDevice(), m_allocator.get(), gpuAccessorSignals) },
       m_renderGraph{std::make_unique<RenderGraph>(*m_device, m_swapchain.get(), m_allocator.get(), m_shaderDescriptorSets.get(), dimensions)},
       m_imgui{std::make_unique<Imgui>(*m_device)},
-      m_frameManager{std::make_unique<FrameManager>(m_device->VkDevice(), m_device->VkPhysicalDevice(), m_surface.get())},
+      m_frameManager{std::make_unique<FrameManager>(*m_device)},
       m_lighting{std::make_unique<Lighting>(registry, m_device->VkDevice(), m_allocator.get(), m_swapchain.get(), m_renderGraph.get(), m_shaderDescriptorSets.get(), m_shaderResources.get(), dimensions)},
       m_resizingMutex{},
       m_imageIndex{UINT32_MAX},
@@ -74,7 +74,7 @@ void VulkanGraphics::Resize(const Vector2& dimensions)
     // Wait for all current commands to complete execution
     m_device->VkDevice().waitIdle();
     m_dimensions = dimensions;
-    m_swapchain->Resize(dimensions);
+    m_swapchain->Resize(*m_device, dimensions);
     m_renderGraph->Resize(*m_device, dimensions);
     m_lighting->Resize(dimensions);
 }

--- a/source/engine/graphics/api/vulkan/core/Device.h
+++ b/source/engine/graphics/api/vulkan/core/Device.h
@@ -47,6 +47,11 @@ class Device
             return m_presentQueue;
         }
 
+        auto GetQueueIndices() const noexcept -> const QueueFamilyIndices&
+        {
+            return m_queueIndices;
+        }
+
         auto GetGpuOptions() const noexcept -> const GpuOptions&
         {
             return m_gpuOptions;


### PR DESCRIPTION
#337

- Removing two remaining cases where we recreate `QueueFamilyIndices`. These probably aren't very expensive, but it simplifies what needs to be passed around a bit.
- Inlined some `FrameManager` functions.
- Factored `Swapchain::Create()` into several functions.