### PR TITLE
Update dependencies

### DIFF
--- a/cmake/FetchDependencies.cmake
+++ b/cmake/FetchDependencies.cmake
@@ -10,7 +10,7 @@ include(FetchContent)
 # NcCommon
 FetchContent_Declare(NcCommon
                      GIT_REPOSITORY https://github.com/NcStudios/NcCommon.git
-                     GIT_TAG        origin/vnext
+                     GIT_TAG        v1.1.0
                      GIT_SHALLOW    TRUE
 )
 
@@ -20,7 +20,7 @@ set(NC_TOOLS_BUILD_TESTS OFF)
 
 FetchContent_Declare(nc-tools
                      GIT_REPOSITORY      https://github.com/NcStudios/NcTools.git
-                     GIT_TAG             v2.0.0
+                     GIT_TAG             v3.0.0
                      GIT_SHALLOW         TRUE
 )
 
@@ -28,26 +28,29 @@ FetchContent_Declare(nc-tools
 # We get a pre-built nc-convert so we don't have to build it and its dependencies
 if(UNIX AND NOT APPLE)
     FetchContent_Declare(nc-convert
-                         URL                        https://github.com/NcStudios/NcTools/releases/download/v2.0.0/nc-convert-ubuntu22.04-x64.zip
-                         URL_HASH                   SHA256=ae96abf6349e42d3e5ee06a6431dddf8ae7950ab70d058ed4c8747fb8ee67501
+                         URL                        https://github.com/NcStudios/NcTools/releases/download/v3.0.0/nc-convert-ubuntu22.04-x64.zip
+                         URL_HASH                   SHA256=5B9AAF2597001CC2A4052239F2D50918A274D258506B1BC92DEEDC15D80FC563
                          DOWNLOAD_NO_EXTRACT        FALSE
-                         DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+                         DOWNLOAD_EXTRACT_TIMESTAMP FALSE
     )
 elseif(WIN32)
     FetchContent_Declare(nc-convert
-                         URL                        https://github.com/NcStudios/NcTools/releases/download/v2.0.0/nc-convert-windows-x64.zip
-                         URL_HASH                   SHA256=97f0fe700224c5c9ab34d4538c1d85a89d6bd377f1040a1bff0b496c395edf08
+                         URL                        https://github.com/NcStudios/NcTools/releases/download/v3.0.0/nc-convert-windows-x64.zip
+                         URL_HASH                   SHA256=B94D0A4C29A7B44085267583D424B04DFA2AAB684AB24CCFADB67C94A4C63846
                          DOWNLOAD_NO_EXTRACT        FALSE
-                         DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+                         DOWNLOAD_EXTRACT_TIMESTAMP FALSE
     )
 elseif(APPLE)
     # TODO: #349 Artifact not yet published
 endif()
 
 # Taskflow
+set(TF_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+set(TF_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
+
 FetchContent_Declare(taskflow
-                     GIT_REPOSITORY https://github.com/NcStudios/taskflow.git
-                     GIT_TAG        origin/master
+                     GIT_REPOSITORY https://github.com/taskflow/taskflow.git
+                     GIT_TAG        v3.6.0
                      GIT_SHALLOW    TRUE
 )
 
@@ -57,8 +60,8 @@ set(GLFW_BUILD_TESTS OFF CACHE BOOL "" FORCE)
 set(GLFW_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
 
 FetchContent_Declare(glfw
-                     GIT_REPOSITORY https://github.com/NcStudios/glfw.git
-                     GIT_TAG        origin/master
+                     GIT_REPOSITORY https://github.com/glfw/glfw.git
+                     GIT_TAG        3.3.9
                      GIT_SHALLOW    TRUE
 )
 
@@ -71,7 +74,7 @@ endif()
 
 FetchContent_Declare(optick
                      GIT_REPOSITORY https://github.com/NcStudios/optick.git
-                     GIT_TAG        e45a8480babaca85bd87ecf1e775547e28754881 # origin/release
+                     GIT_TAG        v1.3.0+nc.1
                      GIT_SHALLOW    TRUE
 )
 
@@ -92,8 +95,9 @@ if(${NC_BUILD_TESTS})
     set(INSTALL_GTEST OFF CACHE BOOL "" FORCE)
 
     FetchContent_Declare(googletest
-                        GIT_REPOSITORY https://github.com/NcStudios/googletest.git
-                        GIT_TAG        origin/main
+                         GIT_REPOSITORY https://github.com/NcStudios/googletest.git
+                         GIT_TAG        v1.14.0+nc.1
+                         GIT_SHALLOW    TRUE
     )
 
     FetchContent_MakeAvailable(googletest)


### PR DESCRIPTION
DRAFT: I jumped the gun. Asset importer updates are needed before taking new NcTools.

resolves #422 #481

- Updating the following:
  - NcCommon/NcTools
  - glfw
  - taskflow
  - gtest
- Changing all dependencies to target an actual tag, rather than branch/commit hash
  - Commit hashes with shallow cloning isn't allowed, at least for the last several CMake versions. Older versions don't complain, but it has been a Cadillac-sized thorn.
  - Using a branch name is the most convenient, but we've hit build issues in the past when needing to build from an older commit.