### PR TITLE
Get all loaded asset names

### DIFF
--- a/include/ncengine/asset/NcAsset.h
+++ b/include/ncengine/asset/NcAsset.h
@@ -42,16 +42,19 @@ class NcAsset : public Module
         virtual auto OnMeshUpdate() noexcept -> Signal<const MeshUpdateEventData&>& = 0;
 
         /** @brief Get the signal for SkeletalAnimation load and unload events. */
-        virtual auto OnSkeletalAnimationUpdate() noexcept -> Signal<const SkeletalAnimationUpdateEventData&> & = 0;
+        virtual auto OnSkeletalAnimationUpdate() noexcept -> Signal<const SkeletalAnimationUpdateEventData&>& = 0;
 
         /** @brief Get the signal for Texture load and unload events. */
-        virtual auto OnTextureUpdate() noexcept -> Signal<const TextureUpdateEventData&> & = 0;
+        virtual auto OnTextureUpdate() noexcept -> Signal<const TextureUpdateEventData&>& = 0;
+
+        /** @brief Get the names of all loaded assets as an AssetMap. */
+        virtual auto GetLoadedAssets() const noexcept -> AssetMap = 0;
 };
 
 /**
  * @brief Build an NcAsset instance.
- * @param assetSettings Settings for NcAsset.
- * @param memorySettings 
+ * @param assetSettings Settings controlling asset search locations.
+ * @param memorySettings Settings controlling memory limits.
  * @param defaults A collection of assets to be available by default.
  * @return An NcAsset instance.
  */

--- a/source/engine/assets/AssetService.h
+++ b/source/engine/assets/AssetService.h
@@ -3,37 +3,46 @@
 #include "asset/Assets.h"
 #include "service/ServiceLocator.h"
 
+#include "ncasset/AssetType.h"
+
 #include <string_view>
 #include <vector>
 
 namespace nc
 {
-    /** Interface for services that manage assets. */
-    template<AssetView T, class InputType>
-    class IAssetService
-    {
-        public:
-            using data_type = T;
+class IAssetServiceBase
+{
+    public:
+        virtual ~IAssetServiceBase() = default;
 
-            IAssetService();
-            virtual ~IAssetService() = default;
+        virtual auto GetAllLoaded() const -> std::vector<std::string_view> = 0;
+        virtual auto GetAssetType() const noexcept -> asset::AssetType = 0;
+};
 
-            virtual bool Load(const InputType& input, bool isExternal, asset_flags_type flags = AssetFlags::None) = 0;
-            virtual bool Load(std::span<const InputType> inputs, bool isExternal, asset_flags_type flags = AssetFlags::None) = 0;
-            virtual bool Unload(const InputType& input, asset_flags_type flags = AssetFlags::None) = 0;
-            virtual void UnloadAll(asset_flags_type flags = AssetFlags::None) = 0;
-            virtual auto Acquire(const InputType& input, asset_flags_type flags = AssetFlags::None) const -> data_type = 0;
-            virtual bool IsLoaded(const InputType& input, asset_flags_type flags = AssetFlags::None) const = 0;
-            virtual auto GetAllLoaded() const -> std::vector<std::string_view> = 0;
-    };
+/** Interface for services that manage assets. */
+template<AssetView T, class InputType>
+class IAssetService : public IAssetServiceBase
+{
+    public:
+        using data_type = T;
 
-    /** Helper alias for locating asset services. */
-    template<AssetView T, class InputType = std::string>
-    using AssetService = ServiceLocator<IAssetService<T, InputType>>;
+        IAssetService();
 
-    template<AssetView T, class InputType>
-    IAssetService<T, InputType>::IAssetService()
-    {
-        AssetService<T, InputType>::Register(this);
-    }
+        virtual bool Load(const InputType& input, bool isExternal, asset_flags_type flags = AssetFlags::None) = 0;
+        virtual bool Load(std::span<const InputType> inputs, bool isExternal, asset_flags_type flags = AssetFlags::None) = 0;
+        virtual bool Unload(const InputType& input, asset_flags_type flags = AssetFlags::None) = 0;
+        virtual void UnloadAll(asset_flags_type flags = AssetFlags::None) = 0;
+        virtual auto Acquire(const InputType& input, asset_flags_type flags = AssetFlags::None) const -> data_type = 0;
+        virtual bool IsLoaded(const InputType& input, asset_flags_type flags = AssetFlags::None) const = 0;
+};
+
+/** Helper alias for locating asset services. */
+template<AssetView T, class InputType = std::string>
+using AssetService = ServiceLocator<IAssetService<T, InputType>>;
+
+template<AssetView T, class InputType>
+IAssetService<T, InputType>::IAssetService()
+{
+    AssetService<T, InputType>::Register(this);
+}
 } // namespace nc

--- a/source/engine/assets/NcAssetImpl.h
+++ b/source/engine/assets/NcAssetImpl.h
@@ -38,6 +38,7 @@ class NcAssetImpl : public NcAsset
         auto OnMeshUpdate() noexcept -> Signal<const MeshUpdateEventData&> & override;
         auto OnTextureUpdate() noexcept -> Signal<const TextureUpdateEventData&>& override;
         auto OnSkeletalAnimationUpdate() noexcept -> Signal<const SkeletalAnimationUpdateEventData&>& override;
+        auto GetLoadedAssets() const noexcept -> AssetMap override;
 
     private:
         std::unique_ptr<AudioClipAssetManager> m_audioClipManager;

--- a/source/engine/assets/manager/AudioClipAssetManager.h
+++ b/source/engine/assets/manager/AudioClipAssetManager.h
@@ -21,6 +21,7 @@ class AudioClipAssetManager : public IAssetService<AudioClipView, std::string>
         auto Acquire(const std::string& path, asset_flags_type flags = AssetFlags::None) const -> AudioClipView override;
         bool IsLoaded(const std::string& path, asset_flags_type flags = AssetFlags::None) const override;
         auto GetAllLoaded() const -> std::vector<std::string_view> override;
+        auto GetAssetType() const noexcept -> asset::AssetType override { return asset::AssetType::AudioClip; }
 
     private:
         std::unordered_map<std::string, asset::AudioClip> m_audioClips;

--- a/source/engine/assets/manager/ConcaveColliderAssetManager.h
+++ b/source/engine/assets/manager/ConcaveColliderAssetManager.h
@@ -20,6 +20,7 @@ class ConcaveColliderAssetManager : public IAssetService<ConcaveColliderView, st
         auto Acquire(const std::string& path, asset_flags_type flags = AssetFlags::None) const -> ConcaveColliderView override;
         bool IsLoaded(const std::string& path, asset_flags_type flags = AssetFlags::None) const override;
         auto GetAllLoaded() const -> std::vector<std::string_view> override;
+        auto GetAssetType() const noexcept -> asset::AssetType override { return asset::AssetType::ConcaveCollider; }
 
     private:
         std::unordered_map<std::string, asset::ConcaveCollider> m_concaveColliders;

--- a/source/engine/assets/manager/CubeMapAssetManager.h
+++ b/source/engine/assets/manager/CubeMapAssetManager.h
@@ -27,6 +27,7 @@ class CubeMapAssetManager : public IAssetService<CubeMapView, std::string>
         bool IsLoaded(const std::string& path, asset_flags_type flags = AssetFlags::None) const override;
         auto GetAllLoaded() const -> std::vector<std::string_view> override;
         auto OnUpdate() -> Signal<const asset::CubeMapUpdateEventData&>&;
+        auto GetAssetType() const noexcept -> asset::AssetType override { return asset::AssetType::CubeMap; }
 
     private:
         std::vector<std::string> m_cubeMapIds;

--- a/source/engine/assets/manager/HullColliderAssetManager.h
+++ b/source/engine/assets/manager/HullColliderAssetManager.h
@@ -21,6 +21,7 @@ class HullColliderAssetManager : public IAssetService<ConvexHullView, std::strin
         auto Acquire(const std::string& path, asset_flags_type flags = AssetFlags::None) const -> ConvexHullView override;
         bool IsLoaded(const std::string& path, asset_flags_type flags = AssetFlags::None) const override;
         auto GetAllLoaded() const -> std::vector<std::string_view> override;
+        auto GetAssetType() const noexcept -> asset::AssetType override { return asset::AssetType::HullCollider; }
 
     private:
         std::unordered_map<std::string, asset::HullCollider> m_hullColliders;

--- a/source/engine/assets/manager/MeshAssetManager.h
+++ b/source/engine/assets/manager/MeshAssetManager.h
@@ -28,6 +28,7 @@ class MeshAssetManager : public IAssetService<MeshView, std::string>
         auto Acquire(const std::string& path, asset_flags_type flags = AssetFlags::None) const -> MeshView override;
         bool IsLoaded(const std::string& path, asset_flags_type flags = AssetFlags::None) const override;
         auto GetAllLoaded() const -> std::vector<std::string_view> override;
+        auto GetAssetType() const noexcept -> asset::AssetType override { return asset::AssetType::Mesh; }
         auto OnBoneUpdate() -> Signal<const asset::BoneUpdateEventData&>&;
         auto OnMeshUpdate() -> Signal<const asset::MeshUpdateEventData&>&;
 

--- a/source/engine/assets/manager/ShaderAssetManager.h
+++ b/source/engine/assets/manager/ShaderAssetManager.h
@@ -26,6 +26,7 @@ class ShaderAssetManager final : public IAssetService<ShaderView, std::string>
         void UnloadAll(asset_flags_type flags = AssetFlags::None) override;
         auto Acquire(const std::string& path, asset_flags_type flags = AssetFlags::None) const -> ShaderView override;
         auto GetAllLoaded() const -> std::vector<std::string_view> override;
+        auto GetAssetType() const noexcept -> asset::AssetType override { return asset::AssetType::Shader; }
         bool IsLoaded(const std::string& path, asset_flags_type flags = AssetFlags::None) const override;
 
     private:

--- a/source/engine/assets/manager/SkeletalAnimationAssetManager.h
+++ b/source/engine/assets/manager/SkeletalAnimationAssetManager.h
@@ -25,6 +25,7 @@ class SkeletalAnimationAssetManager : public IAssetService<SkeletalAnimationView
         auto Acquire(const std::string& path, asset_flags_type flags = AssetFlags::None) const -> SkeletalAnimationView override;
         bool IsLoaded(const std::string& path, asset_flags_type flags = AssetFlags::None) const override;
         auto GetAllLoaded() const -> std::vector<std::string_view> override;
+        auto GetAssetType() const noexcept -> asset::AssetType override { return asset::AssetType::SkeletalAnimation; }
         auto OnUpdate() -> Signal<const asset::SkeletalAnimationUpdateEventData&>&;
 
     private:

--- a/source/engine/assets/manager/TextureAssetManager.h
+++ b/source/engine/assets/manager/TextureAssetManager.h
@@ -27,6 +27,7 @@ class TextureAssetManager : public IAssetService<TextureView, std::string>
         auto Acquire(const std::string& path, asset_flags_type flags = AssetFlags::None) const -> TextureView override;
         bool IsLoaded(const std::string& path, asset_flags_type flags = AssetFlags::None) const override;
         auto GetAllLoaded() const -> std::vector<std::string_view> override;
+        auto GetAssetType() const noexcept -> asset::AssetType override { return asset::AssetType::Texture; }
         auto OnUpdate() -> Signal<const asset::TextureUpdateEventData&>&;
 
     private:

--- a/test/assets/CMakeLists.txt
+++ b/test/assets/CMakeLists.txt
@@ -289,7 +289,7 @@ add_test(TextureAssetManager_tests TextureAssetManager_tests)
 
 ### SkeletalAnimationAssetManager Tests ###
 add_executable(SkeletalAnimationAssetManager_tests
-SkeletalAnimationAssetManager_tests.cpp
+    SkeletalAnimationAssetManager_tests.cpp
     ${NC_SOURCE_DIR}/assets/manager/SkeletalAnimationAssetManager.cpp
     ${NC_SOURCE_DIR}/assets/AssetData.cpp
 )
@@ -320,3 +320,46 @@ target_link_libraries(SkeletalAnimationAssetManager_tests
 )
 
 add_test(SkeletalAnimationAssetManager_tests SkeletalAnimationAssetManager_tests)
+
+### NcAsset Tests ###
+add_executable(NcAsset_tests
+    NcAsset_tests.cpp
+    ${NC_SOURCE_DIR}/assets/NcAssetImpl.cpp
+    ${NC_SOURCE_DIR}/assets/AssetData.cpp
+    ${NC_SOURCE_DIR}/assets/manager/AssetUtilities.cpp
+    ${NC_SOURCE_DIR}/assets/manager/AudioClipAssetManager.cpp
+    ${NC_SOURCE_DIR}/assets/manager/ConcaveColliderAssetManager.cpp
+    ${NC_SOURCE_DIR}/assets/manager/CubeMapAssetManager.cpp
+    ${NC_SOURCE_DIR}/assets/manager/HullColliderAssetManager.cpp
+    ${NC_SOURCE_DIR}/assets/manager/MeshAssetManager.cpp
+    ${NC_SOURCE_DIR}/assets/manager/ShaderAssetManager.cpp
+    ${NC_SOURCE_DIR}/assets/manager/SkeletalAnimationAssetManager.cpp
+    ${NC_SOURCE_DIR}/assets/manager/TextureAssetManager.cpp
+)
+
+target_compile_definitions(NcAsset_tests
+    PRIVATE
+        NC_TEST_COLLATERAL_DIRECTORY="${NC_TEST_COLLATERAL_DIRECTORY}"
+)
+
+target_include_directories(NcAsset_tests
+    PRIVATE
+        ${NC_INCLUDE_DIR}
+        ${NC_INCLUDE_DIR}/ncengine
+        ${NC_SOURCE_DIR}
+        ${NC_EXTERNAL_DIR}
+)
+
+target_compile_options(NcAsset_tests
+    PUBLIC
+        ${NC_COMPILER_FLAGS}
+)
+
+target_link_libraries(NcAsset_tests
+    PRIVATE
+        NcAsset
+        NcUtility
+        gtest_main
+)
+
+add_test(NcAsset_tests NcAsset_tests)

--- a/test/assets/NcAsset_tests.cpp
+++ b/test/assets/NcAsset_tests.cpp
@@ -1,0 +1,42 @@
+#include "ncengine/asset/NcAsset.h"
+#include "ncengine/config/Config.h"
+#include "gtest/gtest.h"
+
+#include <ranges>
+
+const auto g_assetSettings = nc::config::AssetSettings
+{
+    .audioClipsPath         = NC_TEST_COLLATERAL_DIRECTORY,
+    .concaveCollidersPath   = NC_TEST_COLLATERAL_DIRECTORY,
+    .hullCollidersPath      = NC_TEST_COLLATERAL_DIRECTORY,
+    .meshesPath             = NC_TEST_COLLATERAL_DIRECTORY,
+    .shadersPath            = NC_TEST_COLLATERAL_DIRECTORY,
+    .skeletalAnimationsPath = NC_TEST_COLLATERAL_DIRECTORY,
+    .texturesPath           = NC_TEST_COLLATERAL_DIRECTORY,
+    .cubeMapsPath           = NC_TEST_COLLATERAL_DIRECTORY
+};
+
+const auto g_memorySettings = nc::config::MemorySettings{};
+
+const auto g_defaultAssets = nc::asset::AssetMap
+{
+    {nc::asset::AssetType::AudioClip,         {"sound1.nca"}},
+    {nc::asset::AssetType::ConcaveCollider,   {"concave_collider1.nca"}},
+    {nc::asset::AssetType::CubeMap,           {"skybox1.nca"}},
+    {nc::asset::AssetType::HullCollider,      {"hull_collider1.nca"}},
+    {nc::asset::AssetType::Mesh,              {"mesh1.nca"}},
+    {nc::asset::AssetType::SkeletalAnimation, {"test_animation.nca"}},
+    {nc::asset::AssetType::Texture,           {"texture_base.nca", "texture_normal.nca"}}
+};
+
+TEST(NcAssetTests, GetLoadedAssets_returnsCompleteCollection)
+{
+    auto uut = nc::asset::BuildAssetModule(g_assetSettings, g_memorySettings, g_defaultAssets);
+    uut->OnBeforeSceneLoad();
+    const auto actualAssets = uut->GetLoadedAssets();
+    EXPECT_EQ(g_defaultAssets.size(), actualAssets.size());
+    for (const auto& [type, assets] : uut->GetLoadedAssets())
+    {
+        EXPECT_TRUE(std::ranges::equal(g_defaultAssets.at(type), assets));
+    }
+}

--- a/test/physics/CMakeLists.txt
+++ b/test/physics/CMakeLists.txt
@@ -74,6 +74,7 @@ target_compile_options(Collider_unit_tests
 
 target_link_libraries(Collider_unit_tests
     PRIVATE
+        NcAsset
         NcMath
         gtest_main
 )


### PR DESCRIPTION
- Adding method to `NcAsset` to get all currently loaded assets. This will be used during scene serialization.
  - Also adding a method for getting the `AssetType` from a service because it was a clean way to handle this and may be handy in the future.
- Adding missing default loading for skeletal animations (even though we aren't passing in a default yet).
- Adding a simple test for `NcAsset`. Not really much else to test until the other functions are migrated to the module.