### PR TITLE
Ecs::Get<T>() returns a reference

### DIFF
--- a/include/ncengine/ecs/InvokeFreeComponent.h
+++ b/include/ncengine/ecs/InvokeFreeComponent.h
@@ -22,22 +22,22 @@ struct InvokeFreeComponent
     /** FrameLogic call operator */
     void operator()(Entity self, Registry* registry, float dt) const
     {
-        if(auto* component = registry->Get<T>(self))
-            component->Run(self, registry, dt);
+        if(registry->Contains<T>(self))
+            registry->Get<T>(self)->Run(self, registry, dt);
     }
 
     /** FixedLogic call operator */
     void operator()(Entity self, Registry* registry) const
     {
-        if(auto* component = registry->Get<T>(self))
-            component->Run(self, registry);
+        if(registry->Contains<T>(self))
+            registry->Get<T>(self)->Run(self, registry);
     }
 
     /** CollisionLogic call operator */
     void operator()(Entity self, Entity hit, Registry* registry) const
     {
-        if(auto* component = registry->Get<T>(self))
-            component->Run(self, hit, registry);
+        if(registry->Contains<T>(self))
+            registry->Get<T>(self)->Run(self, hit, registry);
     }
 };
 } // namespace nc

--- a/include/ncengine/ecs/Registry.h
+++ b/include/ncengine/ecs/Registry.h
@@ -49,7 +49,7 @@ class Registry : public StableAddress
         template<PooledComponent T, class... Args>
         auto Add(Entity entity, Args&&... args) -> T*
         {
-            return m_ecs.Emplace<T>(entity, std::forward<Args>(args)...);
+            return &m_ecs.Emplace<T>(entity, std::forward<Args>(args)...);
         }
 
         template<PooledComponent T>
@@ -67,13 +67,13 @@ class Registry : public StableAddress
         template<PooledComponent T>
         auto Get(Entity entity) -> T*
         {
-            return m_ecs.Get<T>(entity);
+            return &m_ecs.Get<T>(entity);
         }
 
         template<PooledComponent T>
         auto Get(Entity entity) const -> const T*
         {
-            return m_ecs.Get<T>(entity);
+            return &m_ecs.Get<T>(entity);
         }
 
         template<PooledComponent T>
@@ -132,7 +132,7 @@ class Registry : public StableAddress
         template<std::derived_from<FreeComponent> T, class... Args>
         auto Add(Entity entity, Args&&... args) -> T*
         {
-            return m_ecs.Emplace<T>(entity, std::forward<Args>(args)...);
+            return &m_ecs.Emplace<T>(entity, std::forward<Args>(args)...);
         }
 
         template<std::derived_from<FreeComponent> T>
@@ -150,13 +150,13 @@ class Registry : public StableAddress
         template<std::derived_from<FreeComponent> T>
         auto Get(Entity entity) -> T*
         {
-            return m_ecs.Get<T>(entity);
+            return &m_ecs.Get<T>(entity);
         }
 
         template<std::derived_from<FreeComponent> T>
         auto Get(Entity entity) const -> const T*
         {
-            return m_ecs.Get<T>(entity);
+            return &m_ecs.Get<T>(entity);
         }
 
         /** Engine Functions */

--- a/sample/source/shared/GameLogic.cpp
+++ b/sample/source/shared/GameLogic.cpp
@@ -20,10 +20,11 @@ void WasdBasedMovement(Entity self, Registry* registry, float dt)
 void ForceBasedMovement(Entity self, Registry* registry)
 {
     static constexpr float force = 0.7f;
-    auto* body = registry->Get<physics::PhysicsBody>(self);
 
-    if(!body)
+    if(!registry->Contains<physics::PhysicsBody>(self))
         return;
+
+    auto* body = registry->Get<physics::PhysicsBody>(self);
 
     if(KeyHeld(input::KeyCode::W))
         body->ApplyImpulse(Vector3::Front() * force);
@@ -55,25 +56,37 @@ void DestroyOnTriggerExit(Entity, Entity hit, Registry* registry)
 
 void LogOnCollisionEnter(Entity, Entity hit, Registry* registry)
 {
-    if(auto* tag = registry->Get<Tag>(hit); tag)
+    if(registry->Contains<Entity>(hit))
+    {
+        auto* tag = registry->Get<Tag>(hit);
         GameLog::Log(std::string{"Collision Enter: "} + tag->Value().data());
+    }
 }
 
 void LogOnCollisionExit(Entity, Entity hit, Registry* registry)
 {
-    if(auto* tag = registry->Get<Tag>(hit); tag)
+    if(registry->Contains<Entity>(hit))
+    {
+        auto* tag = registry->Get<Tag>(hit);
         GameLog::Log(std::string{"Collision Exit: "} + tag->Value().data());
+    }
 }
 
 void LogOnTriggerEnter(Entity, Entity hit, Registry* registry)
 {
-    if(auto* tag = registry->Get<Tag>(hit); tag)
+    if(registry->Contains<Entity>(hit))
+    {
+        auto* tag = registry->Get<Tag>(hit);
         GameLog::Log(std::string{"Trigger Enter: "} + tag->Value().data());
+    }
 }
 
 void LogOnTriggerExit(Entity, Entity hit, Registry* registry)
 {
-    if(auto* tag = registry->Get<Tag>(hit); tag)
+    if(registry->Contains<Entity>(hit))
+    {
+        auto* tag = registry->Get<Tag>(hit);
         GameLog::Log(std::string{"Trigger Exit: "} + tag->Value().data());
+    }
 }
 }

--- a/sample/source/shared/spawner/Spawner.h
+++ b/sample/source/shared/spawner/Spawner.h
@@ -106,10 +106,14 @@ inline void Spawner::Spawn(Registry* registry, unsigned count)
 
         registry->Add<FrameLogic>(handle, [](Entity self, Registry* reg, float dt)
         {
-            if(auto* translation = reg->Get<ConstantTranslation>(self))
-                translation->Run(self, reg, dt);
-            if(auto* rotation = reg->Get<ConstantRotation>(self))
-                rotation->Run(self, reg, dt);
+            if(reg->Contains<ConstantTranslation>(self))
+            {
+                reg->Get<ConstantTranslation>(self)->Run(self, reg, dt);
+            }
+            if(reg->Contains<ConstantRotation>(self))
+            {
+                reg->Get<ConstantRotation>(self)->Run(self, reg, dt);
+            }
         });
 
         if(m_extension)

--- a/source/engine/audio/NcAudioImpl.cpp
+++ b/source/engine/audio/NcAudioImpl.cpp
@@ -240,12 +240,12 @@ void NcAudioImpl::MixToBuffer(double* buffer)
     const auto bufferSizeInBytes = ::IndividualBufferSize(bufferFrames) * sizeof(double);
     std::memset(buffer, 0, bufferSizeInBytes);
 
-    const auto* listenerTransform = m_registry->Get<Transform>(m_listener);
-    if(!listenerTransform)
+    if(!m_registry->Contains<Entity>(m_listener))
     {
         throw NcError("Invalid listener registered");
     }
 
+    const auto* listenerTransform = m_registry->Get<Transform>(m_listener);
     const auto listenerPosition = listenerTransform->Position();
     const auto rightEar = listenerTransform->Right();
 

--- a/source/engine/graphics/system/CameraSystem.cpp
+++ b/source/engine/graphics/system/CameraSystem.cpp
@@ -18,7 +18,7 @@ auto CameraSystem::Execute(Registry* registry) -> CameraState
     }
 
     m_mainCamera->UpdateViewMatrix();
-    const auto& transform = registry->Get<Transform>(m_mainCamera->ParentEntity());
+    const auto transform = registry->Get<Transform>(m_mainCamera->ParentEntity());
 
     return CameraState
     {

--- a/source/engine/physics/PhysicsBody.cpp
+++ b/source/engine/physics/PhysicsBody.cpp
@@ -86,11 +86,10 @@ PhysicsBody::PhysicsBody(Entity entity, PhysicsProperties properties, Vector3 li
         m_awake{true}
 {
     auto* registry = ActiveRegistry();
-    auto* collider = registry->Get<Collider>(entity);
-
-    if(!collider)
+    if(!registry->Contains<Collider>(entity))
         throw NcError("PhysicsBody added to Entity with no Collider");
 
+    auto* collider = registry->Get<Collider>(entity);
     if(entity.IsStatic())
     {
         m_properties.mass = 0.0f;

--- a/source/engine/physics/PhysicsPipelineTypes.cpp
+++ b/source/engine/physics/PhysicsPipelineTypes.cpp
@@ -187,14 +187,15 @@ void Manifold::UpdateWorldPoints(const Registry* registry)
      *  cleaner to handle this through registy callbacks, but we can't because the BspTree uses the
      *  ConcaveCollider callback. Long story short, I think we need to support multiple callbacks per
      *  component type. */
-    const auto* transformA = registry->Get<Transform>(m_event.first);
-    const auto* transformB = registry->Get<Transform>(m_event.second);
-    if(!transformA || !transformB)
+
+    if(!registry->Contains<Transform>(m_event.first) || !registry->Contains<Transform>(m_event.second))
     {
         m_contacts.clear();
         return;
     }
 
+    const auto* transformA = registry->Get<Transform>(m_event.first);
+    const auto* transformB = registry->Get<Transform>(m_event.second);
     const auto& aMatrix = transformA->TransformationMatrix();
     const auto& bMatrix = transformB->TransformationMatrix();
 

--- a/source/engine/physics/collision/narrow_phase/NarrowPhase.cpp
+++ b/source/engine/physics/collision/narrow_phase/NarrowPhase.cpp
@@ -84,7 +84,9 @@ auto NarrowPhase::TryGetCollisionLogic(Entity a) -> CollisionLogic*
 {
     if(a.ReceivesCollisionEvents() && m_registry->Contains<Entity>(a))
     {
-        return m_registry->Get<CollisionLogic>(a);
+        return m_registry->Contains<CollisionLogic>(a)
+            ? m_registry->Get<CollisionLogic>(a)
+            : nullptr;
     }
 
     return nullptr;

--- a/source/engine/physics/dynamics/Joint.cpp
+++ b/source/engine/physics/dynamics/Joint.cpp
@@ -108,9 +108,13 @@ void JointSystem::UpdateJoint(Joint& joint, float dt)
     joint.bias = XMVectorScale(XMVectorSubtract(pB, pA), -joint.biasFactor * (1.0f / dt));
 
     /** Fetch inverse mass and inertia of each body */
+    NC_ASSERT(
+        m_registry->Contains<PhysicsBody>(joint.entityA) &&
+        m_registry->Contains<PhysicsBody>(joint.entityB),
+        "UpdateJoint - Entity does not have a PhysicsBody"
+    );
     joint.bodyA = m_registry->Get<PhysicsBody>(joint.entityA);
     joint.bodyB = m_registry->Get<PhysicsBody>(joint.entityB);
-    NC_ASSERT(joint.bodyA && joint.bodyB, "UpdateJoint - Entity does not have a PhysicsBody");
     auto invMassA = joint.bodyA->GetInverseMass();
     const auto& invInertiaA = joint.bodyA->GetInverseInertia();
     auto invMassB = joint.bodyB->GetInverseMass();

--- a/source/engine/physics/dynamics/Solver.cpp
+++ b/source/engine/physics/dynamics/Solver.cpp
@@ -327,8 +327,8 @@ void Solver::GenerateConstraints(std::span<const Manifold> manifolds)
         const Entity entityB = manifold.Event().second;
         auto* transformA = m_registry->Get<Transform>(entityA);
         auto* transformB = m_registry->Get<Transform>(entityB);
-        auto* physBodyA = m_registry->Get<PhysicsBody>(entityA);
-        auto* physBodyB = m_registry->Get<PhysicsBody>(entityB);
+        auto* physBodyA = m_registry->Contains<PhysicsBody>(entityA) ? m_registry->Get<PhysicsBody>(entityA) : nullptr;
+        auto* physBodyB = m_registry->Contains<PhysicsBody>(entityB) ? m_registry->Get<PhysicsBody>(entityB) : nullptr;
 
         if constexpr(EnableDirectPositionCorrection)
         {

--- a/source/engine/physics/proxy/PerFrameProxyCache.h
+++ b/source/engine/physics/proxy/PerFrameProxyCache.h
@@ -46,7 +46,10 @@ void PerFrameProxyCache<ClientData>::Update()
         auto matrix = m_client->template Get<Transform>(entity)->TransformationMatrix();
         auto volume = collider.GetVolume();
         auto estimate = collider.EstimateBoundingVolume(matrix);
-        auto body = m_client->template Get<PhysicsBody>(entity);
+        auto body = m_client->template Contains<PhysicsBody>(entity)
+            ? m_client->template Get<PhysicsBody>(entity)
+            : nullptr;
+
         auto properties = ClientObjectProperties(collider.IsTrigger(), body);
         m_proxies.emplace_back(matrix, volume, estimate, entity, properties);
     }

--- a/source/engine/serialize/EntitySerializationUtility.cpp
+++ b/source/engine/serialize/EntitySerializationUtility.cpp
@@ -7,7 +7,7 @@ void AddChildren(nc::Entity parent,
                  std::function<bool(nc::Entity)>& filter,
                  std::vector<nc::Entity>& out)
 {
-    auto included = ecs.Get<nc::Transform>(parent)->Children() |
+    auto included = ecs.Get<nc::Transform>(parent).Children() |
         std::views::filter(
             [&filter](nc::Entity entity){
                 return entity.IsSerializable() && filter(entity);
@@ -26,15 +26,15 @@ void AddChildren(nc::Entity parent,
 auto ReconstructEntityInfo(nc::Entity entity,
                            nc::ecs::ExplicitEcs<nc::Transform, nc::Tag> ecs) -> nc::EntityInfo
 {
-    const auto transform = ecs.Get<nc::Transform>(entity);
-    const auto tag = ecs.Get<nc::Tag>(entity);
+    const auto& transform = ecs.Get<nc::Transform>(entity);
+    const auto& tag = ecs.Get<nc::Tag>(entity);
     return nc::EntityInfo
     {
-        .position = transform->LocalPosition(),
-        .rotation = transform->LocalRotation(),
-        .scale = transform->LocalScale(),
-        .parent = transform->Parent(),
-        .tag = std::string{tag->Value()},
+        .position = transform.LocalPosition(),
+        .rotation = transform.LocalRotation(),
+        .scale = transform.LocalScale(),
+        .parent = transform.Parent(),
+        .tag = std::string{tag.Value()},
         .layer = entity.Layer(),
         .flags = entity.Flags()
     };
@@ -52,7 +52,7 @@ auto BuildFragmentEntityList(std::span<const Entity> in,
     {
         return entity.IsSerializable()
             && filter(entity)
-            && !ecs.Get<Transform>(entity)->Parent().Valid();
+            && !ecs.Get<Transform>(entity).Parent().Valid();
     });
 
     auto out = std::vector<Entity>{};

--- a/source/engine/ui/editor/impl/windows/EntityContextMenu.cpp
+++ b/source/engine/ui/editor/impl/windows/EntityContextMenu.cpp
@@ -19,7 +19,7 @@ auto EntityContextMenu(Entity entity, ecs::Ecs world) -> Entity
     }
     else if (ImGui::Selectable("Make Root"))
     {
-        world.Get<Transform>(entity)->SetParent(Entity::Null());
+        world.Get<Transform>(entity).SetParent(Entity::Null());
         return entity;
     }
 

--- a/source/engine/ui/editor/impl/windows/SceneGraph.cpp
+++ b/source/engine/ui/editor/impl/windows/SceneGraph.cpp
@@ -7,9 +7,9 @@
 
 namespace
 {
-auto IsRoot(nc::Transform* transform) -> bool
+auto IsRoot(nc::Transform& transform) -> bool
 {
-    return !transform->Parent().Valid();
+    return !transform.Parent().Valid();
 }
 } // anonymous namespace
 
@@ -49,11 +49,11 @@ void SceneGraph::Graph(ecs::Ecs world)
 {
     for(auto entity : world.GetAll<Entity>())
     {
-        auto transform = world.Get<Transform>(entity);
-        auto tag = world.Get<Tag>(entity);
-        if (IsRoot(transform) && PassFilter(*tag))
+        auto& transform = world.Get<Transform>(entity);
+        auto& tag = world.Get<Tag>(entity);
+        if (IsRoot(transform) && PassFilter(tag))
         {
-            GraphNode(world, entity, *tag, *transform);
+            GraphNode(world, entity, tag, transform);
         }
     }
 }
@@ -77,14 +77,14 @@ void SceneGraph::GraphNode(ecs::Ecs world, Entity entity, Tag& tag, Transform& t
     DragAndDropSource<Entity>(&entity);
     DragAndDropTarget<Entity>([entity, world](Entity* source) mutable
     {
-        world.Get<Transform>(*source)->SetParent(entity);
+        world.Get<Transform>(*source).SetParent(entity);
     });
 
     if(isNodeExpanded)
     {
         for(auto child : transform.Children())
         {
-            GraphNode(world, child, *world.Get<Tag>(child), *world.Get<Transform>(child));
+            GraphNode(world, child, world.Get<Tag>(child), world.Get<Transform>(child));
         }
 
         ImGui::TreePop();

--- a/test/ecs/FreeComponentGroup_unit_tests.cpp
+++ b/test/ecs/FreeComponentGroup_unit_tests.cpp
@@ -17,8 +17,8 @@ constexpr auto TestEntity = Entity{0, 0, 0};
 TEST(FreeComponentGroup_unit_test, Add_ValidCall_ConstructsObject)
 {
     auto group = FreeComponentGroup{TestEntity};
-    auto ptr = group.Add<FakeComponent>(TestEntity);
-    EXPECT_EQ(ptr->ParentEntity(), TestEntity);
+    auto& component = group.Add<FakeComponent>(TestEntity);
+    EXPECT_EQ(component.ParentEntity(), TestEntity);
 }
 
 TEST(FreeComponentGroup_unit_test, Add_ReplaceAfterRemove_ConstructsObject)
@@ -28,8 +28,8 @@ TEST(FreeComponentGroup_unit_test, Add_ReplaceAfterRemove_ConstructsObject)
     group.CommitStagedComponents();
     group.Remove<FakeComponent>();
     group.CommitStagedComponents();
-    auto ptr = group.Add<FakeComponent>(TestEntity);
-    EXPECT_EQ(ptr->ParentEntity(), TestEntity);
+    auto& component = group.Add<FakeComponent>(TestEntity);
+    EXPECT_EQ(component.ParentEntity(), TestEntity);
 }
 
 TEST(FreeComponentGroup_unit_test, Add_DoubleCall_Throws)
@@ -102,28 +102,25 @@ TEST(FreeComponentGroup_unit_test, Contains_AfterRemoved_ReturnsFalse)
     EXPECT_FALSE(actual);
 }
 
-TEST(FreeComponentGroup_unit_test, Get_Exists_ReturnsPointer)
+TEST(FreeComponentGroup_unit_test, Get_Exists_Succeeds)
 {
     auto group = FreeComponentGroup{TestEntity};
     group.Add<FakeComponent>(TestEntity);
     group.CommitStagedComponents();
-    auto* ptr = group.Get<FakeComponent>();
-    EXPECT_NE(ptr, nullptr);
+    EXPECT_NO_THROW(group.Get<FakeComponent>());
 }
 
-TEST(FreeComponentGroup_unit_test, Get_ExistsStaged_ReturnsPointer)
+TEST(FreeComponentGroup_unit_test, Get_ExistsStaged_Succeeds)
 {
     auto group = FreeComponentGroup{TestEntity};
     group.Add<FakeComponent>(TestEntity);
-    auto* ptr = group.Get<FakeComponent>();
-    EXPECT_NE(ptr, nullptr);
+    EXPECT_NO_THROW(group.Get<FakeComponent>());
 }
 
-TEST(FreeComponentGroup_unit_test, Get_DoesNotExist_ReturnsNull)
+TEST(FreeComponentGroup_unit_test, Get_DoesNotExist_Throws)
 {
     auto group = FreeComponentGroup{TestEntity};
-    auto* ptr = group.Get<FakeComponent>();
-    EXPECT_EQ(ptr, nullptr);
+    EXPECT_THROW(group.Get<FakeComponent>(), nc::NcError);
 }
 
 TEST(FreeComponentGroup_unit_test, Get_CallAfterRemoved_ReturnsNull)
@@ -133,8 +130,7 @@ TEST(FreeComponentGroup_unit_test, Get_CallAfterRemoved_ReturnsNull)
     group.CommitStagedComponents();
     group.Remove<FakeComponent>();
     group.CommitStagedComponents();
-    auto* ptr = group.Get<FakeComponent>();
-    EXPECT_EQ(ptr, nullptr);
+    EXPECT_THROW(group.Get<FakeComponent>(), nc::NcError);
 }
 
 int main(int argc, char ** argv)

--- a/test/ecs/Registry_unit_tests.cpp
+++ b/test/ecs/Registry_unit_tests.cpp
@@ -289,10 +289,9 @@ TEST_F(Registry_unit_tests, GetComponent_Exists_ReturnsPointer)
     EXPECT_EQ(ptr->value, value);
 }
 
-TEST_F(Registry_unit_tests, GetComponent_BadEntity_ReturnsNull)
+TEST_F(Registry_unit_tests, GetComponent_BadEntity_Throws)
 {
-    auto* actual = registry.Get<Fake1>(Entity{0u, 0u, Entity::Flags::None});
-    EXPECT_EQ(actual, nullptr);
+    EXPECT_THROW(registry.Get<Fake1>(Entity{0u, 0u, Entity::Flags::None}), NcError);
 }
 
 TEST_F(Registry_unit_tests, GetComponent_ExistsStaged_ReturnsPointer)
@@ -305,11 +304,10 @@ TEST_F(Registry_unit_tests, GetComponent_ExistsStaged_ReturnsPointer)
     EXPECT_EQ(ptr->value, value);
 }
 
-TEST_F(Registry_unit_tests, GetComponent_DoesNotExist_ReturnsNull)
+TEST_F(Registry_unit_tests, GetComponent_DoesNotExist_Throws)
 {
     auto handle = registry.Add<Entity>({});
-    auto* ptr = registry.Get<Fake1>(handle);
-    EXPECT_EQ(ptr, nullptr);
+    EXPECT_THROW(registry.Get<Fake1>(handle), NcError);
 }
 
 TEST_F(Registry_unit_tests, GetComponent_CallAfterRemoved_ReturnsNull)
@@ -318,8 +316,7 @@ TEST_F(Registry_unit_tests, GetComponent_CallAfterRemoved_ReturnsNull)
     registry.Add<Fake1>(handle, 1);
     registry.CommitStagedChanges();
     registry.Remove<Fake1>(handle);
-    auto* ptr = registry.Get<Fake1>(handle);
-    EXPECT_EQ(ptr, nullptr);
+    EXPECT_THROW(registry.Get<Fake1>(handle), NcError);
 }
 
 TEST_F(Registry_unit_tests, GetComponentConst_Exists_ReturnsPointer)
@@ -334,11 +331,10 @@ TEST_F(Registry_unit_tests, GetComponentConst_Exists_ReturnsPointer)
     EXPECT_EQ(ptr->value, value);
 }
 
-TEST_F(Registry_unit_tests, GetComponentConst_BadEntity_ReturnsNull)
+TEST_F(Registry_unit_tests, GetComponentConst_BadEntity_Throws)
 {
     const auto& constRegistry = registry;
-    const auto* actual = constRegistry.Get<Fake1>(Entity{0u, 0u, Entity::Flags::None});
-    EXPECT_EQ(actual, nullptr);
+    EXPECT_THROW(constRegistry.Get<Fake1>(Entity{0u, 0u, Entity::Flags::None}), NcError);
 }
 
 TEST_F(Registry_unit_tests, GetComponentConst_ExistsStaged_ReturnsPointer)
@@ -352,23 +348,21 @@ TEST_F(Registry_unit_tests, GetComponentConst_ExistsStaged_ReturnsPointer)
     EXPECT_EQ(ptr->value, value);
 }
 
-TEST_F(Registry_unit_tests, GetComponentConst_DoesNotExist_ReturnsNull)
+TEST_F(Registry_unit_tests, GetComponentConst_DoesNotExist_Throws)
 {
     auto handle = registry.Add<Entity>({});
     const auto& constRegistry = registry;
-    const auto* ptr = constRegistry.Get<Fake1>(handle);
-    EXPECT_EQ(ptr, nullptr);
+    EXPECT_THROW(constRegistry.Get<Fake1>(handle), NcError);
 }
 
-TEST_F(Registry_unit_tests, GetComponentConst_CallAfterRemoved_ReturnsNull)
+TEST_F(Registry_unit_tests, GetComponentConst_CallAfterRemoved_Throws)
 {
     auto handle = registry.Add<Entity>({});
     registry.Add<Fake1>(handle, 1);
     registry.CommitStagedChanges();
     registry.Remove<Fake1>(handle);
     const auto& constRegistry = registry;
-    const auto* ptr = constRegistry.Get<Fake1>(handle);
-    EXPECT_EQ(ptr, nullptr);
+    EXPECT_THROW(constRegistry.Get<Fake1>(handle), NcError);
 }
 
 TEST_F(Registry_unit_tests, GetParent_inPool_returnsParentEntity)

--- a/test/serialize/SceneSerialization_unit_tests.cpp
+++ b/test/serialize/SceneSerialization_unit_tests.cpp
@@ -262,15 +262,13 @@ TEST_F(SceneSerializationTests, RoundTrip_hasEntities_correctlyRestoresEntityVal
         EXPECT_EQ(expected.layer, actualEntity.Layer());
         EXPECT_EQ(expected.flags, actualEntity.Flags());
 
-        const auto actualTransform = ecs.Get<nc::Transform>(actualEntity);
-        ASSERT_NE(nullptr, actualTransform);
-        EXPECT_EQ(expected.position, actualTransform->LocalPosition());
-        EXPECT_EQ(expected.rotation, actualTransform->LocalRotation());
-        EXPECT_EQ(expected.scale, actualTransform->LocalScale());
+        const auto& actualTransform = ecs.Get<nc::Transform>(actualEntity);
+        EXPECT_EQ(expected.position, actualTransform.LocalPosition());
+        EXPECT_EQ(expected.rotation, actualTransform.LocalRotation());
+        EXPECT_EQ(expected.scale, actualTransform.LocalScale());
 
-        const auto actualTag = ecs.Get<nc::Tag>(actualEntity);
-        ASSERT_NE(nullptr, actualTag);
-        EXPECT_EQ(expected.tag, actualTag->Value());
+        const auto& actualTag = ecs.Get<nc::Tag>(actualEntity);
+        EXPECT_EQ(expected.tag, actualTag.Value());
     }
 }
 
@@ -281,7 +279,7 @@ TEST_F(SceneSerializationTests, RoundTrip_hasEntityHierarchy_correctlyRestoresHi
         const auto e2 = ecs.Emplace<nc::Entity>(nc::EntityInfo{.parent = e1, .tag = "2"});
         ecs.Emplace<nc::Entity>(nc::EntityInfo{.parent = e2, .tag = "3"});
         const auto e4 = ecs.Emplace<nc::Entity>(nc::EntityInfo{.tag = "4"});
-        ecs.Get<nc::Transform>(e1)->SetParent(e4); // Disrupt parenting order to ensure we're sorting correctly prior to saving
+        ecs.Get<nc::Transform>(e1).SetParent(e4); // Disrupt parenting order to ensure we're sorting correctly prior to saving
         const auto e5 = ecs.Emplace<nc::Entity>(nc::EntityInfo{ .tag = "exlude me"}); // will filter this out
         ecs.Emplace<nc::Entity>(nc::EntityInfo{ .parent = e5 }); // expect this to get filtered as well
         const auto e6 = ecs.Emplace<nc::Entity>(nc::EntityInfo{ .flags = nc::Entity::Flags::NoSerialize }); // automatically excluded
@@ -292,7 +290,7 @@ TEST_F(SceneSerializationTests, RoundTrip_hasEntityHierarchy_correctlyRestoresHi
     const auto filter = [&ecs = ecs](nc::Entity entity)
     {
         static constexpr auto toExclude = std::string_view{"exlude me"};
-        return ecs.Get<nc::Tag>(entity)->Value() != toExclude;
+        return ecs.Get<nc::Tag>(entity).Value() != toExclude;
     };
 
     auto stream = std::stringstream{};
@@ -306,19 +304,15 @@ TEST_F(SceneSerializationTests, RoundTrip_hasEntityHierarchy_correctlyRestoresHi
     const auto actualEntities = ecs.GetAll<nc::Entity>();
     ASSERT_EQ(4, actualEntities.size());
 
-    const auto transform0 = ecs.Get<nc::Transform>(actualEntities[0]);
-    const auto transform1 = ecs.Get<nc::Transform>(actualEntities[1]);
-    const auto transform2 = ecs.Get<nc::Transform>(actualEntities[2]);
-    const auto transform3 = ecs.Get<nc::Transform>(actualEntities[3]);
-    ASSERT_NE(nullptr, transform0);
-    ASSERT_NE(nullptr, transform1);
-    ASSERT_NE(nullptr, transform2);
-    ASSERT_NE(nullptr, transform3);
+    const auto& transform0 = ecs.Get<nc::Transform>(actualEntities[0]);
+    const auto& transform1 = ecs.Get<nc::Transform>(actualEntities[1]);
+    const auto& transform2 = ecs.Get<nc::Transform>(actualEntities[2]);
+    const auto& transform3 = ecs.Get<nc::Transform>(actualEntities[3]);
 
-    EXPECT_EQ(nc::Entity::Null(), transform0->Parent());
-    EXPECT_EQ(actualEntities[0], transform1->Parent());
-    EXPECT_EQ(actualEntities[1], transform2->Parent());
-    EXPECT_EQ(actualEntities[2], transform3->Parent());
+    EXPECT_EQ(nc::Entity::Null(), transform0.Parent());
+    EXPECT_EQ(actualEntities[0], transform1.Parent());
+    EXPECT_EQ(actualEntities[1], transform2.Parent());
+    EXPECT_EQ(actualEntities[2], transform3.Parent());
 }
 
 TEST_F(SceneSerializationTests, RoundTrip_hasComponents_correctlyLoadsComponents)
@@ -352,16 +346,16 @@ TEST_F(SceneSerializationTests, RoundTrip_hasComponents_correctlyLoadsComponents
     ASSERT_TRUE(ecs.Contains<TestComponent2>(actualEntities[0]));
     ASSERT_FALSE(ecs.Contains<UnserializableTestComponent>(actualEntities[0]));
 
-    EXPECT_EQ(42, ecs.Get<TestComponent1>(actualEntities[0])->value);
-    EXPECT_EQ("test", ecs.Get<TestComponent2>(actualEntities[0])->value);
+    EXPECT_EQ(42, ecs.Get<TestComponent1>(actualEntities[0]).value);
+    EXPECT_EQ("test", ecs.Get<TestComponent2>(actualEntities[0]).value);
 
     ASSERT_TRUE(ecs.Contains<TestComponent1>(actualEntities[1]));
     ASSERT_FALSE(ecs.Contains<TestComponent2>(actualEntities[1]));
-    EXPECT_EQ(900, ecs.Get<TestComponent1>(actualEntities[1])->value);
+    EXPECT_EQ(900, ecs.Get<TestComponent1>(actualEntities[1]).value);
 
     ASSERT_FALSE(ecs.Contains<TestComponent1>(actualEntities[2]));
     ASSERT_TRUE(ecs.Contains<TestComponent2>(actualEntities[2]));
-    EXPECT_EQ("another test", ecs.Get<TestComponent2>(actualEntities[2])->value);
+    EXPECT_EQ("another test", ecs.Get<TestComponent2>(actualEntities[2]).value);
 
     ASSERT_FALSE(ecs.Contains<TestComponent1>(actualEntities[3]));
     ASSERT_FALSE(ecs.Contains<TestComponent2>(actualEntities[3]));


### PR DESCRIPTION
resolves #508

Updating `Get()` in `ComponentPool` and `Ecs` to return a reference (and throw on failure) based on lessons learned from the game jam. `SparseSet` is a visionary and already does this. I did the same for `Emplace()` for consistency (and it never returns nullptr anyway). Leaving `Registry` as it is to reduce the number of changes, and, since we're slowly deleting it, it seemed like wasted effort.