### PR TITLE
Fix crash with no camera

### DIFF
--- a/source/engine/graphics/NcGraphicsImpl.cpp
+++ b/source/engine/graphics/NcGraphicsImpl.cpp
@@ -118,6 +118,7 @@ namespace nc::graphics
         /** @note Don't clear the camera as it may be on a persistent entity. */
         /** @todo graphics::clear not marked noexcept */
         m_graphics->Clear();
+        m_cameraSystem.Clear();
         m_environmentSystem.Clear();
         m_particleEmitterSystem.Clear();
     }
@@ -137,7 +138,7 @@ namespace nc::graphics
     {
         OPTICK_CATEGORY("Render", Optick::Category::Rendering);
         auto cameraState = m_cameraSystem.Execute(m_registry);
-        if (!cameraState.hasCamera || !m_graphics->FrameBegin())
+        if (!m_graphics->FrameBegin())
         {
             return;
         }

--- a/source/engine/graphics/system/CameraSystem.cpp
+++ b/source/engine/graphics/system/CameraSystem.cpp
@@ -8,7 +8,13 @@ auto CameraSystem::Execute(Registry* registry) -> CameraState
 {
     if (!m_mainCamera)
     {
-        return CameraState{};
+        return CameraState
+        {
+            .view = DirectX::XMMatrixIdentity(),
+            .projection = DirectX::XMMatrixIdentity(),
+            .position = Vector3::Zero(),
+            .frustum = Frustum{}
+        };
     }
 
     m_mainCamera->UpdateViewMatrix();
@@ -19,8 +25,7 @@ auto CameraSystem::Execute(Registry* registry) -> CameraState
         .view = m_mainCamera->ViewMatrix(),
         .projection = m_mainCamera->ProjectionMatrix(),
         .position = transform->Position(),
-        .frustum = m_mainCamera->CalculateFrustum(),
-        .hasCamera = true
+        .frustum = m_mainCamera->CalculateFrustum()
     };
 }
 } // namespace nc::graphics

--- a/source/engine/graphics/system/CameraSystem.h
+++ b/source/engine/graphics/system/CameraSystem.h
@@ -18,7 +18,6 @@ struct CameraState
     DirectX::XMMATRIX projection;
     Vector3 position;
     Frustum frustum;
-    bool hasCamera = false;
 };
 
 class CameraSystem final
@@ -32,6 +31,11 @@ class CameraSystem final
         auto Get() noexcept -> Camera*
         {
             return m_mainCamera;
+        }
+
+        void Clear() noexcept
+        {
+            m_mainCamera = nullptr;
         }
 
         auto Execute(Registry* registry) -> CameraState;

--- a/source/engine/graphics/system/ParticleEmitterSystem.cpp
+++ b/source/engine/graphics/system/ParticleEmitterSystem.cpp
@@ -23,10 +23,16 @@ namespace nc::graphics
     {
         OPTICK_CATEGORY("ParticleModule", Optick::Category::VFX);
         const float dt = time::DeltaTime();
-        const auto* camera = m_getCamera();
-        const auto* transform = m_registry->Get<Transform>(camera->ParentEntity());
-        const auto camRotation = transform->Rotation();
-        const auto camForward = transform->Forward();
+        const auto [camRotation, camForward] = [this]()
+        {
+            if (auto camera = m_getCamera())
+            {
+                const auto* transform = m_registry->Get<Transform>(camera->ParentEntity());
+                return std::make_pair(transform->Rotation(), transform->Forward());
+            }
+
+            return std::make_pair(Quaternion::Identity(), Vector3::Front());
+        }();
 
         for (auto& state : m_emitterStates)
         {


### PR DESCRIPTION
#388

Fixed crash in particle land when no camera is set. Also removed skipping of rendering if there's no camera because you also don't get UI. Pretty useless. Returning a default CameraState instead gives us a 'null' perspective, but still lets all the rendering code run.