### PR TITLE
Add camera properties

### DIFF
--- a/include/ncengine/graphics/Camera.h
+++ b/include/ncengine/graphics/Camera.h
@@ -8,52 +8,65 @@
 
 namespace nc::graphics
 {
-    /** @brief Basic camera component. */
-    class Camera : public FreeComponent
-    {
-        public:
-            /**
-             * @brief Construct a new Camera object.
-             * @param self The parent entity.
-             */
-            Camera(Entity self) noexcept;
+/** @brief Properties for controlling a camera's frustum. */
+struct CameraProperties
+{
+    /** @brief Camera field of view in radians. */
+    float fov = 1.5708f;
 
-            /**
-             * @brief Get the camera's view matrix.
-             * @return DirectX::FXMMATRIX
-             */
-            auto ViewMatrix() const noexcept -> DirectX::FXMMATRIX { return m_view; }
+    /** @brief Distance to near clipping plane. Must be greater than 0. */
+    float nearClip = 0.1f;
 
-            /**
-             * @brief Get the camera's projection matrix.
-             * @return DirectX::FXMMATRIX
-             */
-            auto ProjectionMatrix() const noexcept -> DirectX::FXMMATRIX { return m_projection; }
+    /** @brief Distance to far clipping plane. Must be greater than nearClip. */
+    float farClip = 400.0f;
+};
 
-            /**
-             * @brief Calculate the camera's viewport.
-             * @return Frustum
-             */
-            auto CalculateFrustum() const noexcept -> Frustum;
+/** @brief Basic camera component. */
+class Camera : public FreeComponent
+{
+    public:
+        /**
+         * @brief Construct a new Camera object.
+         * @param self The parent entity.
+         * @param properties Camera properties.
+         */
+        Camera(Entity self, const CameraProperties& properties = {}) noexcept;
 
-            /** @brief Construct a new view matrix based on the current transform. */
-            virtual void UpdateViewMatrix();
+        /**
+         * @brief Get the camera's view matrix.
+         * @return DirectX::FXMMATRIX
+         */
+        auto ViewMatrix() const noexcept -> DirectX::FXMMATRIX { return m_view; }
 
-            /**
-             * @brief Construct a new projection matrix based on input values.
-             * @param width Screen width
-             * @param height Screen height
-             * @param nearZ Viewport near z plane
-             * @param farZ Viewport far z plane
-             */
-            virtual void UpdateProjectionMatrix(float width, float height, float nearZ, float farZ);
+        /**
+         * @brief Get the camera's projection matrix.
+         * @return DirectX::FXMMATRIX
+         */
+        auto ProjectionMatrix() const noexcept -> DirectX::FXMMATRIX { return m_projection; }
 
-            #ifdef NC_EDITOR_ENABLED
-            void ComponentGuiElement() override;
-            #endif
+        /**
+         * @brief Calculate the camera's viewport.
+         * @return Frustum
+         */
+        auto CalculateFrustum() const noexcept -> Frustum;
 
-        private:
-            DirectX::XMMATRIX m_view;
-            DirectX::XMMATRIX m_projection;
-    };
-}
+        /** @brief Construct a new view matrix based on the current transform. */
+        virtual void UpdateViewMatrix();
+
+        /**
+         * @brief Construct a new projection matrix based on input values.
+         * @param width Screen width
+         * @param height Screen height
+         */
+        virtual void UpdateProjectionMatrix(float width, float height);
+
+        #ifdef NC_EDITOR_ENABLED
+        void ComponentGuiElement() override;
+        #endif
+
+    private:
+        DirectX::XMMATRIX m_view;
+        DirectX::XMMATRIX m_projection;
+        CameraProperties m_properties;
+};
+} // namespace nc::graphics

--- a/include/ncengine/graphics/Camera.h
+++ b/include/ncengine/graphics/Camera.h
@@ -12,7 +12,7 @@ namespace nc::graphics
 struct CameraProperties
 {
     /** @brief Camera field of view in radians. */
-    float fov = 1.5708f;
+    float fov = 1.0472f;
 
     /** @brief Distance to near clipping plane. Must be greater than 0. */
     float nearClip = 0.1f;

--- a/include/ncengine/graphics/SceneNavigationCamera.h
+++ b/include/ncengine/graphics/SceneNavigationCamera.h
@@ -60,5 +60,5 @@ class SceneNavigationCamera : public Camera
         auto PanAndTilt(float dt, float speedMult, const Vector3& tiltAxis) -> Quaternion;
         auto Dolly(float dt, float speedMult) -> Vector3;
 };
-} // end namespace graphics
-} // end namespacenc
+} // namespace graphics
+} // namespace nc

--- a/include/ncengine/graphics/SceneNavigationCamera.h
+++ b/include/ncengine/graphics/SceneNavigationCamera.h
@@ -33,7 +33,9 @@ class SceneNavigationCamera : public Camera
          * @param self The owning entity
          * @param config Camera movement settings
          */
-        SceneNavigationCamera(Entity self, const SceneCameraConfig& config = SceneCameraConfig{});
+        SceneNavigationCamera(Entity self,
+                              const CameraProperties& cameraProperties = {},
+                              const SceneCameraConfig& config = {});
 
         /**
          * @brief Handle input and update transform. (for use with FrameLogic/InvokeFreeComponent)

--- a/source/engine/engine/NcEngineImpl.cpp
+++ b/source/engine/engine/NcEngineImpl.cpp
@@ -41,7 +41,7 @@ auto InitializeNcEngine(const config::Config& config) -> std::unique_ptr<NcEngin
 }
 
 NcEngineImpl::NcEngineImpl(const config::Config& config)
-    : m_window{std::bind_front(&NcEngineImpl::Stop, this)},
+    : m_window{config.projectSettings, config.graphicsSettings, std::bind_front(&NcEngineImpl::Stop, this)},
       m_registry{config.memorySettings.maxTransforms},
       m_modules{BuildModuleRegistry(&m_registry, &m_window, config)},
       m_executor{},

--- a/source/engine/graphics/NcGraphicsImpl.cpp
+++ b/source/engine/graphics/NcGraphicsImpl.cpp
@@ -172,9 +172,9 @@ namespace nc::graphics
         m_graphics->FrameEnd();
     }
 
-    void NcGraphicsImpl::OnResize(float width, float height, float nearZ, float farZ, bool isMinimized)
+    void NcGraphicsImpl::OnResize(float width, float height, bool isMinimized)
     {
-        m_cameraSystem.Get()->UpdateProjectionMatrix(width, height, nearZ, farZ);
+        m_cameraSystem.Get()->UpdateProjectionMatrix(width, height);
         m_graphics->OnResize(width, height, isMinimized);
     }
 } // namespace nc::graphics

--- a/source/engine/graphics/NcGraphicsImpl.h
+++ b/source/engine/graphics/NcGraphicsImpl.h
@@ -60,7 +60,7 @@ class NcGraphicsImpl : public NcGraphics
         void Clear() noexcept override;
         void Run();
 
-        void OnResize(float width, float height, float nearZ, float farZ, bool isMinimized);
+        void OnResize(float width, float height, bool isMinimized);
 
     private:
         Registry* m_registry;

--- a/source/engine/graphics/components/Camera.cpp
+++ b/source/engine/graphics/components/Camera.cpp
@@ -28,7 +28,7 @@ void Camera::UpdateViewMatrix()
 
 void Camera::UpdateProjectionMatrix(float width, float height)
 {
-    m_projection = DirectX::XMMatrixPerspectiveFovRH(m_properties.fov, height / width, m_properties.nearClip, m_properties.farClip);
+    m_projection = DirectX::XMMatrixPerspectiveFovRH(m_properties.fov, width / height, m_properties.nearClip, m_properties.farClip);
 }
 
 auto Camera::CalculateFrustum() const noexcept -> Frustum

--- a/source/engine/graphics/components/Camera.cpp
+++ b/source/engine/graphics/components/Camera.cpp
@@ -1,5 +1,4 @@
 #include "graphics/Camera.h"
-#include "config/Config.h"
 #include "ecs/Registry.h"
 #include "window/Window.h"
 
@@ -9,14 +8,14 @@
 
 namespace nc::graphics
 {
-Camera::Camera(Entity entity) noexcept
+Camera::Camera(Entity entity, const CameraProperties& properties) noexcept
     : FreeComponent(entity),
-        m_view{},
-        m_projection{}
+      m_view{},
+      m_projection{},
+      m_properties{properties}
 {
     auto [width, height] = window::GetDimensions();
-    const auto& graphicsSettings = config::GetGraphicsSettings();
-    UpdateProjectionMatrix(width, height, graphicsSettings.nearClip, graphicsSettings.farClip);
+    UpdateProjectionMatrix(width, height);
 }
 
 void Camera::UpdateViewMatrix()
@@ -27,9 +26,9 @@ void Camera::UpdateViewMatrix()
     m_view = DirectX::XMMatrixLookAtRH(m.r[3], look, DirectX::g_XMNegIdentityR1);
 }
 
-void Camera::UpdateProjectionMatrix(float width, float height, float nearZ, float farZ)
+void Camera::UpdateProjectionMatrix(float width, float height)
 {
-    m_projection = DirectX::XMMatrixPerspectiveRH(1.0f, height / width, nearZ, farZ);
+    m_projection = DirectX::XMMatrixPerspectiveFovRH(m_properties.fov, height / width, m_properties.nearClip, m_properties.farClip);
 }
 
 auto Camera::CalculateFrustum() const noexcept -> Frustum

--- a/source/engine/graphics/components/SceneNavigationCamera.cpp
+++ b/source/engine/graphics/components/SceneNavigationCamera.cpp
@@ -14,10 +14,12 @@ struct Key
 
 namespace nc::graphics
 {
-SceneNavigationCamera::SceneNavigationCamera(Entity entity, const SceneCameraConfig& config)
-    : Camera{entity},
-        m_fineSpeed{config.truckPedestalFine, config.panTiltFine, config.dollyFine},
-        m_coarseSpeed{config.truckPedestalCoarse, config.panTiltCoarse, config.dollyCoarse}
+SceneNavigationCamera::SceneNavigationCamera(Entity entity,
+                                             const CameraProperties& cameraProperties,
+                                             const SceneCameraConfig& config)
+    : Camera{entity, cameraProperties},
+      m_fineSpeed{config.truckPedestalFine, config.panTiltFine, config.dollyFine},
+      m_coarseSpeed{config.truckPedestalCoarse, config.panTiltCoarse, config.dollyCoarse}
 {
 }
 

--- a/source/engine/window/WindowImpl.cpp
+++ b/source/engine/window/WindowImpl.cpp
@@ -104,7 +104,7 @@ namespace nc::window
         m_dimensions = Vector2{static_cast<float>(width), static_cast<float>(height)};
     }
 
-    void WindowImpl::BindGraphicsOnResizeCallback(std::function<void(float,float,float,float,bool)> callback) noexcept
+    void WindowImpl::BindGraphicsOnResizeCallback(std::function<void(float,float,bool)> callback) noexcept
     {
         GraphicsOnResizeCallback = std::move(callback);
     }
@@ -131,9 +131,8 @@ namespace nc::window
             return;
         }
 
-        const auto& graphicsSettings = config::GetGraphicsSettings();
         int minimized = glfwGetWindowAttrib(window, GLFW_ICONIFIED);
-        GraphicsOnResizeCallback(static_cast<float>(width), static_cast<float>(height), graphicsSettings.nearClip, graphicsSettings.farClip, minimized);
+        GraphicsOnResizeCallback(static_cast<float>(width), static_cast<float>(height), minimized);
 
         for(auto receiver : m_onResizeReceivers)
         {

--- a/source/engine/window/WindowImpl.h
+++ b/source/engine/window/WindowImpl.h
@@ -25,11 +25,11 @@ namespace nc::window
             auto GetWindow() -> GLFWwindow*;
             auto GetDimensions() const noexcept -> Vector2;
 
-            void BindGraphicsOnResizeCallback(std::function<void(float,float,float,float,bool)> callback) noexcept;
+            void BindGraphicsOnResizeCallback(std::function<void(float,float,bool)> callback) noexcept;
             void RegisterOnResizeReceiver(IOnResizeReceiver* receiver);
             void UnregisterOnResizeReceiver(IOnResizeReceiver* receiver) noexcept;
             void InvokeResizeReceivers(GLFWwindow* window, int width, int height);
-            
+
             void ProcessSystemMessages();
 
         private:
@@ -45,7 +45,7 @@ namespace nc::window
             std::vector<IOnResizeReceiver*> m_onResizeReceivers;
             Vector2 m_dimensions;
             GLFWwindow* m_window;
-            std::function<void(float,float,float,float,bool)> GraphicsOnResizeCallback;
+            std::function<void(float,float,bool)> GraphicsOnResizeCallback;
             std::function<void()> EngineDisableRunningCallback;
     };
 } // end namespace nc::window

--- a/source/engine/window/WindowImpl.h
+++ b/source/engine/window/WindowImpl.h
@@ -8,44 +8,55 @@
 #include <functional>
 #include <vector>
 
-namespace nc::window
+namespace nc
 {
-    class IOnResizeReceiver;
+namespace config
+{
+struct GraphicsSettings;
+struct ProjectSettings;
+} // namespace config
 
-    class WindowImpl
-    {
-        public:
-            WindowImpl(std::function<void()> onQuit);
-            ~WindowImpl() noexcept;
-            WindowImpl(const WindowImpl& other) = delete;
-            WindowImpl(WindowImpl&& other) = delete;
-            WindowImpl& operator=(const WindowImpl& other) = delete;
-            WindowImpl& operator=(WindowImpl&& other) = delete;
+namespace window
+{
+class IOnResizeReceiver;
 
-            auto GetWindow() -> GLFWwindow*;
-            auto GetDimensions() const noexcept -> Vector2;
+class WindowImpl
+{
+    public:
+        WindowImpl(const config::ProjectSettings& projectSettings,
+                   const config::GraphicsSettings& graphicsSettings,
+                   std::function<void()> onQuit);
+        ~WindowImpl() noexcept;
+        WindowImpl(const WindowImpl& other) = delete;
+        WindowImpl(WindowImpl&& other) = delete;
+        WindowImpl& operator=(const WindowImpl& other) = delete;
+        WindowImpl& operator=(WindowImpl&& other) = delete;
 
-            void BindGraphicsOnResizeCallback(std::function<void(float,float,bool)> callback) noexcept;
-            void RegisterOnResizeReceiver(IOnResizeReceiver* receiver);
-            void UnregisterOnResizeReceiver(IOnResizeReceiver* receiver) noexcept;
-            void InvokeResizeReceivers(GLFWwindow* window, int width, int height);
+        auto GetWindow() -> GLFWwindow*;
+        auto GetDimensions() const noexcept -> Vector2;
 
-            void ProcessSystemMessages();
+        void BindGraphicsOnResizeCallback(std::function<void(float,float,bool)> callback) noexcept;
+        void RegisterOnResizeReceiver(IOnResizeReceiver* receiver);
+        void UnregisterOnResizeReceiver(IOnResizeReceiver* receiver) noexcept;
+        void InvokeResizeReceivers(GLFWwindow* window, int width, int height);
 
-        private:
-            void SetDimensions(int width, int height) noexcept;
+        void ProcessSystemMessages();
 
-            static void ProcessKeyEvent(GLFWwindow* window, int key, int scancode, int action, int mods);
-            static void ProcessMouseButtonEvent(GLFWwindow* window, int button, int action, int mods);
-            static void ProcessMouseCursorPosEvent(GLFWwindow* window, double xPos, double yPos);
-            static void ProcessMouseScrollEvent(GLFWwindow* window, double xOffset, double yOffset);
-            static void ProcessResizeEvent(GLFWwindow* window, int width, int height);
-            static void ProcessWindowCloseEvent(GLFWwindow* window);
+    private:
+        void SetDimensions(int width, int height) noexcept;
 
-            std::vector<IOnResizeReceiver*> m_onResizeReceivers;
-            Vector2 m_dimensions;
-            GLFWwindow* m_window;
-            std::function<void(float,float,bool)> GraphicsOnResizeCallback;
-            std::function<void()> EngineDisableRunningCallback;
-    };
-} // end namespace nc::window
+        static void ProcessKeyEvent(GLFWwindow* window, int key, int scancode, int action, int mods);
+        static void ProcessMouseButtonEvent(GLFWwindow* window, int button, int action, int mods);
+        static void ProcessMouseCursorPosEvent(GLFWwindow* window, double xPos, double yPos);
+        static void ProcessMouseScrollEvent(GLFWwindow* window, double xOffset, double yOffset);
+        static void ProcessResizeEvent(GLFWwindow* window, int width, int height);
+        static void ProcessWindowCloseEvent(GLFWwindow* window);
+
+        std::vector<IOnResizeReceiver*> m_onResizeReceivers;
+        Vector2 m_dimensions;
+        GLFWwindow* m_window;
+        std::function<void(float,float,bool)> GraphicsOnResizeCallback;
+        std::function<void()> EngineDisableRunningCallback;
+};
+} // end namespace window
+} // end namespace nc


### PR DESCRIPTION
Our handling of clip planes doesn't really work if you want multiple camera's configured differently. Reworking this so that the caller has more control.

- Adding `CameraProperties` struct.
- Updating matrix calculation to use fov.
- Removing near/far z values from resize functions. They aren't needed if the camera manages this.