### PR TITLE
Multiple Clips per AudioSource

### DIFF
--- a/include/ncengine/asset/Assets.h
+++ b/include/ncengine/asset/Assets.h
@@ -24,6 +24,7 @@ bool LoadAudioClipAsset(const std::string& path, bool isExternal = false, asset_
 bool LoadAudioClipAssets(std::span<const std::string> paths, bool isExternal = false, asset_flags_type flags = AssetFlags::None);
 bool UnloadAudioClipAsset(const std::string& path, asset_flags_type flags = AssetFlags::None);
 void UnloadAllAudioClipAssets(asset_flags_type flags = AssetFlags::None);
+auto AcquireAudioClipAsset(const std::string& path) -> AudioClipView;
 
 /** Supported file types: .nca */
 bool LoadConcaveColliderAsset(const std::string& path, bool isExternal = false, asset_flags_type flags = AssetFlags::None);

--- a/include/ncengine/audio/AudioSource.h
+++ b/include/ncengine/audio/AudioSource.h
@@ -11,45 +11,115 @@
 
 namespace nc::audio
 {
-/** @todo InverseSquareLaw, Log? */
-enum class AttenuationFunction
+/** @brief Flags applying to all clips in an AudioSource. */
+struct AudioSourceFlags
 {
-    Linear
+    static constexpr uint8_t None    = 0b00000000;
+    static constexpr uint8_t Play    = 0b00000001;
+    static constexpr uint8_t Loop    = 0b00000010;
+    static constexpr uint8_t Spatial = 0b00000100;
 };
 
+/** @brief Properties applying to all clips in an AudioSource. */
 struct AudioSourceProperties
 {
     float gain = 1.0f;
     float innerRadius = 1.0f;
     float outerRadius = 15.0f;
-    AttenuationFunction attenuation = AttenuationFunction::Linear;
-    bool spatialize = false;
-    bool loop = false;
+    uint8_t flags = AudioSourceFlags::None;
 };
 
+/** @brief Indicates an invalid audio clip index. */
+constexpr auto NullClipIndex = UINT32_MAX;
+
+/** @brief Component managing audio clips.
+ * 
+ * An AudioSource may hold any number of audio clips, but only one may be playing at a time. When the Spatial flag
+ * is set, the position of the owning Entity is used as the location of the AudioSource. For audio to be processed,
+ * a listener Entity must be registered with the NcAudio module.
+*/
 class AudioSource : public ComponentBase
 {
-    NC_ENABLE_IN_EDITOR(AudioSource)
-
     public:
-        AudioSource(Entity entity, const std::string& path, AudioSourceProperties properties = AudioSourceProperties{});
+        AudioSource(Entity entity,
+                    std::vector<std::string> clips,
+                    AudioSourceProperties properties = AudioSourceProperties{});
 
-        void SetClip(const std::string& path);
-        void SetProperties(const AudioSourceProperties& properties);
-        void Play() { m_playing = true; m_currentSampleIndex = 0u; }
-        void Stop() { m_playing = false; m_currentSampleIndex = 0u; }
-        auto GetClip() const -> const std::string& { return m_audioClipPath; }
-        auto GetProperties() const -> const AudioSourceProperties& { return m_properties; }
-        bool IsPlaying() const { return m_playing; }
-        bool IsSpatial() const { return m_properties.spatialize; }
+        /** @brief Play the audio clip at a given index. */
+        void Play(uint32_t clipIndex = 0ull);
+
+        /** @brief Play the audio clip following the one most recently played (round-robin). */
+        void PlayNext();
+
+        /** @brief Check if a clip is currently playing. */
+        auto IsPlaying() const noexcept -> bool { return m_properties.flags & AudioSourceFlags::Play; }
+
+        /**
+         * @brief Get the index of the most recently played clip.
+         * @note Returns NullClipIndex if no clip has been played or the most recent clip was removed.
+         */
+        auto GetRecentClipIndex() const noexcept -> uint32_t { return m_currentClipIndex; }
+
+        /** @brief Stop the currently playing audio clip. */
+        void Stop() noexcept { m_properties.flags &= ~AudioSourceFlags::Play; }
+
+        /**
+         * @brief Add an audio clip.
+         * @return The index where the clip was added.
+         */
+        auto AddClip(std::string clip) -> uint32_t;
+
+        /** @brief Replace the audio clip at a given index. */
+        void SetClip(uint32_t clipIndex, std::string clip);
+
+        /**
+         * @brief Remove the audio clip at a given index.
+         * @note This will change the indices of any clips past the removed element.
+         */
+        void RemoveClip(uint32_t clipIndex);
+
+        auto GetClips() const noexcept -> const std::vector<AudioClipView>& { return m_clips; }
+        auto GetAssetPaths() const noexcept -> const std::vector<std::string>& { return m_coldData->assetPaths; }
+        auto GetProperties() const noexcept -> const AudioSourceProperties& { return m_properties; }
+        auto GetGain() const noexcept -> float { return m_properties.gain; }
+        auto GetInnerRadius() const noexcept -> float { return m_properties.innerRadius; }
+        auto GetOuterRadius() const noexcept -> float { return m_properties.outerRadius; }
+        auto IsSpatial() const noexcept -> bool { return m_properties.flags & AudioSourceFlags::Spatial; }
+        auto IsLooping() const noexcept -> bool { return m_properties.flags & AudioSourceFlags::Loop; }
+
+        void SetProperties(const AudioSourceProperties& properties) noexcept { m_properties = properties; }
+        void SetGain(float gain) noexcept { m_properties.gain = gain; }
+        void SetInnerRadius(float radius) noexcept { m_properties.innerRadius = radius; }
+        void SetOuterRadius(float radius) noexcept { m_properties.outerRadius = radius; }
+
+        void SetSpatial(bool spatialize) noexcept
+        {
+            m_properties.flags = spatialize
+                ? m_properties.flags | AudioSourceFlags::Spatial
+                : m_properties.flags & ~AudioSourceFlags::Spatial;
+        }
+
+        void SetLooping(bool loop) noexcept
+        {
+            m_properties.flags = loop
+                ? m_properties.flags | AudioSourceFlags::Loop
+                : m_properties.flags & ~AudioSourceFlags::Loop;
+        }
 
     private:
-        AudioClipView m_audioClip;
-        size_t m_currentSampleIndex;
-        AudioSourceProperties m_properties;
-        std::string m_audioClipPath;
-        bool m_playing;
+        struct AudioSourceColdData
+        {
+            std::vector<std::string> assetPaths;
+        };
 
+        std::vector<AudioClipView> m_clips;
+        uint32_t m_currentClipIndex = NullClipIndex;
+        uint32_t m_currentSampleIndex = 0u;
+        AudioSourceProperties m_properties;
+        std::unique_ptr<AudioSourceColdData> m_coldData;
+
+        void SetPlaying() noexcept { m_properties.flags |= AudioSourceFlags::Play; }
+        void SetStopped() noexcept { m_properties.flags &= ~AudioSourceFlags::Play; }
         void WriteSpatialSamples(double* buffer, size_t frames, const Vector3& sourcePosition, const Vector3& listenerPosition, const Vector3& rightEar);
         void WriteNonSpatialSamples(double* buffer, size_t frames);
 

--- a/sample/source/scenes/PhysicsTest.cpp
+++ b/sample/source/scenes/PhysicsTest.cpp
@@ -11,6 +11,8 @@
 #include "ncengine/physics/NcPhysics.h"
 #include "ncengine/ui/ImGuiUtility.h"
 
+#include "ncengine/audio/NcAudio.h"
+
 namespace nc::sample
 {
 std::function<void(unsigned)> SpawnFunc = nullptr;
@@ -487,6 +489,9 @@ void PhysicsTest::Load(Registry* registry, ModuleProvider modules)
         .rotation = Quaternion::FromEulerAngles(0.7f, 0.0f, 0.0f),
         .tag = "Main Camera"
     });
+
+    modules.Get<audio::NcAudio>()->RegisterListener(vehicle);
+
 
     auto& camera = world.Emplace<FollowCamera>(cameraHandle, vehicle);
     world.Emplace<FrameLogic>(cameraHandle, InvokeFreeComponent<FollowCamera>{});

--- a/sample/source/scenes/PhysicsTest.cpp
+++ b/sample/source/scenes/PhysicsTest.cpp
@@ -11,8 +11,6 @@
 #include "ncengine/physics/NcPhysics.h"
 #include "ncengine/ui/ImGuiUtility.h"
 
-#include "ncengine/audio/NcAudio.h"
-
 namespace nc::sample
 {
 std::function<void(unsigned)> SpawnFunc = nullptr;
@@ -489,9 +487,6 @@ void PhysicsTest::Load(Registry* registry, ModuleProvider modules)
         .rotation = Quaternion::FromEulerAngles(0.7f, 0.0f, 0.0f),
         .tag = "Main Camera"
     });
-
-    modules.Get<audio::NcAudio>()->RegisterListener(vehicle);
-
 
     auto& camera = world.Emplace<FollowCamera>(cameraHandle, vehicle);
     world.Emplace<FrameLogic>(cameraHandle, InvokeFreeComponent<FollowCamera>{});

--- a/source/engine/assets/Assets.cpp
+++ b/source/engine/assets/Assets.cpp
@@ -23,6 +23,11 @@ void UnloadAllAudioClipAssets(asset_flags_type flags)
     AssetService<AudioClipView>::Get()->UnloadAll(flags);
 }
 
+auto AcquireAudioClipAsset(const std::string& path) -> AudioClipView
+{
+    return AssetService<AudioClipView>::Get()->Acquire(path);
+}
+
 bool LoadConvexHullAsset(const std::string& path, bool isExternal, asset_flags_type flags)
 {
     return AssetService<ConvexHullView>::Get()->Load(path, isExternal, flags);

--- a/source/engine/audio/AudioSource.cpp
+++ b/source/engine/audio/AudioSource.cpp
@@ -67,7 +67,7 @@ auto AudioSource::AddClip(std::string clip) -> uint32_t
 
 void AudioSource::SetClip(uint32_t clipIndex, std::string path)
 {
-    NC_ASSERT(clipIndex < m_clips.size(), "Audio clip index out of bound");
+    NC_ASSERT(clipIndex < m_clips.size(), "Audio clip index out of bounds");
     m_clips[clipIndex] = AcquireAudioClipAsset(path);
     m_coldData->assetPaths.at(clipIndex) = std::move(path);
     if (m_currentClipIndex == clipIndex && IsPlaying())

--- a/source/engine/engine/ComponentFactories.cpp
+++ b/source/engine/engine/ComponentFactories.cpp
@@ -16,7 +16,7 @@ namespace nc
 {
 auto CreateAudioSource(Entity entity, void*) -> audio::AudioSource
 {
-    return audio::AudioSource{entity, asset::DefaultAudioClip};
+    return audio::AudioSource{entity, {asset::DefaultAudioClip}};
 }
 
 auto CreateCollisionLogic(Entity entity, void*) -> CollisionLogic

--- a/source/engine/serialize/ComponentSerialization.cpp
+++ b/source/engine/serialize/ComponentSerialization.cpp
@@ -17,19 +17,19 @@ namespace nc
 void SerializeAudioSource(std::ostream& stream, const audio::AudioSource& out, const SerializationContext& ctx, void*)
 {
     serialize::Serialize(stream, ctx.entityMap.at(out.ParentEntity()));
-    serialize::Serialize(stream, out.GetClip());
+    serialize::Serialize(stream, out.GetAssetPaths());
     serialize::Serialize(stream, out.GetProperties());
 }
 
 auto DeserializeAudioSource(std::istream& stream, const DeserializationContext& ctx, void*) -> audio::AudioSource
 {
     auto id = uint32_t{};
-    auto clip = std::string{};
+    auto paths = std::vector<std::string>{};
     auto properties = audio::AudioSourceProperties{};
     serialize::Deserialize(stream, id);
-    serialize::Deserialize(stream, clip);
+    serialize::Deserialize(stream, paths);
     serialize::Deserialize(stream, properties);
-    return audio::AudioSource{ctx.entityMap.at(id), std::move(clip), std::move(properties)};
+    return audio::AudioSource{ctx.entityMap.at(id), std::move(paths), properties};
 }
 
 void SerializeCollider(std::ostream& stream, const physics::Collider& out, const SerializationContext& ctx, void*)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,6 +5,7 @@ add_definitions(-DNC_ASSERT_ENABLED)
 
 add_subdirectory(alloc)
 add_subdirectory(assets)
+add_subdirectory(audio)
 add_subdirectory(config)
 add_subdirectory(ecs)
 add_subdirectory(graphics)

--- a/test/audio/AudioSource_tests.cpp
+++ b/test/audio/AudioSource_tests.cpp
@@ -1,0 +1,163 @@
+#include "gtest/gtest.h"
+#include "ncengine/audio/AudioSource.h"
+
+namespace nc
+{
+auto AcquireAudioClipAsset(const std::string&) -> AudioClipView
+{
+    static auto view = AudioClipView{}; // tests don't actually view clip data
+    return view;
+}
+} // namespace nc
+
+constexpr auto g_entity = nc::Entity{0, 0, 0};
+const auto g_clip1 = std::string{"clip1.nca"};
+const auto g_clip2 = std::string{"clip2.nca"};
+const auto g_clip3 = std::string{"clip3.nca"};
+
+TEST(AudioSourceTests, Play_validClipIndex_setsPlayState)
+{
+    auto uut = nc::audio::AudioSource{g_entity, {g_clip1}};
+    ASSERT_FALSE(uut.IsPlaying());
+    ASSERT_EQ(nc::audio::NullClipIndex, uut.GetRecentClipIndex());
+    uut.Play(0);
+    EXPECT_TRUE(uut.IsPlaying());
+    EXPECT_EQ(0, uut.GetRecentClipIndex());
+}
+
+TEST(AudioSourceTests, Play_invalidClipIndex_throws)
+{
+    auto uut = nc::audio::AudioSource{g_entity, {g_clip1}};
+    EXPECT_THROW(uut.Play(1), nc::NcError);
+}
+
+TEST(AudioSourceTests, PlayNext_hasPreviousState_advancesRoundRobin)
+{
+    auto uut = nc::audio::AudioSource{g_entity, {g_clip1, g_clip2, g_clip3}};
+    uut.Play(0);
+    uut.PlayNext();
+    EXPECT_TRUE(uut.IsPlaying());
+    EXPECT_EQ(1, uut.GetRecentClipIndex());
+    uut.PlayNext();
+    EXPECT_TRUE(uut.IsPlaying());
+    EXPECT_EQ(2, uut.GetRecentClipIndex());
+    uut.PlayNext();
+    EXPECT_TRUE(uut.IsPlaying());
+    EXPECT_EQ(0, uut.GetRecentClipIndex());
+}
+
+TEST(AudioSourceTests, PlayNext_noPreviousState_startsFromBeginning)
+{
+    auto uut = nc::audio::AudioSource{g_entity, {g_clip1}};
+    uut.PlayNext();
+    EXPECT_TRUE(uut.IsPlaying());
+    EXPECT_EQ(0, uut.GetRecentClipIndex());
+}
+
+TEST(AudioSourceTests, PlayNext_empty_throws)
+{
+    auto uut = nc::audio::AudioSource{g_entity, {}};
+    EXPECT_THROW(uut.PlayNext(), nc::NcError);
+}
+
+TEST(AudioSourceTests, Stop_setsPlayState)
+{
+    auto uut = nc::audio::AudioSource{g_entity, {g_clip1}};
+    uut.Play(0);
+    uut.Stop();
+    EXPECT_FALSE(uut.IsPlaying());
+    EXPECT_EQ(0, uut.GetRecentClipIndex());
+}
+
+TEST(AudioSourceTests, Stop_notPlaying_preservesPlayState)
+{
+    auto uut = nc::audio::AudioSource{g_entity, {g_clip1}};
+    uut.Stop();
+    EXPECT_FALSE(uut.IsPlaying());
+    EXPECT_EQ(nc::audio::NullClipIndex, uut.GetRecentClipIndex());
+}
+
+TEST(AudioSourceTests, AddClip_updatesClipsAndPaths)
+{
+    auto uut = nc::audio::AudioSource{g_entity, {g_clip1}};
+    const auto actualIndex = uut.AddClip(g_clip2);
+    ASSERT_EQ(1, actualIndex);
+    EXPECT_EQ(2, uut.GetClips().size());
+    const auto paths = uut.GetAssetPaths();
+    ASSERT_EQ(2, paths.size());
+    EXPECT_EQ(g_clip2, paths[actualIndex]);
+}
+
+TEST(AudioSourceTests, SetClip_validClipIndex_replacesClip)
+{
+    auto uut = nc::audio::AudioSource{g_entity, {g_clip1, g_clip2}};
+    uut.SetClip(0, g_clip3);
+    EXPECT_EQ(2, uut.GetClips().size());
+    const auto paths = uut.GetAssetPaths();
+    ASSERT_EQ(2, paths.size());
+    EXPECT_EQ(g_clip3, paths[0]);
+}
+
+TEST(AudioSourceTests, SetClip_invalidClipIndex_throws)
+{
+    auto uut = nc::audio::AudioSource{g_entity, {g_clip1, g_clip2}};
+    EXPECT_THROW(uut.SetClip(2, g_clip3), nc::NcError);
+}
+
+TEST(AudioSourceTests, SetClip_replacesLastPlayedClip_resetsPlayState)
+{
+    auto uut = nc::audio::AudioSource{g_entity, {g_clip1, g_clip2}};
+    uut.Play(0);
+    uut.SetClip(0, g_clip3);
+    EXPECT_FALSE(uut.IsPlaying());
+    EXPECT_EQ(nc::audio::NullClipIndex, uut.GetRecentClipIndex());
+}
+
+TEST(AudioSourceTests, RemoveClip_validClipIndex_removesClip)
+{
+    auto uut = nc::audio::AudioSource{g_entity, {g_clip1, g_clip2, g_clip3}};
+    uut.RemoveClip(0);
+    ASSERT_EQ(2, uut.GetClips().size());
+    ASSERT_EQ(2, uut.GetAssetPaths().size());
+    EXPECT_EQ(g_clip2, uut.GetAssetPaths()[0]);
+    EXPECT_EQ(g_clip3, uut.GetAssetPaths()[1]);
+    uut.RemoveClip(1);
+    ASSERT_EQ(1, uut.GetClips().size());
+    ASSERT_EQ(1, uut.GetAssetPaths().size());
+    EXPECT_EQ(g_clip2, uut.GetAssetPaths()[0]);
+    uut.RemoveClip(0);
+    ASSERT_EQ(0, uut.GetClips().size());
+    ASSERT_EQ(0, uut.GetAssetPaths().size());
+}
+
+TEST(AudioSourceTests, RemoveClip_invalidClipIndex_throws)
+{
+    auto uut = nc::audio::AudioSource{g_entity, {g_clip1}};
+    EXPECT_THROW(uut.RemoveClip(2), nc::NcError);
+}
+
+TEST(AudioSourceTests, RemoveClip_removesLastPlayedClip_resetsPlayState)
+{
+    auto uut = nc::audio::AudioSource{g_entity, {g_clip1}};
+    uut.Play(0);
+    uut.RemoveClip(0);
+    EXPECT_FALSE(uut.IsPlaying());
+    EXPECT_EQ(nc::audio::NullClipIndex, uut.GetRecentClipIndex());
+}
+
+TEST(AudioSourceTests, FlagGettersAndSetters_updateProperties)
+{
+    auto uut = nc::audio::AudioSource{g_entity, {g_clip1}};
+
+    EXPECT_FALSE(uut.IsSpatial());
+    uut.SetSpatial(true);
+    EXPECT_TRUE(uut.IsSpatial());
+    uut.SetSpatial(false);
+    EXPECT_FALSE(uut.IsSpatial());
+
+    EXPECT_FALSE(uut.IsLooping());
+    uut.SetLooping(true);
+    EXPECT_TRUE(uut.IsLooping());
+    uut.SetLooping(false);
+    EXPECT_FALSE(uut.IsLooping());
+}

--- a/test/audio/CMakeLists.txt
+++ b/test/audio/CMakeLists.txt
@@ -1,0 +1,24 @@
+### Config Tests ###
+add_executable(AudioSource_tests
+    AudioSource_tests.cpp
+    ${NC_SOURCE_DIR}/audio/AudioSource.cpp
+)
+
+target_include_directories(AudioSource_tests
+    PRIVATE
+        ${NC_INCLUDE_DIR}
+)
+
+target_compile_options(AudioSource_tests
+    PUBLIC
+        ${NC_COMPILER_FLAGS}
+)
+
+target_link_libraries(AudioSource_tests
+    PRIVATE
+        NcUtility
+        NcMath
+        gtest_main
+)
+
+add_test(AudioSource_tests AudioSource_tests)

--- a/test/serialize/ComponentSerialization_integration_tests.cpp
+++ b/test/serialize/ComponentSerialization_integration_tests.cpp
@@ -17,16 +17,24 @@
 
 #include <sstream>
 
-DEFINE_ASSET_SERVICE_STUB(audioClipAssetManager, nc::asset::AssetType::AudioClip, nc::AudioClipView, std::string);
 DEFINE_ASSET_SERVICE_STUB(concaveColliderAssetManager, nc::asset::AssetType::ConcaveCollider, nc::ConcaveColliderView, std::string);
 DEFINE_ASSET_SERVICE_STUB(hullColliderAssetManager, nc::asset::AssetType::HullCollider, nc::ConvexHullView, std::string);
 DEFINE_ASSET_SERVICE_STUB(meshAssetManager, nc::asset::AssetType::Mesh, nc::MeshView, std::string);
 DEFINE_ASSET_SERVICE_STUB(textureAssetManager, nc::asset::AssetType::Texture, nc::TextureView, std::string);
 
-namespace nc::graphics
+namespace nc
+{
+auto AcquireAudioClipAsset(const std::string&) -> AudioClipView
+{
+    static auto view = AudioClipView{};
+    return view;
+}
+
+namespace graphics
 {
 void ParticleEmitterSystem::Emit(Entity, size_t) {}
-} // namespace nc::graphics
+} // namespace graphics
+} // namespace nc
 
 // We only need the old Registry here so that it sets the ptr for ActiveRegistry(), which is only used by PhysicsBody.
 auto g_registry = nc::ecs::ComponentRegistry{10ull};
@@ -61,18 +69,18 @@ auto g_deserializationContext = nc::DeserializationContext
 TEST(ComponentSerializationTests, RoundTrip_audioSource_preservesValues)
 {
     auto stream = std::stringstream{};
-    const auto expectedProperties = nc::audio::AudioSourceProperties{};
-    const auto expected = nc::audio::AudioSource{g_entity, "sound.nca", expectedProperties};
+    const auto expectedClips = std::vector<std::string>{"sound1.nca", "sound2.nca"};
+    const auto expectedFlags = nc::audio::AudioSourceFlags::Spatial;
+    const auto expectedProperties = nc::audio::AudioSourceProperties{.flags = expectedFlags};
+    const auto expected = nc::audio::AudioSource{g_entity, expectedClips, expectedProperties};
     nc::SerializeAudioSource(stream, expected, g_serializationContext, nullptr);
     const auto actual = nc::DeserializeAudioSource(stream, g_deserializationContext, nullptr);
-    EXPECT_EQ(expected.GetClip(), actual.GetClip());
+    EXPECT_TRUE(std::ranges::equal(expectedClips, actual.GetAssetPaths()));
     const auto& actualProperties = actual.GetProperties();
     EXPECT_EQ(expectedProperties.gain, actualProperties.gain);
     EXPECT_EQ(expectedProperties.innerRadius, actualProperties.innerRadius);
     EXPECT_EQ(expectedProperties.outerRadius, actualProperties.outerRadius);
-    EXPECT_EQ(expectedProperties.attenuation, actualProperties.attenuation);
-    EXPECT_EQ(expectedProperties.spatialize, actualProperties.spatialize);
-    EXPECT_EQ(expectedProperties.loop, actualProperties.loop);
+    EXPECT_EQ(expectedFlags, actualProperties.flags);
 }
 
 TEST(ComponentSerializationTests, RoundTrip_collider_box_preservesValues)


### PR DESCRIPTION
resolves #223

- Reworking `AudioSource` to hold any number of clips.
  - Added a round-robin-esque `PlayNext()` option I wanted in SS & DD.
  - Also cut down on the size: removed the (basically) unused `AttenuationFunction`, coalesced bools to a bitfield, and put paths behind a cold pointer.
- Updated UI to show multiple clips and the `AudioSourceProperties`. Each clip has a play button next to it now, which is handy.
- Added unit tests for `AudioSource`
  - Added `AcquireAudioClipAsset()` so I didn't have to stub out the whole `AssetService` in the unit tests. I have no idea why we haven't done this already.