### PR TITLE
Add Module::OnSceneLoad()

### DIFF
--- a/include/ncengine/NcFwd.h
+++ b/include/ncengine/NcFwd.h
@@ -1,6 +1,6 @@
 /**
  * @file NcFwd.h
- * @copyright Jaremie and McCallister Romer 2023
+ * @copyright Jaremie Romer and McCallister Romer 2023
  */
 #pragma once
 

--- a/include/ncengine/module/Module.h
+++ b/include/ncengine/module/Module.h
@@ -1,3 +1,7 @@
+/**
+ * @file Module.h
+ * @copyright Jaremie and McCallister Romer 2023
+ */
 #pragma once
 
 #include <vector>
@@ -19,8 +23,11 @@ struct Module
     /** @brief Called on registered modules when the task graph is constructed. */
     virtual void OnBuildTaskGraph(task::TaskGraph&) {}
 
-    /** @brief Called prior to clearing the module's associated data registry. This includes
-     *         scene changes and NcEngine::Shutdown(). */
+    /** @brief Called on registered modules prior to loading a new scene. */
+    virtual void OnSceneLoad() {}
+
+    /** @brief Called on registered modules prior to clearing the Registry. This
+     *         includes Scene::Unload() and NcEngine::Shutdown(). */
     virtual void Clear() noexcept {}
 };
 } // namespace nc

--- a/include/ncengine/module/Module.h
+++ b/include/ncengine/module/Module.h
@@ -24,7 +24,7 @@ struct Module
     virtual void OnBuildTaskGraph(task::TaskGraph&) {}
 
     /** @brief Called on registered modules prior to loading a new scene. */
-    virtual void OnSceneLoad() {}
+    virtual void OnBeforeSceneLoad() {}
 
     /** @brief Called on registered modules prior to clearing the Registry. This
      *         includes Scene::Unload() and NcEngine::Shutdown(). */

--- a/include/ncengine/module/Module.h
+++ b/include/ncengine/module/Module.h
@@ -1,6 +1,6 @@
 /**
  * @file Module.h
- * @copyright Jaremie and McCallister Romer 2023
+ * @copyright Jaremie Romer and McCallister Romer 2023
  */
 #pragma once
 

--- a/include/ncengine/module/ModuleRegistry.h
+++ b/include/ncengine/module/ModuleRegistry.h
@@ -1,3 +1,7 @@
+/**
+ * @file ModuleRegistry.h
+ * @copyright Jaremie and McCallister Romer 2023
+ */
 #pragma once
 
 #include "Module.h"
@@ -10,10 +14,7 @@ namespace nc
 class ModuleRegistry
 {
     public:
-        /**
-         * @brief Add a new module to the registry. Overwrites any existing
-         * module of the same type.
-         */
+        /** @brief Add a new module to the registry. Overwrites any existing module of the same type. */
         template<std::derived_from<Module> T>
         void Register(std::unique_ptr<T> module)
         {
@@ -26,10 +27,7 @@ class ModuleRegistry
             m_modules.push_back(std::move(module));
         }
 
-        /**
-         * @brief Remove a module from the registry. Does nothing if no
-         * matching module is found.
-         */
+        /** @brief Remove a module from the registry. Does nothing if no matching module is found. */
         template<std::derived_from<Module> T>
         void Unregister()
         {
@@ -42,38 +40,21 @@ class ModuleRegistry
             m_typedModulePointer<T> = nullptr;
         }
 
-        /**
-         * @brief Notify all modules the data registry is about to be cleared.
-         */
-        void Clear() noexcept
-        {
-            for(auto& module : m_modules)
-            {
-                module->Clear();
-            }
-        }
-
-        /**
-         * @brief Check if a module matching a type is registered.
-         */
+        /** @brief Check if a module matching a type is registered. */
         template<std::derived_from<Module> T>
         bool IsRegistered() const noexcept
         {
             return Get<T>() != nullptr;
         }
 
-        /**
-         * @brief Get a pointer to a module or nullptr if it is unregistered.
-         */
+        /** @brief Get a pointer to a module or nullptr if it is unregistered. */
         template<std::derived_from<Module> T>
         auto Get() const noexcept -> T*
         {
             return m_typedModulePointer<T>;
         }
 
-        /**
-         * @brief Get the collection of all registered modules.
-         */
+        /*** @brief Get the collection of all registered modules. */
         auto GetAllModules() noexcept -> const std::vector<std::unique_ptr<Module>>&
         {
             return m_modules;

--- a/include/ncengine/module/ModuleRegistry.h
+++ b/include/ncengine/module/ModuleRegistry.h
@@ -1,6 +1,6 @@
 /**
  * @file ModuleRegistry.h
- * @copyright Jaremie and McCallister Romer 2023
+ * @copyright Jaremie Romer and McCallister Romer 2023
  */
 #pragma once
 

--- a/include/ncengine/ui/ImGuiConversion.h
+++ b/include/ncengine/ui/ImGuiConversion.h
@@ -1,6 +1,6 @@
 /**
  * @file ImGuiConversion.h
- * @copyright Jaremie and McCallister Romer 2023
+ * @copyright Jaremie Romer and McCallister Romer 2023
  */
 #pragma once
 

--- a/include/ncengine/ui/ImGuiStyle.h
+++ b/include/ncengine/ui/ImGuiStyle.h
@@ -1,6 +1,6 @@
 /**
  * @file ImGuiStyle.h
- * @copyright Jaremie and McCallister Romer 2023
+ * @copyright Jaremie Romer and McCallister Romer 2023
  */
 #pragma once
 

--- a/include/ncengine/ui/ImGuiUtility.h
+++ b/include/ncengine/ui/ImGuiUtility.h
@@ -1,6 +1,6 @@
 /**
  * @file ImGuiUtility.h
- * @copyright Jaremie and McCallister Romer 2023
+ * @copyright Jaremie Romer and McCallister Romer 2023
  * 
  * @note Unless otherwise noted, all functions in this file must only be called
  *       during UI rendering. Calls should be made only from within IUI::Draw()

--- a/source/engine/engine/NcEngineImpl.cpp
+++ b/source/engine/engine/NcEngineImpl.cpp
@@ -116,7 +116,7 @@ void NcEngineImpl::LoadScene()
 {
     for (auto& module : m_modules.GetAllModules())
     {
-        module->OnSceneLoad();
+        module->OnBeforeSceneLoad();
     }
 
     m_sceneManager.LoadQueuedScene(&m_registry, ModuleProvider{&m_modules});

--- a/source/engine/engine/NcEngineImpl.h
+++ b/source/engine/engine/NcEngineImpl.h
@@ -31,6 +31,7 @@ namespace nc
             scene::SceneManager m_sceneManager;
             bool m_isRunning;
 
+            void LoadScene();
             void Clear();
             void Run();
     };

--- a/source/engine/scene/SceneManager.cpp
+++ b/source/engine/scene/SceneManager.cpp
@@ -2,45 +2,55 @@
 #include "module/ModuleProvider.h"
 #include "utility/Log.h"
 
+#include "ncutility/NcError.h"
+
 namespace nc::scene
 {
-    SceneManager::SceneManager(std::function<void()> clearOnSceneChangeCallback)
-        : m_activeScene{nullptr},
-          m_swapScene{nullptr},
-          m_clearCallback{std::move(clearOnSceneChangeCallback)}
-    {
-    }
-
-    bool SceneManager::IsSceneChangeQueued() const noexcept
-    {
-        return static_cast<bool>(m_swapScene);
-    }
-
-    void SceneManager::QueueSceneChange(std::unique_ptr<Scene> swapScene) noexcept
-    {
-        NC_LOG_TRACE("Queueing scene change");
-        m_swapScene = std::move(swapScene);
-    }
-
-    void SceneManager::DoSceneChange(Registry* registry, ModuleProvider modules)
-    {
-        NC_LOG_TRACE("Changing scene");
-        if(!m_swapScene)
-        {
-            return;
-        }
-
-        if(m_activeScene)
-        {
-            NC_LOG_TRACE("Unloading active scene");
-            m_activeScene->Unload();
-            m_activeScene = nullptr;
-        }
-
-        m_clearCallback();
-        m_activeScene = std::move(m_swapScene);
-        m_swapScene = nullptr;
-        NC_LOG_TRACE("Loading scene");
-        m_activeScene->Load(registry, modules);
-    }
+SceneManager::SceneManager()
+    : m_activeScene{nullptr},
+      m_swapScene{nullptr}
+{
 }
+
+auto SceneManager::IsSceneChangeQueued() const noexcept -> bool
+{
+    return static_cast<bool>(m_swapScene);
+}
+
+void SceneManager::QueueSceneChange(std::unique_ptr<Scene> swapScene) noexcept
+{
+    NC_LOG_TRACE("Queueing scene change");
+    m_swapScene = std::move(swapScene);
+}
+
+auto SceneManager::UnloadActiveScene() -> bool
+{
+    NC_LOG_TRACE("Unloading active scene");
+    if(!m_activeScene)
+    {
+        NC_LOG_WARNING("No scene loaded - ignoring scene unload request.");
+        return false;
+    }
+
+    m_activeScene->Unload();
+    m_activeScene = nullptr;
+    return true;
+}
+
+auto SceneManager::LoadQueuedScene(Registry* registry, ModuleProvider modules)-> bool
+{
+    NC_LOG_TRACE("Changing scene");
+    NC_ASSERT(!m_activeScene, "Attempt to change scenes with an active scene loaded.");
+    if(!m_swapScene)
+    {
+        NC_LOG_WARNING("No scene queued - ignoring scene change request.");
+        return false;
+    }
+
+    m_activeScene = std::move(m_swapScene);
+    m_swapScene = nullptr;
+    NC_LOG_TRACE("Loading scene");
+    m_activeScene->Load(registry, modules);
+    return true;
+}
+} // namespace nc::scene

--- a/source/engine/scene/SceneManager.h
+++ b/source/engine/scene/SceneManager.h
@@ -2,22 +2,20 @@
 
 #include "scene/Scene.h"
 
-#include <functional>
-
 namespace nc::scene
 {
     class SceneManager
     {
         public:
-            SceneManager(std::function<void()> clearOnSceneChangeCallback);
+            SceneManager();
 
-            bool IsSceneChangeQueued() const noexcept;
+            auto IsSceneChangeQueued() const noexcept -> bool;
             void QueueSceneChange(std::unique_ptr<Scene> swapScene) noexcept;
-            void DoSceneChange(Registry* registry, ModuleProvider modules);
+            auto UnloadActiveScene() -> bool;
+            auto LoadQueuedScene(Registry* registry, ModuleProvider modules) -> bool;
 
         private:
             std::unique_ptr<Scene> m_activeScene;
             std::unique_ptr<Scene> m_swapScene;
-            std::function<void()> m_clearCallback;
     };
 }

--- a/test/module/ModuleRegistry_unit_tests.cpp
+++ b/test/module/ModuleRegistry_unit_tests.cpp
@@ -60,16 +60,6 @@ TEST(ModuleRegistry_unit_tests, Unregister_NonexistentModule_Succeeds)
     EXPECT_EQ(uut.GetAllModules().size(), 0);
 }
 
-TEST(ModuleRegistry_unit_tests, Clear_NotifiesModules)
-{
-    auto uut = ModuleRegistry{};
-    uut.Register<TestModule1>(std::make_unique<TestModule1>());
-    uut.Register<TestModule2>(std::make_unique<TestModule2>());
-    uut.Clear();
-    EXPECT_TRUE(uut.Get<TestModule1>()->cleared);
-    EXPECT_TRUE(uut.Get<TestModule2>()->cleared);
-}
-
 int main(int argc, char ** argv)
 {
     ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
needed for #467

Adding a hook for `Module`s to run code right before scene load. Will be used by `NcAsset` to ensure all default assets are loaded before launching into the next scene.