### PR TITLE
Changed standard CPP version from 23 to 20

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,8 +65,6 @@ jobs:
       with:
         msystem: 'mingw64'
         update: true
-          git
-          make
         pacboy: >-
           toolchain:p
           cmake:p

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,7 +73,7 @@ jobs:
     - name: Setup Vulkan Sdk
       uses: humbletim/setup-vulkan-sdk@v1.2.0
       with:
-        vulkan-query-version: 1.2.198.0
+        vulkan-query-version: 1.3.204.0
         vulkan-components: Vulkan-Headers, Vulkan-Loader
 
     - name: Configure

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Setup Vulkan Sdk
       uses: humbletim/setup-vulkan-sdk@v1.2.0
       with:
-        vulkan-query-version: 1.2.198.0
+        vulkan-query-version: 1.3.204.0
         vulkan-components: Vulkan-Headers, Vulkan-Loader
 
     - name: Configure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ option(NC_BUILD_TESTS "Enable building tests." OFF)
 option(NC_PROD_BUILD "Only build NcEngine production binaries." OFF)
 
 # Variables
-set(CMAKE_CXX_STANDARD 23) # we only actually need 20, but michaelsoft dances to their own beat
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 set(CMAKE_DEBUG_POSTFIX d)
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
@@ -33,9 +33,6 @@ else()
     set(NC_SAMPLE_EXE "Sample")
 endif()
 
-# TODO: #383 Taskflow has deprecation warnings for std::aligned_XXX with c++23. We eventually want to remove this.
-add_definitions(-D_SILENCE_ALL_CXX23_DEPRECATION_WARNINGS)
-
 # TODO: #383 RtAudio uses deprecated wchar_t conversion
 add_definitions(-D_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING)
 
@@ -46,7 +43,7 @@ include(FetchContent)
 
 FetchContent_Declare(NcCommon
                      GIT_REPOSITORY https://github.com/NcStudios/NcCommon.git
-                     GIT_TAG        origin/release
+                     GIT_TAG        origin/vnext
                      GIT_SHALLOW    TRUE
 )
 
@@ -67,13 +64,13 @@ FetchContent_Declare(nc-convert
 
 FetchContent_Declare(taskflow
                      GIT_REPOSITORY https://github.com/NcStudios/taskflow.git
-                     GIT_TAG        ab6c1b6cd2651d4a4b1a3204b2e1b95f75d06a56 # origin/master
+                     GIT_TAG        origin/master
                      GIT_SHALLOW    TRUE
 )
 
 FetchContent_Declare(glfw
                      GIT_REPOSITORY https://github.com/NcStudios/glfw.git
-                     GIT_TAG        8f470597d625ae28758c16b4293dd42d63e8a83a # origin/master
+                     GIT_TAG        origin/master
                      GIT_SHALLOW    TRUE
 )
 

--- a/source/external/vulkan/vk_mem_alloc.h
+++ b/source/external/vulkan/vk_mem_alloc.h
@@ -3480,6 +3480,7 @@ VMA_CALL_PRE void VMA_CALL_POST vmaDestroyImage(
 #ifdef VMA_IMPLEMENTATION
 #undef VMA_IMPLEMENTATION
 
+#include <cstdio>
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>


### PR DESCRIPTION
Changed standard CPP version from 23 to 20.
Updated dependencies to point to origin/vnext or origin/master rather than a static Git hash