### PR TITLE
Enable Static Entity Rebaking

### DIFF
--- a/include/ncengine/Events.h
+++ b/include/ncengine/Events.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "ncengine/utility/Signal.h"
+
+namespace nc
+{
+/** @brief Signals for internal engine events. */
+struct SystemEvents
+{
+    /**
+     * @brief Event fired when static Entity data is made stale.
+     * @note This operation may be expensive and is intended for editor and debug purposes.
+     */
+    Signal<> rebuildStatics;
+};
+} // namespace nc

--- a/include/ncengine/NcEngine.h
+++ b/include/ncengine/NcEngine.h
@@ -1,9 +1,10 @@
 #pragma once
 
-#include "config/Config.h"
-#include "ecs/Registry.h"
-#include "module/ModuleRegistry.h"
-#include "scene/Scene.h"
+#include "ncengine/Events.h"
+#include "ncengine/config/Config.h"
+#include "ncengine/ecs/Registry.h"
+#include "ncengine/module/ModuleRegistry.h"
+#include "ncengine/scene/Scene.h"
 
 namespace nc
 {
@@ -19,26 +20,20 @@ class NcEngine
          */
         virtual void Start(std::unique_ptr<Scene> initialScene) = 0;
 
-        /**
-         * @brief Signal the engine to stop execution after all tasks have completed.
-         */
+        /** @brief Signal the engine to stop execution after all tasks have completed. */
         virtual void Stop() noexcept = 0;
 
-        /**
-         * @brief Clear all engine state.
-         */
+        /** @brief Clear all engine state. */
         virtual void Shutdown() noexcept = 0;
 
-        /**
-         * @brief Get a reference to the ComponentRegistry.
-         * @brief Get a pointer to the active registry.
-         */
+        /** @brief Get a reference to the ComponentRegistry. */
         virtual auto GetComponentRegistry() noexcept -> ecs::ComponentRegistry& = 0;
 
-        /**
-         * @brief Get a pointer to the module registry.
-         */
+        /** @brief Get a pointer to the module registry. */
         virtual auto GetModuleRegistry() noexcept -> ModuleRegistry* = 0;
+
+        /** @brief Get a reference to the collection of system events. */
+        virtual auto GetSystemEvents() noexcept -> SystemEvents& = 0;
 
         /**
          * @brief Compose a new task graph from all registered modules.

--- a/source/engine/ecs/EcsModule.h
+++ b/source/engine/ecs/EcsModule.h
@@ -1,10 +1,15 @@
 #pragma once
 
-#include "module/Module.h"
+#include "ncengine/module/Module.h"
+#include "ncengine/utility/Signal.h"
 
 #include <memory>
 
-namespace nc { class Registry; }
+namespace nc
+{
+struct SystemEvents;
+class Registry;
+}
 
 namespace nc::ecs
 {
@@ -12,16 +17,18 @@ namespace nc::ecs
 class EcsModule : public Module
 {
     public:
-        EcsModule(Registry* registry) noexcept;
+        EcsModule(Registry* registry, SystemEvents& events) noexcept;
 
         void OnBuildTaskGraph(task::TaskGraph&) override;
         void RunFrameLogic();
 
     private:
         Registry* m_registry;
+        Connection<> m_rebuildStaticConnection;
 
         void UpdateWorldSpaceMatrices();
+        void UpdateStaticWorldSpaceMatrices();
 };
 
-auto BuildEcsModule(Registry* registry) -> std::unique_ptr<EcsModule>;
+auto BuildEcsModule(Registry* registry, SystemEvents& events) -> std::unique_ptr<EcsModule>;
 } // namespace nc::ecs

--- a/source/engine/engine/ModuleFactory.cpp
+++ b/source/engine/engine/ModuleFactory.cpp
@@ -1,5 +1,6 @@
 #include "ModuleFactory.h"
 
+#include "ncengine/Events.h"
 #include "ncengine/asset/DefaultAssets.h"
 #include "ncengine/asset/NcAsset.h"
 #include "ncengine/config/Config.h"
@@ -35,6 +36,7 @@ auto BuildDefaultAssetMap() -> nc::asset::AssetMap
 namespace nc
 {
 auto BuildModuleRegistry(Registry* registry,
+                         SystemEvents& events,
                          window::WindowImpl* window,
                          const config::Config& config) -> std::unique_ptr<ModuleRegistry>
 {
@@ -49,11 +51,12 @@ auto BuildModuleRegistry(Registry* registry,
                                                               config.memorySettings,
                                                               ModuleProvider{moduleRegistry.get()},
                                                               registry,
+                                                              events,
                                                               window));
-    moduleRegistry->Register(nc::physics::BuildPhysicsModule(config.physicsSettings, registry));
+    moduleRegistry->Register(nc::physics::BuildPhysicsModule(config.physicsSettings, registry, events));
     moduleRegistry->Register(nc::audio::BuildAudioModule(config.audioSettings, registry));
     moduleRegistry->Register(nc::time::BuildTimeModule());
-    moduleRegistry->Register(nc::ecs::BuildEcsModule(registry));
+    moduleRegistry->Register(nc::ecs::BuildEcsModule(registry, events));
     moduleRegistry->Register(std::make_unique<nc::Random>());
     return moduleRegistry;
 }

--- a/source/engine/engine/ModuleFactory.h
+++ b/source/engine/engine/ModuleFactory.h
@@ -4,6 +4,7 @@
 
 namespace nc
 {
+struct SystemEvents;
 class ModuleRegistry;
 class Registry;
 
@@ -19,6 +20,7 @@ class WindowImpl;
 
 // Create a module registry and register all engine modules
 auto BuildModuleRegistry(Registry* registry,
+                         SystemEvents& events,
                          window::WindowImpl* window,
                          const config::Config& config) -> std::unique_ptr<ModuleRegistry>;
 } // namespace nc

--- a/source/engine/engine/NcEngineImpl.cpp
+++ b/source/engine/engine/NcEngineImpl.cpp
@@ -56,7 +56,7 @@ NcEngineImpl::NcEngineImpl(const config::Config& config)
     : m_window{config.projectSettings, config.graphicsSettings, std::bind_front(&NcEngineImpl::Stop, this)},
       m_registry{BuildRegistry(config.memorySettings.maxTransforms)},
       m_legacyRegistry{*m_registry},
-      m_modules{BuildModuleRegistry(&m_legacyRegistry, &m_window, config)},
+      m_modules{BuildModuleRegistry(&m_legacyRegistry, m_events, &m_window, config)},
       m_executor{task::BuildContext(m_modules->GetAllModules())},
       m_isRunning{false}
 {
@@ -106,6 +106,11 @@ auto NcEngineImpl::GetComponentRegistry() noexcept -> ecs::ComponentRegistry&
 auto NcEngineImpl::GetModuleRegistry() noexcept -> ModuleRegistry*
 {
     return m_modules.get();
+}
+
+auto NcEngineImpl::GetSystemEvents() noexcept -> SystemEvents&
+{
+    return m_events;
 }
 
 void NcEngineImpl::RebuildTaskGraph()

--- a/source/engine/engine/NcEngineImpl.h
+++ b/source/engine/engine/NcEngineImpl.h
@@ -18,9 +18,11 @@ namespace nc
             void Shutdown() noexcept override;
             auto GetComponentRegistry() noexcept -> ecs::ComponentRegistry& override;
             auto GetModuleRegistry() noexcept -> ModuleRegistry* override;
+            auto GetSystemEvents() noexcept -> SystemEvents& override;
             void RebuildTaskGraph() override;
 
         private:
+            SystemEvents m_events;
             window::WindowImpl m_window;
             std::unique_ptr<ecs::ComponentRegistry> m_registry;
             Registry m_legacyRegistry; // delete once all usage is cutover

--- a/source/engine/graphics/NcGraphicsImpl.cpp
+++ b/source/engine/graphics/NcGraphicsImpl.cpp
@@ -37,6 +37,7 @@ namespace nc::graphics
                              const config::MemorySettings& memorySettings,
                              ModuleProvider modules,
                              Registry* registry,
+                             SystemEvents& events,
                              window::WindowImpl* window) -> std::unique_ptr<NcGraphics>
     {
         if (graphicsSettings.enabled)
@@ -50,7 +51,7 @@ namespace nc::graphics
             auto graphicsApi = GraphicsFactory(projectSettings, graphicsSettings, memorySettings, ncAsset, resourceBus, registry, window);
 
             NC_LOG_TRACE("Building NcGraphics module");
-            return std::make_unique<NcGraphicsImpl>(graphicsSettings, registry, modules, std::move(graphicsApi), std::move(resourceBus), window);
+            return std::make_unique<NcGraphicsImpl>(graphicsSettings, registry, modules, events, std::move(graphicsApi), std::move(resourceBus), window);
         }
 
         NC_LOG_TRACE("Graphics disabled - building NcGraphics stub");
@@ -60,6 +61,7 @@ namespace nc::graphics
     NcGraphicsImpl::NcGraphicsImpl(const config::GraphicsSettings& graphicsSettings,
                                    Registry* registry,
                                    ModuleProvider modules,
+                                   SystemEvents& events,
                                    std::unique_ptr<IGraphics> graphics,
                                    ShaderResourceBus&& shaderResourceBus,
                                    window::WindowImpl* window)
@@ -75,7 +77,7 @@ namespace nc::graphics
                                     modules.Get<asset::NcAsset>()->OnBoneUpdate(),
                                     std::move(shaderResourceBus.skeletalAnimationChannel)},
           m_widgetSystem{},
-          m_uiSystem{registry->GetEcs(), modules}
+          m_uiSystem{registry->GetEcs(), modules, events}
     {
         window->BindGraphicsOnResizeCallback(std::bind_front(&NcGraphicsImpl::OnResize, this));
     }

--- a/source/engine/graphics/NcGraphicsImpl.h
+++ b/source/engine/graphics/NcGraphicsImpl.h
@@ -16,6 +16,7 @@
 
 namespace nc
 {
+struct SystemEvents;
 class Scene;
 
 namespace config
@@ -40,6 +41,7 @@ auto BuildGraphicsModule(const config::ProjectSettings& projectSettings,
                          const config::MemorySettings& memorySettings,
                          ModuleProvider modules,
                          Registry* registry,
+                         SystemEvents& events,
                          window::WindowImpl* window) -> std::unique_ptr<NcGraphics>;
 
 class NcGraphicsImpl : public NcGraphics
@@ -48,6 +50,7 @@ class NcGraphicsImpl : public NcGraphics
         NcGraphicsImpl(const config::GraphicsSettings& graphicsSettings,
                        Registry* registry,
                        ModuleProvider modules,
+                       SystemEvents& events,
                        std::unique_ptr<IGraphics> graphics,
                        ShaderResourceBus&& shaderResourceBus,
                        window::WindowImpl* window);

--- a/source/engine/graphics/system/UISystem.cpp
+++ b/source/engine/graphics/system/UISystem.cpp
@@ -4,8 +4,8 @@
 
 namespace nc::graphics
 {
-UISystem::UISystem(ecs::Ecs world, ModuleProvider modules)
-    : m_editor{ui::editor::BuildEditor(world, modules)}
+UISystem::UISystem(ecs::Ecs world, ModuleProvider modules, SystemEvents& events)
+    : m_editor{ui::editor::BuildEditor(world, modules, events)}
 {
 }
 

--- a/source/engine/graphics/system/UISystem.h
+++ b/source/engine/graphics/system/UISystem.h
@@ -7,6 +7,8 @@
 
 namespace nc
 {
+struct SystemEvents;
+
 namespace asset
 {
 class NcAsset;
@@ -27,7 +29,7 @@ namespace graphics
 class UISystem
 {
     public:
-        UISystem(ecs::Ecs world, ModuleProvider modules);
+        UISystem(ecs::Ecs world, ModuleProvider modules, SystemEvents& events);
         ~UISystem() noexcept;
 
         auto IsHovered() const noexcept -> bool;

--- a/source/engine/physics/NcPhysicsImpl.cpp
+++ b/source/engine/physics/NcPhysicsImpl.cpp
@@ -1,8 +1,9 @@
 #include "NcPhysicsImpl.h"
-#include "config/Config.h"
-#include "physics/ConcaveCollider.h"
-#include "time/Time.h"
-#include "utility/Log.h"
+#include "ncengine/Events.h"
+#include "ncengine/config/Config.h"
+#include "ncengine/physics/ConcaveCollider.h"
+#include "ncengine/time/Time.h"
+#include "ncengine/utility/Log.h"
 
 namespace
 {
@@ -40,20 +41,20 @@ class NcPhysicsStub : public nc::physics::NcPhysics
 
 namespace nc::physics
 {
-auto BuildPhysicsModule(const config::PhysicsSettings& settings, Registry* registry) -> std::unique_ptr<NcPhysics>
+auto BuildPhysicsModule(const config::PhysicsSettings& settings, Registry* registry, SystemEvents& events) -> std::unique_ptr<NcPhysics>
 {
     if(settings.enabled)
     {
         NC_LOG_TRACE("Building NcPhysics module");
-        return std::make_unique<NcPhysicsImpl>(settings, registry);
+        return std::make_unique<NcPhysicsImpl>(settings, registry, events);
     }
 
     NC_LOG_TRACE("Physics disabled - building NcPhysics stub");
     return std::make_unique<NcPhysicsStub>(registry);
 }
 
-NcPhysicsImpl::NcPhysicsImpl(const config::PhysicsSettings& settings, Registry* registry)
-    : m_pipeline{registry, settings.fixedUpdateInterval},
+NcPhysicsImpl::NcPhysicsImpl(const config::PhysicsSettings& settings, Registry* registry, SystemEvents& events)
+    : m_pipeline{registry, settings.fixedUpdateInterval, events.rebuildStatics},
       m_clickableSystem{},
       m_accumulatedTime{0.0},
       m_currentIterations{0u}

--- a/source/engine/physics/NcPhysicsImpl.h
+++ b/source/engine/physics/NcPhysicsImpl.h
@@ -8,12 +8,19 @@
 #include "proxy/PerFrameProxyCache.h"
 #include "task/TaskGraph.h"
 
-namespace nc::config { struct PhysicsSettings; }
+namespace nc
+{
+struct SystemEvents;
 
-namespace nc::physics
+namespace config
+{
+struct PhysicsSettings;
+} // namespace config
+
+namespace physics
 {
 /** @brief Factor for creating a physics module instance */
-auto BuildPhysicsModule(const config::PhysicsSettings& settings, Registry* registry) -> std::unique_ptr<NcPhysics>;
+auto BuildPhysicsModule(const config::PhysicsSettings& settings, Registry* registry, SystemEvents& events) -> std::unique_ptr<NcPhysics>;
 
 /** @brief Physics module implementation.
  * 
@@ -30,7 +37,7 @@ class NcPhysicsImpl final : public NcPhysics
     };
 
     public:
-        NcPhysicsImpl(const config::PhysicsSettings& settings, Registry* registry);
+        NcPhysicsImpl(const config::PhysicsSettings& settings, Registry* registry, SystemEvents& events);
 
         void AddJoint(Entity entityA, Entity entityB, const Vector3& anchorA, const Vector3& anchorB, float bias = 0.2f, float softness = 0.0f) override;
         void RemoveJoint(Entity entityA, Entity entityB) override;
@@ -47,4 +54,5 @@ class NcPhysicsImpl final : public NcPhysics
         float m_accumulatedTime;
         unsigned m_currentIterations;
 };
-} // namespace nc::physics
+} // namespace physics
+} // namespace nc

--- a/source/engine/physics/PhysicsPipeline.h
+++ b/source/engine/physics/PhysicsPipeline.h
@@ -21,7 +21,7 @@ class PhysicsPipeline
     static_assert(ConcavePhase<concave_phase>);
 
     public:
-        PhysicsPipeline(Registry* registry, float fixedTimeStep);
+        PhysicsPipeline(Registry* registry, float fixedTimeStep, Signal<>& rebuildStatics);
 
         void Clear();
         auto GetJointSystem() -> JointSystem* { return &m_jointSystem; }
@@ -39,11 +39,11 @@ class PhysicsPipeline
 };
 
 template<class Stages>
-PhysicsPipeline<Stages>::PhysicsPipeline(Registry* registry, float fixedTimeStep)
+PhysicsPipeline<Stages>::PhysicsPipeline(Registry* registry, float fixedTimeStep, Signal<>& rebuildStatics)
     : m_proxyCache{registry},
       m_broadPhase{},
       m_narrowPhase{registry},
-      m_concavePhase{registry},
+      m_concavePhase{registry, rebuildStatics},
       m_jointSystem{registry},
       m_solver{registry},
       m_registry{registry},

--- a/source/engine/physics/collision/BspTree.h
+++ b/source/engine/physics/collision/BspTree.h
@@ -101,10 +101,6 @@ void BspTree::FindPairs(std::span<const ProxyType> proxies)
         if (proxy.Id().IsStatic())
             continue;
 
-        // DO NOT CHECKIN
-        if (proxy.Id().IsStatic())
-            continue;
-
         /** Find mesh colliders that are in the same region as the estimate. */
         narrowTestMeshIndices.clear();
         BroadTest(0u, proxy.estimate, narrowTestMeshIndices);

--- a/source/engine/physics/collision/BspTree.h
+++ b/source/engine/physics/collision/BspTree.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "ecs/Registry.h"
-#include "physics/ConcaveCollider.h"
+#include "ncengine/ecs/Registry.h"
+#include "ncengine/physics/ConcaveCollider.h"
 #include "physics/PhysicsPipelineTypes.h"
 #include "physics/collision/IntersectionQueries.h"
 
@@ -52,10 +52,11 @@ class BspTree
     static constexpr float PlaneEpsilon = 0.01f;
 
     public:
-        BspTree(Registry* registry);
+        BspTree(Registry* registry, Signal<>& rebuildStatics);
 
         void OnAdd(ConcaveCollider& collider);
         void OnRemove(Entity entity);
+        void Rebuild();
 
         template<Proxy ProxyType>
         void FindPairs(std::span<const ProxyType> proxies);
@@ -69,6 +70,7 @@ class BspTree
         NarrowPhysicsResult m_results;
         Connection<ConcaveCollider&> m_onAddConnection;
         Connection<Entity> m_onRemoveConnection;
+        Connection<> m_onRebuildStaticsConnection;
 
         void AddToTree(const TriMesh& mesh, size_t meshIndex, size_t currentNodeIndex);
         void AddToInnerNode(const TriMesh& mesh, size_t meshIndex, InnerNode* innerNode);
@@ -96,6 +98,10 @@ void BspTree::FindPairs(std::span<const ProxyType> proxies)
     for(size_t i = 0u; i < dynamicCount; ++i)
     {
         const auto& proxy = proxies[i];
+
+        // DO NOT CHECKIN
+        if (proxy.Id().IsStatic())
+            continue;
 
         /** Find mesh colliders that are in the same region as the estimate. */
         narrowTestMeshIndices.clear();

--- a/source/engine/ui/editor/Editor.h
+++ b/source/engine/ui/editor/Editor.h
@@ -7,6 +7,11 @@
 
 #include <memory>
 
+namespace nc
+{
+struct SystemEvents;
+}
+
 namespace nc::ui::editor
 {
 struct EditorHotkeys
@@ -31,6 +36,7 @@ struct EditorContext
     // General game state
     ecs::Ecs world;
     ModuleProvider modules;
+    SystemEvents* events;
 
     // Mutable state
     Entity selectedEntity;
@@ -68,5 +74,6 @@ class Editor
 
 auto BuildEditor(ecs::Ecs world,
                  ModuleProvider modules,
+                 SystemEvents& events,
                  const EditorHotkeys& hotkeys = EditorHotkeys{}) -> std::unique_ptr<Editor>;
 } // namespace nc::ui::editor

--- a/source/engine/ui/editor/impl/EditorImpl.cpp
+++ b/source/engine/ui/editor/impl/EditorImpl.cpp
@@ -32,12 +32,14 @@ auto BuildEditorObjects(nc::ecs::Ecs world, nc::ModuleProvider modules, nc::inpu
 
 auto BuildContext(nc::ecs::Ecs world,
                   nc::ModuleProvider modules,
+                  nc::SystemEvents& events,
                   nc::ui::editor::EditorHotkeys hotkeys) -> nc::ui::editor::EditorContext
 {
     const auto [bucket, camera] = ::BuildEditorObjects(world, modules, hotkeys.toggleEditorCamera);
     return nc::ui::editor::EditorContext{
         .world = world,
         .modules = modules,
+        .events = &events,
         .selectedEntity = nc::Entity::Null(),
         .openState = nc::ui::editor::OpenState::ClosePersisted,
         .dimensions = ImVec2{},
@@ -53,8 +55,8 @@ namespace nc::ui::editor
 class EditorImpl : public Editor
 {
     public:
-        explicit EditorImpl(ecs::Ecs world, ModuleProvider modules, const EditorHotkeys& hotkeys)
-            : Editor{::BuildContext(world, modules, hotkeys)},
+        explicit EditorImpl(ecs::Ecs world, ModuleProvider modules, SystemEvents& events, const EditorHotkeys& hotkeys)
+            : Editor{::BuildContext(world, modules, events, hotkeys)},
               m_ui{m_ctx}
         {
         }
@@ -70,8 +72,9 @@ class EditorImpl : public Editor
 
 auto BuildEditor(ecs::Ecs world,
                  ModuleProvider modules,
+                 SystemEvents& events,
                  const EditorHotkeys& hotkeys) -> std::unique_ptr<Editor>
 {
-    return std::make_unique<EditorImpl>(world, modules, hotkeys);
+    return std::make_unique<EditorImpl>(world, modules, events, hotkeys);
 }
 } // namespace nc::ui::editor

--- a/source/engine/ui/editor/impl/EditorUI.cpp
+++ b/source/engine/ui/editor/impl/EditorUI.cpp
@@ -1,14 +1,11 @@
 #include "EditorUI.h"
 #include "ui/editor/Editor.h"
+#include "ncengine/Events.h"
 #include "ncengine/ecs/Registry.h"
 #include "ncengine/input/Input.h"
 #include "ncengine/scene/NcScene.h"
 #include "ncengine/ui/ImGuiUtility.h"
 #include "ncengine/window/Window.h"
-
-
-
-#include "ncengine/Events.h"
 
 // Helper for setting up initial window layout:
 // Runs a block only the first time its seen by wrapping in an immediately

--- a/source/engine/ui/editor/impl/EditorUI.cpp
+++ b/source/engine/ui/editor/impl/EditorUI.cpp
@@ -6,6 +6,10 @@
 #include "ncengine/ui/ImGuiUtility.h"
 #include "ncengine/window/Window.h"
 
+
+
+#include "ncengine/Events.h"
+
 // Helper for setting up initial window layout:
 // Runs a block only the first time its seen by wrapping in an immediately
 // invoked lambda and storing an arbitrary result in a local static.
@@ -63,7 +67,7 @@ void EditorUI::Draw(EditorContext& ctx)
     RUN_ONCE(WindowLayout(g_initialGraphWidth, g_pivotLeft));
     Window("Scene Graph", ImGuiWindowFlags_MenuBar, [&]()
     {
-        DrawMenu(ncAsset);
+        DrawMenu(ctx);
         m_sceneGraph.Draw(ctx, m_createEntityDialog);
     });
 
@@ -123,7 +127,7 @@ void EditorUI::DrawDialogs(EditorContext& ctx)
         m_loadSceneDialog.Draw(ctx);
 }
 
-void EditorUI::DrawMenu(asset::NcAsset& ncAsset)
+void EditorUI::DrawMenu(EditorContext& ctx)
 {
     if (ImGui::BeginMenuBar())
     {
@@ -132,9 +136,9 @@ void EditorUI::DrawMenu(asset::NcAsset& ncAsset)
             if (ImGui::MenuItem("New"))
                 m_newSceneDialog.Open();
             if (ImGui::MenuItem("Save"))
-                m_saveSceneDialog.Open(ncAsset.GetLoadedAssets());
+                m_saveSceneDialog.Open(ctx.modules.Get<asset::NcAsset>()->GetLoadedAssets());
             if (ImGui::MenuItem("Load"))
-                m_loadSceneDialog.Open(&ncAsset);
+                m_loadSceneDialog.Open(ctx.modules.Get<asset::NcAsset>());
 
             ImGui::EndMenu();
         }
@@ -143,6 +147,8 @@ void EditorUI::DrawMenu(asset::NcAsset& ncAsset)
         {
             if (ImGui::MenuItem("FPS Overlay"))
                 m_fpsOverlay.ToggleOpen();
+            if (ImGui::MenuItem("Rebuild Static Entity Data"))
+                ctx.events->rebuildStatics.Emit();
 
             ImGui::EndMenu();
         }

--- a/source/engine/ui/editor/impl/EditorUI.h
+++ b/source/engine/ui/editor/impl/EditorUI.h
@@ -39,7 +39,7 @@ class EditorUI
         LoadSceneDialog m_loadSceneDialog;
 
         auto ProcessInput(const EditorHotkeys& hotkeys, asset::NcAsset& ncAsset) -> OpenState;
-        void DrawMenu(asset::NcAsset& ncAsset);
+        void DrawMenu(EditorContext& ctx);
         void DrawOverlays(const ImVec2& dimensions);
         void DrawDialogs(EditorContext& ctx);
 };

--- a/source/engine/ui/editor/stub/EditorStub.cpp
+++ b/source/engine/ui/editor/stub/EditorStub.cpp
@@ -18,6 +18,7 @@ auto BuildEditor(ecs::Ecs world, ModuleProvider modules, SystemEvents&, const Ed
     {
         .world = world,
         .modules = modules,
+        .events = nullptr,
         .selectedEntity = Entity::Null(),
         .openState = OpenState::ClosePersisted,
         .dimensions = ImVec2{},

--- a/source/engine/ui/editor/stub/EditorStub.cpp
+++ b/source/engine/ui/editor/stub/EditorStub.cpp
@@ -12,7 +12,7 @@ struct EditorStub : public Editor
     void Draw(ecs::Ecs) override {}
 };
 
-auto BuildEditor(ecs::Ecs world, ModuleProvider modules, const EditorHotkeys& hotkeys) -> std::unique_ptr<Editor>
+auto BuildEditor(ecs::Ecs world, ModuleProvider modules, SystemEvents&, const EditorHotkeys& hotkeys) -> std::unique_ptr<Editor>
 {
     return std::make_unique<EditorStub>(EditorContext
     {

--- a/test/ecs/Transform_unit_tests.cpp
+++ b/test/ecs/Transform_unit_tests.cpp
@@ -1,6 +1,7 @@
 #include "gtest/gtest.h"
 #include "ecs/Registry.h"
 #include "ecs/EcsModule.h"
+#include "ncengine/Events.h"
 
 using namespace nc;
 
@@ -11,8 +12,12 @@ Registry g_registry{g_impl};
 
 namespace ecs
 {
-EcsModule::EcsModule(Registry* registry) noexcept
-    : Module{0ull}, m_registry{registry} {}
+EcsModule::EcsModule(Registry* registry, SystemEvents& events) noexcept
+    : Module{0ull},
+      m_registry{registry},
+      m_rebuildStaticConnection{events.rebuildStatics.Connect([](){})}
+{
+}
 
 void EcsModule::OnBuildTaskGraph(task::TaskGraph&) {}
 void EcsModule::RunFrameLogic()
@@ -65,11 +70,12 @@ class Transform_unit_tests : public ::testing::Test
 {
     public:
         Registry* registry;
+        SystemEvents events;
         ecs::EcsModule ecsModule;
 
         Transform_unit_tests()
             : registry{&g_registry},
-              ecsModule{registry}
+              ecsModule{registry, events}
         {
         }
 


### PR DESCRIPTION
related to #574

Under normal circumstances, static entities should not move. When positioning things in the editor, however, they do. Adding a signal that can be fired by the editor to notify modules of the broken promise. I imagine someday we'll want to update this to include exactly which entities need updating, but, given the scope of what we're currently doing, its totally fine to recompute everything.

We're not really optimizing for this everywhere, but the following are changed accordingly:
- `BspTree` connects a `Rebuild()` method.
- `EcsModule` connects a `UpdateStaticWorldMatrices()` method.
  - Changed the normal update to skip static entities.
- The editor debug menu has an option to fire the event.
  - This is workable, but probably pesky. I want to experiment with it a bit before making any more involved changes, like automatically firing when you update a static transform.