### PR TITLE
Fixed OutOfPoolMemory Error

### DIFF
--- a/source/engine/graphics/api/vulkan/Imgui.cpp
+++ b/source/engine/graphics/api/vulkan/Imgui.cpp
@@ -26,7 +26,7 @@ auto CreateImguiDescriptorPool(vk::Device device) -> vk::UniqueDescriptorPool
     };
 
     vk::DescriptorPoolCreateInfo imguiDescriptorPoolInfo = {};
-    imguiDescriptorPoolInfo.setFlags(vk::DescriptorPoolCreateFlagBits::eFreeDescriptorSet);
+    imguiDescriptorPoolInfo.setFlags(vk::DescriptorPoolCreateFlagBits::eFreeDescriptorSet | vk::DescriptorPoolCreateFlagBits::eUpdateAfterBind);
     imguiDescriptorPoolInfo.setMaxSets(1000);
     imguiDescriptorPoolInfo.setPoolSizeCount(static_cast<uint32_t>(imguiPoolSizes.size()));
     imguiDescriptorPoolInfo.setPPoolSizes(imguiPoolSizes.data());

--- a/source/engine/graphics/api/vulkan/Initializers.cpp
+++ b/source/engine/graphics/api/vulkan/Initializers.cpp
@@ -230,7 +230,7 @@ vk::UniqueDescriptorSetLayout CreateDescriptorSetLayout(vk::Device device, std::
 
     vk::DescriptorSetLayoutCreateInfo setInfo{};
     setInfo.setBindingCount(static_cast<uint32_t>(layoutBindings.size()));
-    setInfo.setFlags(vk::DescriptorSetLayoutCreateFlags());
+    setInfo.setFlags(vk::DescriptorSetLayoutCreateFlagBits::eUpdateAfterBindPool);
     setInfo.setPNext(&extendedInfo);
     setInfo.setPBindings(layoutBindings.data());
 

--- a/source/engine/graphics/api/vulkan/shaders/ShaderDescriptorSets.cpp
+++ b/source/engine/graphics/api/vulkan/shaders/ShaderDescriptorSets.cpp
@@ -7,15 +7,15 @@ namespace
     {
         std::array<vk::DescriptorPoolSize, 4> renderingPoolSizes =
         {
-            vk::DescriptorPoolSize { vk::DescriptorType::eSampler, 10 },
             vk::DescriptorPoolSize { vk::DescriptorType::eSampledImage, 1000 },
-            vk::DescriptorPoolSize { vk::DescriptorType::eCombinedImageSampler, 10 },
-            vk::DescriptorPoolSize { vk::DescriptorType::eStorageBuffer, 10 }
+            vk::DescriptorPoolSize { vk::DescriptorType::eCombinedImageSampler, 1000 },
+            vk::DescriptorPoolSize { vk::DescriptorType::eStorageBuffer, 10 },
+            vk::DescriptorPoolSize { vk::DescriptorType::eUniformBuffer, 10 }
         };
         
         vk::DescriptorPoolCreateInfo renderingDescriptorPoolInfo = {};
         renderingDescriptorPoolInfo.setFlags(vk::DescriptorPoolCreateFlagBits::eFreeDescriptorSet | vk::DescriptorPoolCreateFlagBits::eUpdateAfterBind);
-        renderingDescriptorPoolInfo.setMaxSets(1000);
+        renderingDescriptorPoolInfo.setMaxSets(10);
         renderingDescriptorPoolInfo.setPoolSizeCount(static_cast<uint32_t>(renderingPoolSizes.size()));
         renderingDescriptorPoolInfo.setPPoolSizes(renderingPoolSizes.data());
 

--- a/source/engine/graphics/api/vulkan/shaders/ShaderDescriptorSets.cpp
+++ b/source/engine/graphics/api/vulkan/shaders/ShaderDescriptorSets.cpp
@@ -14,7 +14,7 @@ namespace
         };
         
         vk::DescriptorPoolCreateInfo renderingDescriptorPoolInfo = {};
-        renderingDescriptorPoolInfo.setFlags(vk::DescriptorPoolCreateFlagBits::eFreeDescriptorSet);
+        renderingDescriptorPoolInfo.setFlags(vk::DescriptorPoolCreateFlagBits::eFreeDescriptorSet | vk::DescriptorPoolCreateFlagBits::eUpdateAfterBind);
         renderingDescriptorPoolInfo.setMaxSets(1000);
         renderingDescriptorPoolInfo.setPoolSizeCount(static_cast<uint32_t>(renderingPoolSizes.size()));
         renderingDescriptorPoolInfo.setPPoolSizes(renderingPoolSizes.data());

--- a/source/external/imgui/src/imgui_impl_vulkan.cpp
+++ b/source/external/imgui/src/imgui_impl_vulkan.cpp
@@ -878,6 +878,7 @@ bool ImGui_ImplVulkan_CreateDeviceObjects()
         info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
         info.bindingCount = 1;
         info.pBindings = binding;
+        info.flags = VkDescriptorSetLayoutCreateFlagBits::VK_DESCRIPTOR_SET_LAYOUT_CREATE_UPDATE_AFTER_BIND_POOL_BIT;
         err = vkCreateDescriptorSetLayout(v->Device, &info, v->Allocator, &bd->DescriptorSetLayout);
         check_vk_result(err);
     }

--- a/source/external/imgui/src/imgui_impl_vulkan.cpp
+++ b/source/external/imgui/src/imgui_impl_vulkan.cpp
@@ -878,7 +878,6 @@ bool ImGui_ImplVulkan_CreateDeviceObjects()
         info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
         info.bindingCount = 1;
         info.pBindings = binding;
-        info.flags = VkDescriptorSetLayoutCreateFlagBits::VK_DESCRIPTOR_SET_LAYOUT_CREATE_UPDATE_AFTER_BIND_POOL_BIT;
         err = vkCreateDescriptorSetLayout(v->Device, &info, v->Allocator, &bd->DescriptorSetLayout);
         check_vk_result(err);
     }


### PR DESCRIPTION

### Goal
Fix bug #426 (OutOfPoolMemoryError). 

### Background
Certain devices were crashing on launch with an `OutOfPoolMemoryError`. This was caused both by the descriptor pools and sets not being created with the `UpdateAfterBind` flag (which allows for creation of memory resources beyond the hardware limitations) and because we are using a `UniformBuffer` but did not allocate one in our pool.

The error was device specific because some graphics drivers are more permissive than others on Vulkan setup. 
Example: I removed all descriptor types from the pool except for one we weren't using, and my graphics driver allowed it.

### Changes

 1. Added an entry in pool creation for `UniformBuffer`
 2. Updated the descriptor pools and sets to include the `UpdateAfterBind` flag.
 

closes #426 
