### PR TITLE
Log improvements

### DIFF
--- a/include/ncengine/config/Config.h
+++ b/include/ncengine/config/Config.h
@@ -9,7 +9,8 @@ namespace nc::config
 struct ProjectSettings
 {
     std::string projectName = "Project Name";
-    std::string logFilePath = "Diagnostics.log";
+    std::string logFilePath = "NcEngine.log";
+    size_t logMaxFileSize = 1000000ull;
 };
 
 /**

--- a/include/ncengine/config/Config.h
+++ b/include/ncengine/config/Config.h
@@ -1,3 +1,7 @@
+/**
+ * @file Config.h
+ * @copyright Jaremie Romer and McCallister Romer 2023
+ */
 #pragma once
 
 #include <filesystem>

--- a/include/ncengine/utility/Log.h
+++ b/include/ncengine/utility/Log.h
@@ -14,14 +14,14 @@
     #define NC_LOG_ERROR(str, ...)        NC_LOG_IMPL('E', str NC_OPT_EXPAND(__VA_ARGS__));
     #define NC_LOG_EXCEPTION(exception)   nc::utility::detail::Log(exception);
 #else
-    #define NC_LOG_INFO(str);
-    #define NC_LOG_WARNING(str);
-    #define NC_LOG_ERROR(str);
+    #define NC_LOG_INFO(str, ...);
+    #define NC_LOG_WARNING(str, ...);
+    #define NC_LOG_ERROR(str, ...);
     #define NC_LOG_EXCEPTION(exception);
 #endif
 
 #if NC_LOG_LEVEL >= 2
     #define NC_LOG_TRACE(str, ...)        NC_LOG_IMPL('V', str NC_OPT_EXPAND(__VA_ARGS__));
 #else
-    #define NC_LOG_TRACE(str);
+    #define NC_LOG_TRACE(str, ...);
 #endif

--- a/include/ncengine/utility/Log.h
+++ b/include/ncengine/utility/Log.h
@@ -1,3 +1,7 @@
+/**
+ * @file Log.h
+ * @copyright Jaremie and McCallister Romer 2023
+ */
 #pragma once
 
 #include "detail/LogInternal.h"
@@ -5,27 +9,19 @@
 #include "fmt/format.h"
 
 #if NC_LOG_LEVEL >= 1
-    #define NC_LOG_INFO(str)             nc::utility::detail::Log(str, 'I');
-    #define NC_LOG_INFO_FMT(str, ...)    nc::utility::detail::Log(fmt::format(str, __VA_ARGS__), 'I');
-    #define NC_LOG_WARNING(str)          nc::utility::detail::Log(str, 'W');
-    #define NC_LOG_WARNING_FMT(str, ...) nc::utility::detail::Log(fmt::format(str, __VA_ARGS__), 'W');
-    #define NC_LOG_ERROR(str)            nc::utility::detail::Log(str, 'E');
-    #define NC_LOG_ERROR_FMT(str, ...)   nc::utility::detail::Log(fmt::format(str, __VA_ARGS__), 'E');
-    #define NC_LOG_EXCEPTION(exception)  nc::utility::detail::Log(exception);
+    #define NC_LOG_INFO(str, ...)         NC_LOG_IMPL('I', str NC_OPT_EXPAND(__VA_ARGS__));
+    #define NC_LOG_WARNING(str, ...)      NC_LOG_IMPL('W', str NC_OPT_EXPAND(__VA_ARGS__));
+    #define NC_LOG_ERROR(str, ...)        NC_LOG_IMPL('E', str NC_OPT_EXPAND(__VA_ARGS__));
+    #define NC_LOG_EXCEPTION(exception)   nc::utility::detail::Log(exception);
 #else
     #define NC_LOG_INFO(str);
-    #define NC_LOG_INFO_FMT(str, ...);
     #define NC_LOG_WARNING(str);
-    #define NC_LOG_WARNING_FMT(str, ...);
     #define NC_LOG_ERROR(str);
-    #define NC_LOG_ERROR_FMT(str, ...);
     #define NC_LOG_EXCEPTION(exception);
 #endif
 
 #if NC_LOG_LEVEL >= 2
-    #define NC_LOG_TRACE(str)          nc::utility::detail::Log(str, 'V');
-    #define NC_LOG_TRACE_FMT(str, ...) nc::utility::detail::Log(fmt::format(str, __VA_ARGS__), 'V');
+    #define NC_LOG_TRACE(str, ...)        NC_LOG_IMPL('V', str NC_OPT_EXPAND(__VA_ARGS__));
 #else
     #define NC_LOG_TRACE(str);
-    #define NC_LOG_TRACE_FMT(str, ...);
 #endif

--- a/include/ncengine/utility/Log.h
+++ b/include/ncengine/utility/Log.h
@@ -1,6 +1,6 @@
 /**
  * @file Log.h
- * @copyright Jaremie and McCallister Romer 2023
+ * @copyright Jaremie Romer and McCallister Romer 2023
  */
 #pragma once
 

--- a/include/ncengine/utility/detail/LogInternal.h
+++ b/include/ncengine/utility/detail/LogInternal.h
@@ -1,11 +1,59 @@
 #pragma once
 
+#include "ncutility/platform/SourceLocation.h"
+
 #include <string_view>
 
-namespace nc::utility::detail
+namespace nc
 {
-void InitializeLog(std::string_view path);
+namespace config
+{
+struct ProjectSettings;
+} // namespace config
+
+namespace utility::detail
+{
+void InitializeLog(const config::ProjectSettings& settings);
 void CloseLog() noexcept;
-void Log(std::string_view item, char prefix) noexcept;
+void Log(char prefix, std::string_view item) noexcept;
+void Log(char prefix, std::string_view file, int line, std::string_view item) noexcept;
 void Log(const std::exception& e) noexcept;
+
+constexpr auto TrimToFilename(const char* path) noexcept -> const char*
+{
+    constexpr auto separator =
+        #if defined(_WIN32) && ! defined(__MINGW32__)
+            '\\';
+        #else
+            '/';
+        #endif
+
+    auto file = path;
+    while (*path)
+    {
+        if (*path++ == separator)
+            file = path;
+    }
+
+    return file;
 }
+} // namespace utility::detail
+} // namespace nc
+
+#define NC_LOG_IMPL(prefix, ...)                                              \
+nc::utility::detail::Log(prefix,                                              \
+                         nc::utility::detail::TrimToFilename(NC_SOURCE_FILE), \
+                         NC_SOURCE_LINE,                                      \
+                         fmt::format(__VA_ARGS__));
+
+#define NC_VA_OPT_SUPPORTED_SELECT(a,b,c,...) c
+#define NC_VA_OPT_SUPPORTED_IMPL(...) NC_VA_OPT_SUPPORTED_SELECT(__VA_OPT__(,),true,false,)
+#define NC_VA_OPT_SUPPORTED NC_VA_OPT_SUPPORTED_IMPL(?)
+
+#if NC_VA_OPT_SUPPORTED
+    #define NC_OPT_EXPAND(...) __VA_OPT__(,) __VA_ARGS__
+#elif defined(__GNUC__)
+    #define NC_OPT_EXPAND(...) , ##__VA_ARGS__
+#else
+    #define NC_OPT_EXPAND(...) , __VA_ARGS__
+#endif

--- a/sample/config.ini
+++ b/sample/config.ini
@@ -1,6 +1,7 @@
 [project_settings]
 project_name=NcEngine Samples
-log_file_path=Diagnostics.log
+log_file_path=Sample.log
+log_max_file_size=1000000
 [asset_settings]
 audio_clips_path=nca\audio_clip\
 concave_colliders_path=nca\concave_collider\

--- a/source/engine/audio/DeviceStream.cpp
+++ b/source/engine/audio/DeviceStream.cpp
@@ -58,7 +58,7 @@ class DeviceStream::ErrorContext
         {
             return [this](RtAudioErrorType type, const std::string& errorText)
             {
-                NC_LOG_ERROR_FMT("Audio device error: '{}'\n\tError Text: '{}'", ToString(type), errorText);
+                NC_LOG_ERROR("Audio device error: '{}'\n\tError Text: '{}'", ToString(type), errorText);
                 SetStatus(nc::audio::StreamStatus::Failed);
             };
         }
@@ -73,7 +73,7 @@ DeviceStream::DeviceStream(const StreamParameters& params)
       m_rtAudio{std::make_unique<RtAudio>(RtAudio::Api::UNSPECIFIED, m_errorContext->MakeCallback())},
       m_activeDevice{g_nullDevice}
 {
-    NC_LOG_INFO_FMT("Audio API: {}", m_rtAudio->getApiName(m_rtAudio->getCurrentApi()));
+    NC_LOG_INFO("Audio API: {}", m_rtAudio->getApiName(m_rtAudio->getCurrentApi()));
     OpenStream(params);
 }
 
@@ -92,7 +92,7 @@ auto DeviceStream::OpenStream(const StreamParameters& params) -> bool
         return false;
     }
 
-    NC_LOG_INFO_FMT("Selected audio output device: '{}'", m_activeDevice.name);
+    NC_LOG_INFO("Selected audio output device: '{}'", m_activeDevice.name);
     auto rtParams = RtAudio::StreamParameters{m_activeDevice.id, params.channelCount, 0};
     m_bufferFrames = params.bufferFrames;
     const auto result = m_rtAudio->openStream(&rtParams,
@@ -105,14 +105,14 @@ auto DeviceStream::OpenStream(const StreamParameters& params) -> bool
                                               nullptr);
     if (result)
     {
-        NC_LOG_ERROR_FMT("Failed to open audio stream: '{}'", ::ToString(result));
+        NC_LOG_ERROR("Failed to open audio stream: '{}'", ::ToString(result));
         m_activeDevice = g_nullDevice;
         return false;
     }
 
     if (auto startResult = m_rtAudio->startStream())
     {
-        NC_LOG_ERROR_FMT("Failed to start audio stream: '{}'", ::ToString(startResult));
+        NC_LOG_ERROR("Failed to start audio stream: '{}'", ::ToString(startResult));
         m_activeDevice = g_nullDevice;
         return false;
     }
@@ -133,7 +133,7 @@ void DeviceStream::CloseStream() noexcept
 
     if (auto result = m_rtAudio->isStreamRunning() ? m_rtAudio->stopStream() : RTAUDIO_NO_ERROR)
     {
-        NC_LOG_ERROR_FMT("Failed to stop audio stream: '{}'", ::ToString(result));
+        NC_LOG_ERROR("Failed to stop audio stream: '{}'", ::ToString(result));
         return;
     }
 

--- a/source/engine/audio/NcAudioImpl.cpp
+++ b/source/engine/audio/NcAudioImpl.cpp
@@ -127,7 +127,7 @@ void NcAudioImpl::OnBuildTaskGraph(task::TaskGraph& graph)
 
 void NcAudioImpl::RegisterListener(Entity listener) noexcept
 {
-    NC_LOG_TRACE_FMT("Registering audio listener: {}", listener.Index());
+    NC_LOG_TRACE("Registering audio listener: {}", listener.Index());
     m_listener = listener;
 }
 

--- a/source/engine/config/Config.cpp
+++ b/source/engine/config/Config.cpp
@@ -19,6 +19,7 @@ using namespace std::literals;
 // project
 constexpr auto ProjectNameKey = "project_name"sv;
 constexpr auto LogFilePathKey = "log_file_path"sv;
+constexpr auto LogMaxFileSizeKey = "log_max_file_size"sv;
 
 // asset
 constexpr auto AudioClipsPathKey = "audio_clips_path"sv;
@@ -145,6 +146,7 @@ auto BuildFromConfigMap(const std::unordered_map<std::string, std::string>& kvPa
     {
         ParseValueIfExists(out.projectName, ProjectNameKey, kvPairs);
         ParseValueIfExists(out.logFilePath, LogFilePathKey, kvPairs);
+        ParseValueIfExists(out.logMaxFileSize, LogMaxFileSizeKey, kvPairs);
     }
     else if constexpr (std::same_as<Struct_t, nc::config::AssetSettings>)
     {
@@ -275,6 +277,7 @@ void Write(std::ostream& stream, const Config& config, bool writeSections)
     if (writeSections) stream << "[project_settings]\n";
     ::WriteKVPair(stream, ProjectNameKey, config.projectSettings.projectName);
     ::WriteKVPair(stream, LogFilePathKey, config.projectSettings.logFilePath);
+    ::WriteKVPair(stream, LogMaxFileSizeKey, config.projectSettings.logMaxFileSize);
 
     if (writeSections) stream << "[asset_settings]\n";
     ::WriteKVPair(stream, AudioClipsPathKey, config.assetSettings.audioClipsPath);
@@ -320,6 +323,7 @@ bool Validate(const Config& config)
 {
     return (config.projectSettings.projectName != "") &&
            (config.projectSettings.logFilePath != "") &&
+           (config.projectSettings.logMaxFileSize > 0) &&
            (config.assetSettings.audioClipsPath != "") &&
            (config.assetSettings.concaveCollidersPath != "") &&
            (config.assetSettings.hullCollidersPath != "") &&

--- a/source/engine/engine/NcEngineImpl.cpp
+++ b/source/engine/engine/NcEngineImpl.cpp
@@ -1,6 +1,7 @@
 #include "NcEngineImpl.h"
 #include "RegistryFactories.h"
 #include "config/ConfigInternal.h"
+#include "config/Version.h"
 #include "input/InputInternal.h"
 #include "utility/Log.h"
 
@@ -27,7 +28,7 @@ void LogConfig(const nc::config::Config& config)
         }
     }
 
-    NC_LOG_INFO_FMT("Initializing NcEngine with Config:\n{}", configStr);
+    NC_LOG_INFO("Initializing NcEngine with Config:\n{}", configStr);
 }
 } // anonymous namespace
 
@@ -36,9 +37,9 @@ namespace nc
 auto InitializeNcEngine(const config::Config& config) -> std::unique_ptr<NcEngine>
 {
     config::SetConfig(config);
-    utility::detail::InitializeLog(config.projectSettings.logFilePath);
+    utility::detail::InitializeLog(config.projectSettings);
     ::LogConfig(config);
-    NC_LOG_INFO("Creating NcEngine instance");
+    NC_LOG_INFO("Creating NcEngine instance v{}", NC_PROJECT_VERSION);
     return std::make_unique<NcEngineImpl>(config);
 }
 

--- a/source/engine/graphics/NcGraphicsImpl.cpp
+++ b/source/engine/graphics/NcGraphicsImpl.cpp
@@ -79,7 +79,7 @@ namespace nc::graphics
 
     void NcGraphicsImpl::SetCamera(Camera* camera) noexcept
     {
-        NC_LOG_TRACE_FMT("Setting main camera to: {}", static_cast<void*>(camera));
+        NC_LOG_TRACE("Setting main camera to: {}", static_cast<void*>(camera));
         m_cameraSystem.Set(camera);
     }
 
@@ -90,7 +90,7 @@ namespace nc::graphics
 
     void NcGraphicsImpl::SetUi(ui::IUI* ui) noexcept
     {
-        NC_LOG_TRACE_FMT("Setting UI to {}", static_cast<void*>(ui));
+        NC_LOG_TRACE("Setting UI to {}", static_cast<void*>(ui));
         m_uiSystem.SetClientUI(ui);
     }
 
@@ -101,7 +101,7 @@ namespace nc::graphics
 
     void NcGraphicsImpl::SetSkybox(const std::string& path)
     {
-        NC_LOG_TRACE_FMT("Setting skybox to {}", path);
+        NC_LOG_TRACE("Setting skybox to {}", path);
         m_environmentSystem.SetSkybox(path);
     }
 


### PR DESCRIPTION
resolves #471

- Removing need for separate fmt/non-fmt log variants.
  - Had to add a few macros to make this work. Ideally we'd just use __VA_OPT__ to discard the extra comma when `...` is empty, but MSVC doesn't support it by default, and enabling it barfed on some 3rd party things. So we have `NC_OPT_EXPAND` to select between a few options.
- Adding source file/line information to each log message. We were only doing this for exceptions before.
  - Since `std::source_location` gives back the whole path the a source file, I also added an internal helper, `TrimToFilename()`.
- Adding a max log size + 2 rotating log files. These default to 1MB a piece, but can be set in the config.
- Logging engine version on intialization.