### PR TITLE
Some PCs crash with new Vulkan SDK

### DIFF
--- a/source/engine/graphics/api/vulkan/GpuAllocator.cpp
+++ b/source/engine/graphics/api/vulkan/GpuAllocator.cpp
@@ -9,6 +9,10 @@ namespace
     auto CreateAllocator(vk::Device logicalDevice, vk::PhysicalDevice physicalDevice, vk::Instance instance) -> vma::Allocator
     {
         vma::AllocatorCreateInfo allocatorInfo{};
+        vma::VulkanFunctions vulkanFunctions{};
+        vulkanFunctions.vkGetInstanceProcAddr = vkGetInstanceProcAddr;
+        vulkanFunctions.vkGetDeviceProcAddr = vkGetDeviceProcAddr;
+        allocatorInfo.pVulkanFunctions = &vulkanFunctions;
         allocatorInfo.physicalDevice = physicalDevice;
         allocatorInfo.device = logicalDevice;
         allocatorInfo.instance = instance;

--- a/source/engine/graphics/api/vulkan/vma.cpp
+++ b/source/engine/graphics/api/vulkan/vma.cpp
@@ -1,2 +1,4 @@
 #define VMA_IMPLEMENTATION
+#define VMA_STATIC_VULKAN_FUNCTIONS 0
+#define VMA_DYNAMIC_VULKAN_FUNCTIONS 1
 #include "vulkan/vk_mem_alloc.hpp"


### PR DESCRIPTION
After targeting Vulkan SDK 1.3.250, the Surface laptop was crashing due to the following error:
"The procedure entry point vkGetDeviceBufferMemoryRequirements could not be located in the DLL."

This is because the version of the vulkan-1.lib (the Vulkan Loader) on the surface does not contain that function, even though the driver has it.
To fix, the function pointers `vkGetInstanceProcAddr` and `vkGetDeviceProcAddr` had to be passed into the Vulkan Memory Allocator, and the VMA had to have `VMA_STATIC_FUNCTIONS` disabled and `VMA_DYNAMIC_FUNCTIONS` enabled.

This tells the vulkan loader to pass along the request for `vkGetDeviceBufferMemoryRequirements` and any other functions VMA needs directly to the driver - the driver then returns the pointer to it's implementation of `vkGetDeviceBufferMemoryRequirements` and the program can continue as usual.