### PR TITLE
Add PointLight in editor

### DIFF
--- a/include/ncengine/ecs/Component.h
+++ b/include/ncengine/ecs/Component.h
@@ -72,10 +72,13 @@ concept Component = PooledComponent<T> || std::derived_from<T, FreeComponent>;
 /** @brief Default storage behavior for pooled components. */
 struct DefaultStoragePolicy
 {
-    /** @brief Allows OnAdd callbacks to be set in the registry. */
+    /** @brief Enable the OnAdd Signal in the component's pool. */
     static constexpr bool EnableOnAddCallbacks = false;
 
-    /** @brief Allows OnRemove callbacks to be set in the registry. */
+    /** @brief Enable the OnCommit Signal in the component's pool. */
+    static constexpr bool EnableOnCommitCallbacks = false;
+
+    /** @brief Enable the OnRemove Signal in the component's pool. */
     static constexpr bool EnableOnRemoveCallbacks = false;
 };
 

--- a/include/ncengine/ecs/Registry.h
+++ b/include/ncengine/ecs/Registry.h
@@ -115,6 +115,13 @@ class Registry : public StableAddress
         }
 
         template<PooledComponent T>
+            requires StoragePolicy<T>::EnableOnCommitCallbacks
+        auto OnCommit() -> Signal<T&>&
+        {
+            return m_impl.GetPool<T>().OnCommit();
+        }
+
+        template<PooledComponent T>
             requires StoragePolicy<T>::EnableOnRemoveCallbacks
         auto OnRemove() -> Signal<Entity>&
         {

--- a/include/ncengine/graphics/PointLight.h
+++ b/include/ncengine/graphics/PointLight.h
@@ -16,7 +16,10 @@ class PointLight final : public ComponentBase
     NC_ENABLE_IN_EDITOR(PointLight)
 
     public:
-        PointLight(Entity entity, const Vector3& ambient, const Vector3& diffuseColor, float diffuseIntensity)
+        PointLight(Entity entity,
+                   const Vector3& ambient = Vector3{1.0f, 0.9f, 0.9f},
+                   const Vector3& diffuseColor = Vector3{1.0f, 0.9f, 0.9f},
+                   float diffuseIntensity = 600.0f)
             : ComponentBase{entity},
               m_ambient{ambient},
               m_diffuseColor{diffuseColor},
@@ -66,7 +69,8 @@ namespace nc
 template<>
 struct StoragePolicy<graphics::PointLight> : DefaultStoragePolicy
 {
-    static constexpr bool EnableOnAddCallbacks = true;
+    static constexpr bool EnableOnAddCallbacks = false;
+    static constexpr bool EnableOnCommitCallbacks = true;
     static constexpr bool EnableOnRemoveCallbacks = true;
 };
 } // namespace nc

--- a/source/engine/engine/ComponentFactories.cpp
+++ b/source/engine/engine/ComponentFactories.cpp
@@ -4,6 +4,7 @@
 #include "ncengine/ecs/Logic.h"
 #include "ncengine/ecs/Registry.h"
 #include "ncengine/graphics/ParticleEmitter.h"
+#include "ncengine/graphics/PointLight.h"
 #include "ncengine/graphics/MeshRenderer.h"
 #include "ncengine/graphics/SkeletalAnimator.h"
 #include "ncengine/graphics/ToonRenderer.h"
@@ -36,6 +37,11 @@ auto CreateFrameLogic(Entity entity, void*) -> FrameLogic
 auto CreateParticleEmitter(Entity entity, void*) -> graphics::ParticleEmitter
 {
     return graphics::ParticleEmitter{entity, graphics::ParticleInfo{}};
+}
+
+auto CreatePointLight(Entity entity, void*) -> graphics::PointLight
+{
+    return graphics::PointLight{entity};
 }
 
 auto CreateMeshRenderer(Entity entity, void*) -> graphics::MeshRenderer

--- a/source/engine/engine/ComponentFactories.h
+++ b/source/engine/engine/ComponentFactories.h
@@ -9,6 +9,7 @@ auto CreateCollisionLogic(Entity entity, void*) -> CollisionLogic;
 auto CreateFixedLogic(Entity entity, void*) -> FixedLogic;
 auto CreateFrameLogic(Entity entity, void*) -> FrameLogic;
 auto CreateParticleEmitter(Entity entity, void*) -> graphics::ParticleEmitter;
+auto CreatePointLight(Entity entity, void*) -> graphics::PointLight;
 auto CreateMeshRenderer(Entity entity, void*) -> graphics::MeshRenderer;
 auto CreateToonRenderer(Entity entity, void*) -> graphics::ToonRenderer;
 auto CreateSkeletalAnimator(Entity entity, void*) -> graphics::SkeletalAnimator;

--- a/source/engine/engine/RegistryFactory.cpp
+++ b/source/engine/engine/RegistryFactory.cpp
@@ -58,7 +58,7 @@ auto BuildRegistry(size_t maxEntities) -> std::unique_ptr<Registry>
     Register<graphics::MeshRenderer>(*registry, MeshRendererId, "MeshRenderer", editor::MeshRendererUIWidget, CreateMeshRenderer, SerializeMeshRenderer, DeserializeMeshRenderer);
     Register<graphics::ToonRenderer>(*registry, ToonRendererId, "ToonRenderer", editor::ToonRendererUIWidget, CreateToonRenderer, SerializeToonRenderer, DeserializeToonRenderer);
     Register<graphics::SkeletalAnimator>(*registry, SkeletalAnimatorId, "SkeletalAnimator", editor::SkeletalAnimatorUIWidget, CreateSkeletalAnimator);
-    Register<graphics::PointLight>(*registry, PointLightId, "PointLight", editor::PointLightUIWidget);//, nullptr, SerializePointLight, DeserializePointLight);
+    Register<graphics::PointLight>(*registry, PointLightId, "PointLight", editor::PointLightUIWidget, CreatePointLight, SerializePointLight, DeserializePointLight);
     Register<graphics::ParticleEmitter>(*registry, ParticleEmitterId, "ParticleEmitter", editor::ParticleEmitterUIWidget, CreateParticleEmitter, SerializeParticleEmitter, DeserializeParticleEmitter);
     Register<physics::Collider>(*registry, ColliderId, "Collider", editor::ColliderUIWidget, CreateCollider, SerializeCollider, DeserializeCollider);
     Register<physics::ConcaveCollider>(*registry, ConcaveColliderId, "ConcaveCollider", editor::ConcaveColliderUIWidget, nullptr, SerializeConcaveCollider, DeserializeConcaveCollider);

--- a/source/engine/graphics/api/vulkan/Lighting.cpp
+++ b/source/engine/graphics/api/vulkan/Lighting.cpp
@@ -35,8 +35,8 @@ Lighting::Lighting(Registry* registry,
       m_shaderDescriptorSets{shaderDescriptorSets},
       m_shaderResources{shaderResources},
       m_dimensions{dimensions},
-      m_onAddPointLightConnection{registry->OnAdd<PointLight>().Connect([this](graphics::PointLight&){OnAddPointLightConnection();})},
-      m_onRemovePointLightConnection{registry->OnRemove<PointLight>().Connect([this](Entity){OnRemovePointLightConnection();})},
+      m_onCommitPointLightConnection{registry->OnCommit<PointLight>().Connect([this](graphics::PointLight&){OnCommitPointLight();})},
+      m_onRemovePointLightConnection{registry->OnRemove<PointLight>().Connect([this](Entity){OnRemovePointLight();})},
       m_numShadowCasters{0u}
 {
 }
@@ -46,7 +46,7 @@ void Lighting::Clear()
     const auto countBeforeClearing = m_numShadowCasters;
     for (auto i = 0u; i < countBeforeClearing; ++i)
     {
-        OnRemovePointLightConnection();
+        OnRemovePointLight();
     }
     m_numShadowCasters = 0u;
 }
@@ -59,11 +59,11 @@ void Lighting::Resize(const Vector2& dimensions)
     m_numShadowCasters = 0u;
     for (auto i = 0u; i < countBeforeClearing; ++i)
     {
-        OnAddPointLightConnection();
+        OnCommitPointLight();
     }
 }
 
-void Lighting::OnAddPointLightConnection()
+void Lighting::OnCommitPointLight()
 {
     m_renderGraph->AddRenderPass(CreateShadowMappingPass(m_dimensions, m_numShadowCasters));
 
@@ -77,7 +77,7 @@ void Lighting::OnAddPointLightConnection()
     m_numShadowCasters++;
 }
 
-void Lighting::OnRemovePointLightConnection()
+void Lighting::OnRemovePointLight()
 {
     m_numShadowCasters--;
     m_renderGraph->RemoveRenderPass(m_ids.back());

--- a/source/engine/graphics/api/vulkan/Lighting.h
+++ b/source/engine/graphics/api/vulkan/Lighting.h
@@ -29,8 +29,8 @@ class Lighting
         void Clear();
 
     private:
-        void OnAddPointLightConnection();
-        void OnRemovePointLightConnection();
+        void OnCommitPointLight();
+        void OnRemovePointLight();
         auto CreateShadowMappingPass(nc::Vector2 dimensions, uint32_t index) -> nc::graphics::RenderPass;
 
         Registry* m_registry;
@@ -41,9 +41,9 @@ class Lighting
         ShaderDescriptorSets* m_shaderDescriptorSets;
         ShaderResources* m_shaderResources;
         Vector2 m_dimensions;
-        Connection<PointLight&> m_onAddPointLightConnection;
+        Connection<PointLight&> m_onCommitPointLightConnection;
         Connection<Entity> m_onRemovePointLightConnection;
         uint32_t m_numShadowCasters;
         std::vector<std::string> m_ids;
 };
-}
+} // namespace nc::graphics


### PR DESCRIPTION
resolves #469, #478

Adding an `OnCommit` signal to `ComponentPool` so we receive events either when a component is initially added or when its merged into the final pool. Added specifically for `Lighting` to address the issue of `Lighting` and `PointLightSystem` getting out of sync when we add `PointLights` through the ui callback.

Adding back the `PointLight` factory and (de)serialize functions.