### PR TITLE
Update standard to c++23

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
   schedule:
     - cron: '0 14 * * 5'
   pull_request:
-    branches: [ vnext, release ]
+    branches: [ vnext ]
     paths-ignore:
       - '**/*.md'
       - '**/*.txt'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ option(NC_PROFILING_ENABLED "Enable profiling with Optick" OFF)
 option(NC_PROD_BUILD "Only build NcEngine production binaries." OFF)
 
 # Variables
-set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 set(CMAKE_DEBUG_POSTFIX d)
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
@@ -46,6 +46,9 @@ endif()
 
 # TODO: #383 RtAudio uses deprecated wchar_t conversion
 add_definitions(-D_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING)
+
+# TODO: #494 Remove usage of aligned_storage
+add_definitions(-D_SILENCE_CXX23_ALIGNED_STORAGE_DEPRECATION_WARNING)
 
 # Get dependencies
 include(cmake/FetchDependencies.cmake)


### PR DESCRIPTION
Lots of good things to come, but much is still to be implemented. Primarily bumping to get access to `std::views::zip`.

Also, I guess referencing the now renamed 'release' branch in the build yaml was blocking the CI trigger. Removed that too.