### PR TITLE
Fix pages deployment

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/configure-pages@v2
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: 'build/docs/html'
 


### PR DESCRIPTION
Updated action version required for github pages. Tested [here](https://github.com/NcStudios/NcEngine/actions/runs/7302173445).