### PR TITLE
Stable Registry

### DIFF
--- a/include/ncengine/ecs/Registry.h
+++ b/include/ncengine/ecs/Registry.h
@@ -6,6 +6,7 @@
 #include "detail/HandleManager.h"
 #include "detail/PerComponentStorage.h"
 #include "detail/FreeComponentGroup.h"
+#include "ncengine/type/StableAddress.h"
 
 namespace nc
 {
@@ -21,17 +22,12 @@ concept Viewable = PooledComponent<T> || std::same_as<T, Entity>;
 /**
  * @brief Storage orchestrator for all Entities and Components.
  */
-class Registry
+class Registry : public StableAddress
 {
     using index_type = Entity::index_type;
 
     public:
-        Registry(size_t maxEntities);
-        Registry(Registry&&) = default;
-        Registry& operator=(Registry&&) = default;
-        ~Registry() = default;
-        Registry(const Registry&) = delete;
-        Registry& operator=(const Registry&) = delete;
+        explicit Registry(size_t maxEntities);
 
         /** Entity Functions */
         template<std::same_as<Entity> T>

--- a/source/engine/engine/NcEngineImpl.cpp
+++ b/source/engine/engine/NcEngineImpl.cpp
@@ -46,7 +46,7 @@ auto InitializeNcEngine(const config::Config& config) -> std::unique_ptr<NcEngin
 NcEngineImpl::NcEngineImpl(const config::Config& config)
     : m_window{config.projectSettings, config.graphicsSettings, std::bind_front(&NcEngineImpl::Stop, this)},
       m_registry{BuildRegistry(config.memorySettings.maxTransforms)},
-      m_modules{BuildModuleRegistry(&m_registry, &m_window, config)},
+      m_modules{BuildModuleRegistry(m_registry.get(), &m_window, config)},
       m_executor{task::BuildContext(m_modules.GetAllModules())},
       m_sceneManager{},
       m_isRunning{false}
@@ -99,7 +99,7 @@ void NcEngineImpl::QueueSceneChange(std::unique_ptr<Scene> scene)
 
 auto NcEngineImpl::GetRegistry() noexcept -> Registry*
 {
-    return &m_registry;
+    return m_registry.get();
 }
 
 auto NcEngineImpl::GetModuleRegistry() noexcept -> ModuleRegistry*
@@ -120,7 +120,7 @@ void NcEngineImpl::LoadScene()
         module->OnBeforeSceneLoad();
     }
 
-    m_sceneManager.LoadQueuedScene(&m_registry, ModuleProvider{&m_modules});
+    m_sceneManager.LoadQueuedScene(m_registry.get(), ModuleProvider{&m_modules});
 }
 
 void NcEngineImpl::Clear()
@@ -132,7 +132,7 @@ void NcEngineImpl::Clear()
         module->Clear();
     }
 
-    m_registry.Clear();
+    m_registry->Clear();
 }
 
 void NcEngineImpl::Run()

--- a/source/engine/engine/NcEngineImpl.h
+++ b/source/engine/engine/NcEngineImpl.h
@@ -25,7 +25,7 @@ namespace nc
 
         private:
             window::WindowImpl m_window;
-            nc::Registry m_registry;
+            std::unique_ptr<Registry> m_registry;
             ModuleRegistry m_modules;
             task::Executor m_executor;
             scene::SceneManager m_sceneManager;

--- a/source/engine/engine/RegistryFactories.cpp
+++ b/source/engine/engine/RegistryFactories.cpp
@@ -50,25 +50,25 @@ void Set(nc::Registry& registry, const char* name, void(*drawUI)(T&))
 
 namespace nc
 {
-auto BuildRegistry(size_t maxEntities) -> Registry
+auto BuildRegistry(size_t maxEntities) -> std::unique_ptr<Registry>
 {
     NC_LOG_INFO("Building registry");
-    auto registry = Registry{maxEntities};
-    Set<Transform>(registry, "Transform", editor::TransformUIWidget);
-    Set<Tag>(registry, "Tag", editor::TagUIWidget);
+    auto registry = std::make_unique<Registry>(maxEntities);
+    Set<Transform>(*registry, "Transform", editor::TransformUIWidget);
+    Set<Tag>(*registry, "Tag", editor::TagUIWidget);
 
-    Register<CollisionLogic>(registry, "CollisionLogic", editor::CollisionLogicUIWidget);
-    Register<FrameLogic>(registry, "FrameLogic", editor::FrameLogicUIWidget);
-    Register<FixedLogic>(registry, "FixedLogic", editor::FixedLogicUIWidget);
-    Register<audio::AudioSource>(registry, "AudioSource", editor::AudioSourceUIWidget);
-    Register<graphics::MeshRenderer>(registry, "MeshRenderer", editor::MeshRendererUIWidget);
-    Register<graphics::ParticleEmitter>(registry, "ParticleEmitter", editor::ParticleEmitterUIWidget);
-    Register<graphics::PointLight>(registry, "PointLight", editor::PointLightUIWidget);
-    Register<graphics::ToonRenderer>(registry, "ToonRenderer", editor::ToonRendererUIWidget);
-    Register<net::NetworkDispatcher>(registry, "NetworkDispatcher", editor::NetworkDispatcherUIWidget);
-    Register<physics::Collider>(registry, "Collider", editor::ColliderUIWidget);
-    Register<physics::ConcaveCollider>(registry, "ConcaveCollider", editor::ConcaveColliderUIWidget);
-    Register<physics::PhysicsBody>(registry, "PhysicsBody", editor::PhysicsBodyUIWidget);
+    Register<CollisionLogic>(*registry, "CollisionLogic", editor::CollisionLogicUIWidget);
+    Register<FrameLogic>(*registry, "FrameLogic", editor::FrameLogicUIWidget);
+    Register<FixedLogic>(*registry, "FixedLogic", editor::FixedLogicUIWidget);
+    Register<audio::AudioSource>(*registry, "AudioSource", editor::AudioSourceUIWidget);
+    Register<graphics::MeshRenderer>(*registry, "MeshRenderer", editor::MeshRendererUIWidget);
+    Register<graphics::ParticleEmitter>(*registry, "ParticleEmitter", editor::ParticleEmitterUIWidget);
+    Register<graphics::PointLight>(*registry, "PointLight", editor::PointLightUIWidget);
+    Register<graphics::ToonRenderer>(*registry, "ToonRenderer", editor::ToonRendererUIWidget);
+    Register<net::NetworkDispatcher>(*registry, "NetworkDispatcher", editor::NetworkDispatcherUIWidget);
+    Register<physics::Collider>(*registry, "Collider", editor::ColliderUIWidget);
+    Register<physics::ConcaveCollider>(*registry, "ConcaveCollider", editor::ConcaveColliderUIWidget);
+    Register<physics::PhysicsBody>(*registry, "PhysicsBody", editor::PhysicsBodyUIWidget);
     return registry;
 }
 

--- a/source/engine/engine/RegistryFactories.h
+++ b/source/engine/engine/RegistryFactories.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstddef>
+#include <memory>
 
 namespace nc
 {
@@ -18,7 +19,7 @@ class WindowImpl;
 } // namespace window
 
 // Create a registry instance and register all engine components
-auto BuildRegistry(size_t maxEntities) -> Registry;
+auto BuildRegistry(size_t maxEntities) -> std::unique_ptr<Registry>;
 
 // Create a module registry and register all engine modules
 auto BuildModuleRegistry(Registry* registry,


### PR DESCRIPTION
Updating `Registry` to derive from `StableAddress` and putting it in a `std::unique_ptr`.

The `Registry` generally has a stable address, but we do move it once on initialization when it is returned from its factory. In-progress editor work requires the address to be stable upon construction (need to form a pointer to it from inside the factory). 