### PR TITLE
Optick source not optional

### DIFF
--- a/cmake/FetchDependencies.cmake
+++ b/cmake/FetchDependencies.cmake
@@ -60,8 +60,21 @@ FetchContent_Declare(glfw
                      GIT_SHALLOW    TRUE
 )
 
+# Optick
+if(${NC_PROFILING_ENABLED})
+    set(OPTICK_ENABLED ON CACHE BOOL "" FORCE)
+else()
+    set(OPTICK_ENABLED OFF CACHE BOOL "" FORCE)
+endif()
+
+FetchContent_Declare(optick
+                     GIT_REPOSITORY https://github.com/NcStudios/optick.git
+                     GIT_TAG        e45a8480babaca85bd87ecf1e775547e28754881 # origin/release
+                     GIT_SHALLOW    TRUE
+)
+
 # Fetch all required sources
-FetchContent_MakeAvailable(NcCommon nc-tools nc-convert taskflow glfw)
+FetchContent_MakeAvailable(NcCommon nc-tools nc-convert taskflow glfw optick)
 
 #############################
 ### Optional Dependencies ###
@@ -78,15 +91,4 @@ if(${NC_BUILD_TESTS})
     )
 
     FetchContent_MakeAvailable(googletest)
-endif()
-
-# Optick
-if(${NC_PROFILING_ENABLED})
-    FetchContent_Declare(optick
-                         GIT_REPOSITORY https://github.com/NcStudios/optick.git
-                         GIT_TAG        a89846fb813771ef21ca663cbd85e2a65cc56c5d # origin/release
-                         GIT_SHALLOW    TRUE
-    )
-
-    FetchContent_MakeAvailable(optick)
 endif()

--- a/source/engine/CMakeLists.txt
+++ b/source/engine/CMakeLists.txt
@@ -42,6 +42,7 @@ target_link_libraries(${NC_ENGINE_LIB}
         Vulkan::Vulkan
         Taskflow
         glfw
+        OptickCore
 )
 
 if(WIN32)
@@ -60,13 +61,6 @@ elseif(APPLE)
     target_link_libraries(${NC_ENGINE_LIB}
         PUBLIC
             "-framework CoreAudio"
-    )
-endif()
-
-if(${NC_PROFILING_ENABLED})
-    target_link_libraries(${NC_ENGINE_LIB}
-        PUBLIC
-            OptickCore
     )
 endif()
 


### PR DESCRIPTION
We still need to fetch Optick when profiling is off just to get the headers. Turning off `OPTICK_ENABLED` builds a stubbed static lib and eliminates the runtime dependency on OptickCore.dll. Unfortunately, the Optick CMakeLists doesn't install this dummy lib, so I had to modify it again.