### PR TITLE
Asset Manger Updates

### DIFF
--- a/include/ncengine/asset/AssetViews.h
+++ b/include/ncengine/asset/AssetViews.h
@@ -14,6 +14,7 @@ namespace nc
 {
 struct AudioClipView
 {
+    size_t id;
     std::span<const double> leftChannel;
     std::span<const double> rightChannel;
     size_t samplesPerChannel;
@@ -21,12 +22,14 @@ struct AudioClipView
 
 struct ConcaveColliderView
 {
+    size_t id;
     std::span<const Triangle> triangles;
     float maxExtent;
 };
 
 struct ConvexHullView
 {
+    size_t id;
     std::span<const Vector3> vertices;
     Vector3 extents;
     float maxExtent;
@@ -40,12 +43,14 @@ enum class CubeMapUsage
 
 struct CubeMapView
 {
+    size_t id;
     CubeMapUsage usage;
     uint32_t index;
 };
 
 struct MeshView
 {
+    size_t id;
     uint32_t firstVertex;
     uint32_t vertexCount;
     uint32_t firstIndex;
@@ -55,6 +60,7 @@ struct MeshView
 
 struct TextureView
 {
+    size_t id;
     uint32_t index;
 };
 
@@ -91,6 +97,7 @@ struct ShaderView
 
 struct SkeletalAnimationView
 {
+    size_t id;
     uint32_t index;
 };
 

--- a/include/ncengine/asset/Assets.h
+++ b/include/ncengine/asset/Assets.h
@@ -60,6 +60,7 @@ bool LoadTextureAsset(const std::string& path, bool isExternal = false, asset_fl
 bool LoadTextureAssets(std::span<const std::string> paths, bool isExternal = false, asset_flags_type flags = AssetFlags::None);
 bool UnloadTextureAsset(const std::string& path, asset_flags_type flags = AssetFlags::None);
 void UnloadAllTextureAssets(asset_flags_type flags = AssetFlags::None);
+auto AcquireTextureAsset(const std::string& path) -> TextureView;
 
 /** Supported file types: .nca 
  *  @note Unloading skeletal animations invalidates all SkeletalAnimations. It is intended

--- a/sample/source/scenes/GraphicsTest.cpp
+++ b/sample/source/scenes/GraphicsTest.cpp
@@ -34,25 +34,26 @@ void GraphicsTest::Load(Registry* registry, ModuleProvider modules)
 
     std::vector<std::string> textures
     {
-        "DefaultBaseColor.nca",
-        "DefaultNormal.nca",
-        "DefaultMetallic.nca",
         "ogre\\BaseColor.nca",
-        "ogre\\Normal.nca",
         "ogre\\Roughness.nca",
         "ogre\\Metallic.nca",
         "cave\\BaseColor.nca",
-        "cave\\Normal.nca",
         "cave\\Roughness.nca",
         "cave\\Metallic.nca",
         "cave_ceiling\\BaseColor.nca",
-        "cave_ceiling\\Normal.nca",
         "cave_ceiling\\Roughness.nca",
         "cave_ceiling\\Metallic.nca",
         "skeleton\\BaseColor.nca",
-        "skeleton\\Normal.nca",
         "skeleton\\Roughness.nca",
         "skeleton\\Metallic.nca",
+    };
+
+    std::vector<std::string> normals
+    {
+        "ogre\\Normal.nca",
+        "cave\\Normal.nca",
+        "cave_ceiling\\Normal.nca",
+        "skeleton\\Normal.nca"
     };
 
     std::vector<std::string> cubemaps
@@ -81,7 +82,8 @@ void GraphicsTest::Load(Registry* registry, ModuleProvider modules)
     };
 
     LoadSkeletalAnimationAssets(animations);
-    LoadTextureAssets(textures);
+    LoadTextureAssets(textures, false, AssetFlags::TextureTypeImage);
+    LoadTextureAssets(normals, false, AssetFlags::TextureTypeNormalMap);
     LoadMeshAssets(meshes);
     LoadCubeMapAssets(cubemaps);
 

--- a/source/engine/assets/AssetService.h
+++ b/source/engine/assets/AssetService.h
@@ -16,6 +16,7 @@ class IAssetServiceBase
         virtual ~IAssetServiceBase() = default;
 
         virtual auto GetAllLoaded() const -> std::vector<std::string_view> = 0;
+        virtual auto GetPath(size_t hash) const -> std::string_view = 0;
         virtual auto GetAssetType() const noexcept -> asset::AssetType = 0;
 };
 

--- a/source/engine/assets/Assets.cpp
+++ b/source/engine/assets/Assets.cpp
@@ -143,6 +143,11 @@ void UnloadAllTextureAssets(asset_flags_type flags)
     return AssetService<TextureView>::Get()->UnloadAll(flags);
 }
 
+auto AcquireTextureAsset(const std::string& path) -> TextureView
+{
+    return AssetService<TextureView>::Get()->Acquire(path);
+}
+
 bool LoadFont(const FontInfo& font, bool isExternal, asset_flags_type flags)
 {
     return AssetService<FontView, FontInfo>::Get()->Load(font, isExternal, flags);

--- a/source/engine/assets/manager/AudioClipAssetManager.cpp
+++ b/source/engine/assets/manager/AudioClipAssetManager.cpp
@@ -45,7 +45,7 @@ bool AudioClipAssetManager::Load(std::span<const std::string> paths, bool isExte
 
 bool AudioClipAssetManager::Unload(const std::string& path, asset_flags_type)
 {
-    return static_cast<bool>(m_audioClips.erase(path));
+    return m_audioClips.erase(path);
 }
 
 void AudioClipAssetManager::UnloadAll(asset_flags_type)
@@ -55,17 +55,12 @@ void AudioClipAssetManager::UnloadAll(asset_flags_type)
 
 auto AudioClipAssetManager::Acquire(const std::string& path, asset_flags_type) const -> AudioClipView
 {
-    const auto it = m_audioClips.find(path);
-    if (it == m_audioClips.end())
-    {
-        throw NcError("Asset is not loaded: " + path);
-    }
-
+    const auto& clip = m_audioClips.at(path);
     return AudioClipView
     {
-        .leftChannel = std::span<const double>{it->second.leftChannel},
-        .rightChannel = std::span<const double>{it->second.rightChannel},
-        .samplesPerChannel = it->second.samplesPerChannel
+        .leftChannel = std::span<const double>{clip.leftChannel},
+        .rightChannel = std::span<const double>{clip.rightChannel},
+        .samplesPerChannel = clip.samplesPerChannel
     };
 }
 
@@ -76,6 +71,6 @@ bool AudioClipAssetManager::IsLoaded(const std::string& path, asset_flags_type) 
 
 auto AudioClipAssetManager::GetAllLoaded() const -> std::vector<std::string_view>
 {
-    return GetPaths(m_audioClips);
+    return GetPaths(m_audioClips.keys());
 }
 }

--- a/source/engine/assets/manager/AudioClipAssetManager.cpp
+++ b/source/engine/assets/manager/AudioClipAssetManager.cpp
@@ -55,9 +55,13 @@ void AudioClipAssetManager::UnloadAll(asset_flags_type)
 
 auto AudioClipAssetManager::Acquire(const std::string& path, asset_flags_type) const -> AudioClipView
 {
-    const auto& clip = m_audioClips.at(path);
+    const auto hash = m_audioClips.hash(path);
+    const auto index = m_audioClips.index(hash);
+    NC_ASSERT(index != m_audioClips.NullIndex, fmt::format("Asset is not loaded: '{}'", path));
+    const auto& clip = m_audioClips.at(index);
     return AudioClipView
     {
+        .id = hash,
         .leftChannel = std::span<const double>{clip.leftChannel},
         .rightChannel = std::span<const double>{clip.rightChannel},
         .samplesPerChannel = clip.samplesPerChannel

--- a/source/engine/assets/manager/AudioClipAssetManager.h
+++ b/source/engine/assets/manager/AudioClipAssetManager.h
@@ -21,6 +21,7 @@ class AudioClipAssetManager : public IAssetService<AudioClipView, std::string>
         void UnloadAll(asset_flags_type flags = AssetFlags::None) override;
         auto Acquire(const std::string& path, asset_flags_type flags = AssetFlags::None) const -> AudioClipView override;
         bool IsLoaded(const std::string& path, asset_flags_type flags = AssetFlags::None) const override;
+        auto GetPath(size_t id) const -> std::string_view override { return m_audioClips.key_at(id); }
         auto GetAllLoaded() const -> std::vector<std::string_view> override;
         auto GetAssetType() const noexcept -> asset::AssetType override { return asset::AssetType::AudioClip; }
 

--- a/source/engine/assets/manager/AudioClipAssetManager.h
+++ b/source/engine/assets/manager/AudioClipAssetManager.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "assets/AssetService.h"
+#include "utility/StringMap.h"
 
 #include "ncasset/AssetsFwd.h"
 
@@ -24,7 +25,7 @@ class AudioClipAssetManager : public IAssetService<AudioClipView, std::string>
         auto GetAssetType() const noexcept -> asset::AssetType override { return asset::AssetType::AudioClip; }
 
     private:
-        std::unordered_map<std::string, asset::AudioClip> m_audioClips;
+        StringMap<asset::AudioClip> m_audioClips;
         std::string m_assetDirectory;
 };
 } // namespace nc

--- a/source/engine/assets/manager/ConcaveColliderAssetManager.cpp
+++ b/source/engine/assets/manager/ConcaveColliderAssetManager.cpp
@@ -22,7 +22,7 @@ namespace nc
         m_concaveColliders.emplace(path, asset::ImportConcaveCollider(fullPath));
         return true;
     }
-    
+
     bool ConcaveColliderAssetManager::Load(std::span<const std::string> paths, bool isExternal, asset_flags_type)
     {
         auto anyLoaded = false;
@@ -42,10 +42,10 @@ namespace nc
 
         return anyLoaded;
     }
-    
+
     bool ConcaveColliderAssetManager::Unload(const std::string& path, asset_flags_type)
     {
-        return static_cast<bool>(m_concaveColliders.erase(path));
+        return m_concaveColliders.erase(path);
     }
 
     void ConcaveColliderAssetManager::UnloadAll(asset_flags_type)
@@ -55,26 +55,21 @@ namespace nc
 
     auto ConcaveColliderAssetManager::Acquire(const std::string& path, asset_flags_type) const -> ConcaveColliderView
     {
-        const auto it = m_concaveColliders.find(path);
-        if (it == m_concaveColliders.end())
-        {
-            throw NcError("Asset is not loaded: " + path);
-        }
-
+        const auto& collider = m_concaveColliders.at(path);
         return ConcaveColliderView
         {
-            .triangles = std::span<const Triangle>{it->second.triangles},
-            .maxExtent = it->second.maxExtent
+            .triangles = std::span<const Triangle>{collider.triangles},
+            .maxExtent = collider.maxExtent
         };
     }
-    
+
     bool ConcaveColliderAssetManager::IsLoaded(const std::string& path, asset_flags_type) const
     {
-        return m_concaveColliders.end() != m_concaveColliders.find(path);
+        return m_concaveColliders.contains(path);
     }
 
     auto ConcaveColliderAssetManager::GetAllLoaded() const -> std::vector<std::string_view>
     {
-        return GetPaths(m_concaveColliders);
+        return GetPaths(m_concaveColliders.keys());
     }
 }

--- a/source/engine/assets/manager/ConcaveColliderAssetManager.cpp
+++ b/source/engine/assets/manager/ConcaveColliderAssetManager.cpp
@@ -55,9 +55,13 @@ namespace nc
 
     auto ConcaveColliderAssetManager::Acquire(const std::string& path, asset_flags_type) const -> ConcaveColliderView
     {
-        const auto& collider = m_concaveColliders.at(path);
+        const auto hash = m_concaveColliders.hash(path);
+        const auto index = m_concaveColliders.index(hash);
+        NC_ASSERT(index != m_concaveColliders.NullIndex, fmt::format("Asset is not loaded: '{}'", path));
+        const auto& collider = m_concaveColliders.at(index);
         return ConcaveColliderView
         {
+            .id = hash,
             .triangles = std::span<const Triangle>{collider.triangles},
             .maxExtent = collider.maxExtent
         };

--- a/source/engine/assets/manager/ConcaveColliderAssetManager.h
+++ b/source/engine/assets/manager/ConcaveColliderAssetManager.h
@@ -20,6 +20,7 @@ class ConcaveColliderAssetManager : public IAssetService<ConcaveColliderView, st
         void UnloadAll(asset_flags_type flags = AssetFlags::None) override;
         auto Acquire(const std::string& path, asset_flags_type flags = AssetFlags::None) const -> ConcaveColliderView override;
         bool IsLoaded(const std::string& path, asset_flags_type flags = AssetFlags::None) const override;
+        auto GetPath(size_t id) const -> std::string_view override { return m_concaveColliders.key_at(id); }
         auto GetAllLoaded() const -> std::vector<std::string_view> override;
         auto GetAssetType() const noexcept -> asset::AssetType override { return asset::AssetType::ConcaveCollider; }
 

--- a/source/engine/assets/manager/ConcaveColliderAssetManager.h
+++ b/source/engine/assets/manager/ConcaveColliderAssetManager.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "assets/AssetService.h"
+#include "utility/StringMap.h"
 
 #include "ncasset/AssetsFwd.h"
 
@@ -23,7 +24,7 @@ class ConcaveColliderAssetManager : public IAssetService<ConcaveColliderView, st
         auto GetAssetType() const noexcept -> asset::AssetType override { return asset::AssetType::ConcaveCollider; }
 
     private:
-        std::unordered_map<std::string, asset::ConcaveCollider> m_concaveColliders;
+        StringMap<asset::ConcaveCollider> m_concaveColliders;
         std::string m_assetDirectory;
 };
 } // namespace nc

--- a/source/engine/assets/manager/CubeMapAssetManager.cpp
+++ b/source/engine/assets/manager/CubeMapAssetManager.cpp
@@ -8,7 +8,6 @@
 #include <cassert>
 #include <fstream>
 #include <filesystem>
-#include <iostream>
 
 namespace nc
 {
@@ -34,7 +33,7 @@ bool CubeMapAssetManager::Load(const std::string& path, bool isExternal, asset_f
 
     const auto fullPath = isExternal ? path : m_assetDirectory + path;
     const auto data = asset::CubeMapWithId{asset::ImportCubeMap(fullPath), path};
-    m_cubeMapIds.push_back(path);
+    m_cubeMapIds.emplace(path);
     m_onUpdate.Emit(asset::CubeMapUpdateEventData{
         asset::UpdateAction::Load,
         std::vector<std::string>{path},
@@ -71,7 +70,7 @@ bool CubeMapAssetManager::Load(std::span<const std::string> paths, bool isExtern
         const auto fullPath = isExternal ? path : m_assetDirectory + path;
         loadedCubeMaps.push_back(asset::CubeMapWithId{asset::ImportCubeMap(fullPath), path});
         idsToLoad.push_back(path);
-        m_cubeMapIds.push_back(path);
+        m_cubeMapIds.emplace(path);
     }
 
     if (idsToLoad.empty())
@@ -90,20 +89,16 @@ bool CubeMapAssetManager::Load(std::span<const std::string> paths, bool isExtern
 
 bool CubeMapAssetManager::Unload(const std::string& path, asset_flags_type)
 {
-    if (const auto pos = std::ranges::find(m_cubeMapIds, path); pos != m_cubeMapIds.cend())
-    {
-        m_cubeMapIds.erase(pos);
-        m_onUpdate.Emit(asset::CubeMapUpdateEventData
-        {
-            asset::UpdateAction::Unload,
-            std::vector<std::string>{path},
-            std::span<const asset::CubeMapWithId>{}
-        });
+    if (!m_cubeMapIds.erase(path))
+        return false;
 
-        return true;
-    }
+    m_onUpdate.Emit(asset::CubeMapUpdateEventData{
+        asset::UpdateAction::Unload,
+        std::vector<std::string>{path},
+        {}
+    });
 
-    return false;
+    return true;
 }
 
 void CubeMapAssetManager::UnloadAll(asset_flags_type)
@@ -113,24 +108,19 @@ void CubeMapAssetManager::UnloadAll(asset_flags_type)
 
 auto CubeMapAssetManager::Acquire(const std::string& path, asset_flags_type) const -> CubeMapView
 {
-    const auto pos = std::ranges::find(m_cubeMapIds, path);
-    if (pos == m_cubeMapIds.cend())
-    {
-        throw NcError("Asset is not loaded: " + path);
-    }
-
-    const auto index = static_cast<uint32_t>(std::distance(m_cubeMapIds.cbegin(), pos));
-    return CubeMapView{CubeMapUsage::Skybox, index};
+    const auto index = m_cubeMapIds.index(path);
+    NC_ASSERT(index != m_cubeMapIds.NullIndex, fmt::format("Asset is not loaded: '{}'", path));
+    return CubeMapView{CubeMapUsage::Skybox, static_cast<unsigned>(index)};
 }
 
 bool CubeMapAssetManager::IsLoaded(const std::string& path, asset_flags_type) const
 {
-    return m_cubeMapIds.cend() != std::ranges::find(m_cubeMapIds, path);
+    return m_cubeMapIds.contains(path);
 }
 
 auto CubeMapAssetManager::GetAllLoaded() const -> std::vector<std::string_view>
 {
-    return GetPaths(m_cubeMapIds);
+    return GetPaths(m_cubeMapIds.keys());
 }
 
 auto CubeMapAssetManager::OnUpdate() -> Signal<const asset::CubeMapUpdateEventData&>&

--- a/source/engine/assets/manager/CubeMapAssetManager.cpp
+++ b/source/engine/assets/manager/CubeMapAssetManager.cpp
@@ -108,9 +108,15 @@ void CubeMapAssetManager::UnloadAll(asset_flags_type)
 
 auto CubeMapAssetManager::Acquire(const std::string& path, asset_flags_type) const -> CubeMapView
 {
-    const auto index = m_cubeMapIds.index(path);
+    const auto hash = m_cubeMapIds.hash(path);
+    const auto index = m_cubeMapIds.index(hash);
     NC_ASSERT(index != m_cubeMapIds.NullIndex, fmt::format("Asset is not loaded: '{}'", path));
-    return CubeMapView{CubeMapUsage::Skybox, static_cast<unsigned>(index)};
+    return CubeMapView
+    {
+        .id = hash,
+        .usage = CubeMapUsage::Skybox,
+        .index = static_cast<unsigned>(index)
+    };
 }
 
 bool CubeMapAssetManager::IsLoaded(const std::string& path, asset_flags_type) const

--- a/source/engine/assets/manager/CubeMapAssetManager.h
+++ b/source/engine/assets/manager/CubeMapAssetManager.h
@@ -1,11 +1,10 @@
 #pragma once
 
 #include "assets/AssetService.h"
-#include "utility/Signal.h"
+#include "utility/StringMap.h"
+#include "ncengine/utility/Signal.h"
 
 #include <string>
-#include <unordered_map>
-#include <vector>
 
 namespace nc
 {
@@ -30,7 +29,7 @@ class CubeMapAssetManager : public IAssetService<CubeMapView, std::string>
         auto GetAssetType() const noexcept -> asset::AssetType override { return asset::AssetType::CubeMap; }
 
     private:
-        std::vector<std::string> m_cubeMapIds;
+        StringTable m_cubeMapIds;
         std::string m_assetDirectory;
         uint32_t m_maxCubeMapsCount;
         Signal<const asset::CubeMapUpdateEventData&> m_onUpdate;

--- a/source/engine/assets/manager/CubeMapAssetManager.h
+++ b/source/engine/assets/manager/CubeMapAssetManager.h
@@ -24,9 +24,10 @@ class CubeMapAssetManager : public IAssetService<CubeMapView, std::string>
         void UnloadAll(asset_flags_type flags = AssetFlags::None) override;
         auto Acquire(const std::string& path, asset_flags_type flags = AssetFlags::None) const -> CubeMapView override;
         bool IsLoaded(const std::string& path, asset_flags_type flags = AssetFlags::None) const override;
+        auto GetPath(size_t id) const -> std::string_view override { return m_cubeMapIds.at(m_cubeMapIds.index(id)); }
         auto GetAllLoaded() const -> std::vector<std::string_view> override;
-        auto OnUpdate() -> Signal<const asset::CubeMapUpdateEventData&>&;
         auto GetAssetType() const noexcept -> asset::AssetType override { return asset::AssetType::CubeMap; }
+        auto OnUpdate() -> Signal<const asset::CubeMapUpdateEventData&>&;
 
     private:
         StringTable m_cubeMapIds;

--- a/source/engine/assets/manager/FontAssetManager.h
+++ b/source/engine/assets/manager/FontAssetManager.h
@@ -41,6 +41,7 @@ class FontAssetManager : public IAssetService<FontView, FontInfo>
         void UnloadAll(asset_flags_type flags = AssetFlags::None) override;
         auto Acquire(const FontInfo& font, asset_flags_type flags = AssetFlags::None) const -> FontView override;
         bool IsLoaded(const FontInfo& font, asset_flags_type flags = AssetFlags::None) const override;
+        auto GetPath(size_t) const -> std::string_view override { throw NcError{"Not Implemented"}; }
         auto GetAllLoaded() const -> std::vector<std::string_view> override;
         auto OnUpdate() -> Signal<>&;
         auto GetAssetType() const noexcept -> asset::AssetType override { return asset::AssetType::Font; }

--- a/source/engine/assets/manager/HullColliderAssetManager.cpp
+++ b/source/engine/assets/manager/HullColliderAssetManager.cpp
@@ -45,7 +45,7 @@ namespace nc
 
     bool HullColliderAssetManager::Unload(const std::string& path, asset_flags_type)
     {
-        return static_cast<bool>(m_hullColliders.erase(path));
+        return m_hullColliders.erase(path);
     }
 
     void HullColliderAssetManager::UnloadAll(asset_flags_type)
@@ -55,17 +55,12 @@ namespace nc
 
     auto HullColliderAssetManager::Acquire(const std::string& path, asset_flags_type) const -> ConvexHullView
     {
-        const auto it = m_hullColliders.find(path);
-        if (it == m_hullColliders.end())
-        {
-            throw NcError("Asset is not loaded: " + path);
-        }
-
+        const auto& collider = m_hullColliders.at(path);
         return ConvexHullView
         {
-            .vertices = std::span<const Vector3>{it->second.vertices},
-            .extents = it->second.extents,
-            .maxExtent = it->second.maxExtent
+            .vertices = std::span<const Vector3>{collider.vertices},
+            .extents = collider.extents,
+            .maxExtent = collider.maxExtent
         };
     }
 
@@ -76,6 +71,6 @@ namespace nc
 
     auto HullColliderAssetManager::GetAllLoaded() const -> std::vector<std::string_view>
     {
-        return GetPaths(m_hullColliders);
+        return GetPaths(m_hullColliders.keys());
     }
 }

--- a/source/engine/assets/manager/HullColliderAssetManager.cpp
+++ b/source/engine/assets/manager/HullColliderAssetManager.cpp
@@ -55,9 +55,13 @@ namespace nc
 
     auto HullColliderAssetManager::Acquire(const std::string& path, asset_flags_type) const -> ConvexHullView
     {
-        const auto& collider = m_hullColliders.at(path);
+        const auto hash = m_hullColliders.hash(path);
+        const auto index = m_hullColliders.index(hash);
+        NC_ASSERT(index != m_hullColliders.NullIndex, fmt::format("Asset is not loaded: '{}'", path));
+        const auto& collider = m_hullColliders.at(index);
         return ConvexHullView
         {
+            .id = hash,
             .vertices = std::span<const Vector3>{collider.vertices},
             .extents = collider.extents,
             .maxExtent = collider.maxExtent

--- a/source/engine/assets/manager/HullColliderAssetManager.h
+++ b/source/engine/assets/manager/HullColliderAssetManager.h
@@ -1,11 +1,11 @@
 #pragma once
 
 #include "assets/AssetService.h"
+#include "utility/StringMap.h"
 
 #include "ncasset/AssetsFwd.h"
 
 #include <string>
-#include <unordered_map>
 
 namespace nc
 {
@@ -24,7 +24,7 @@ class HullColliderAssetManager : public IAssetService<ConvexHullView, std::strin
         auto GetAssetType() const noexcept -> asset::AssetType override { return asset::AssetType::HullCollider; }
 
     private:
-        std::unordered_map<std::string, asset::HullCollider> m_hullColliders;
+        StringMap<asset::HullCollider> m_hullColliders;
         std::string m_assetDirectory;
 };
 } // namespace nc

--- a/source/engine/assets/manager/HullColliderAssetManager.h
+++ b/source/engine/assets/manager/HullColliderAssetManager.h
@@ -20,6 +20,7 @@ class HullColliderAssetManager : public IAssetService<ConvexHullView, std::strin
         void UnloadAll(asset_flags_type flags = AssetFlags::None) override;
         auto Acquire(const std::string& path, asset_flags_type flags = AssetFlags::None) const -> ConvexHullView override;
         bool IsLoaded(const std::string& path, asset_flags_type flags = AssetFlags::None) const override;
+        auto GetPath(size_t id) const -> std::string_view override { return m_hullColliders.key_at(id); }
         auto GetAllLoaded() const -> std::vector<std::string_view> override;
         auto GetAssetType() const noexcept -> asset::AssetType override { return asset::AssetType::HullCollider; }
 

--- a/source/engine/assets/manager/MeshAssetManager.cpp
+++ b/source/engine/assets/manager/MeshAssetManager.cpp
@@ -25,6 +25,7 @@ auto MeshAssetManager::ImportMesh(const std::string& path, bool isExternal) -> a
     const auto mesh = asset::ImportMesh(fullPath);
 
     auto meshView = MeshView{
+        .id = m_accessors.hash(path),
         .firstVertex = static_cast<uint32_t>(m_vertexData.size()),
         .vertexCount = static_cast<uint32_t>(mesh.vertices.size()),
         .firstIndex = static_cast<uint32_t>(m_indexData.size()),
@@ -105,7 +106,7 @@ bool MeshAssetManager::Unload(const std::string& path, asset_flags_type)
     if (index == StringTable::NullIndex)
         return false;
 
-    const auto [firstVertex, vertexCount, firstIndex, indexCount, unused] = m_accessors.at(index);
+    const auto [id, firstVertex, vertexCount, firstIndex, indexCount, unused] = m_accessors.at(index);
     m_accessors.erase(path);
 
     auto indBeg = m_indexData.begin() + firstIndex;

--- a/source/engine/assets/manager/MeshAssetManager.cpp
+++ b/source/engine/assets/manager/MeshAssetManager.cpp
@@ -19,13 +19,6 @@ MeshAssetManager::MeshAssetManager(const std::string& assetDirectory)
 {
 }
 
-MeshAssetManager::~MeshAssetManager() noexcept
-{
-    m_vertexData = {};
-    m_indexData = {};
-    m_accessors.clear();
-}
-
 auto MeshAssetManager::ImportMesh(const std::string& path, bool isExternal) -> asset::Mesh
 {
     const auto fullPath = isExternal ? path : m_assetDirectory + path;
@@ -55,9 +48,9 @@ bool MeshAssetManager::Load(const std::string& path, bool isExternal, asset_flag
     auto mesh = ImportMesh(path, isExternal);
     if (mesh.bonesData.has_value() && mesh.bonesData.value().vertexSpaceToBoneSpace.size() > 0)
     {
-        m_bonesData.push_back(std::move(mesh.bonesData.value()));
+        auto& bones = mesh.bonesData.value();
         m_onBoneUpdate.Emit(asset::BoneUpdateEventData{
-            std::span<const asset::BonesData>{&m_bonesData.back(), 1},
+            std::span<const asset::BonesData>{&bones, 1},
             std::vector<std::string>{path},
             asset::UpdateAction::Load
         });
@@ -70,6 +63,7 @@ bool MeshAssetManager::Load(const std::string& path, bool isExternal, asset_flag
 bool MeshAssetManager::Load(std::span<const std::string> paths, bool isExternal, asset_flags_type)
 {
     auto idsToLoad = std::vector<std::string>{};
+    auto bones = std::vector<asset::BonesData>{};
     idsToLoad.reserve(paths.size());
     bool anyLoaded = false;
     bool anyBonesLoaded = false;
@@ -84,17 +78,18 @@ bool MeshAssetManager::Load(std::span<const std::string> paths, bool isExternal,
         auto mesh = ImportMesh(path, isExternal);
         if (mesh.bonesData.has_value() && mesh.bonesData.value().vertexSpaceToBoneSpace.size() > 0)
         {
-            m_bonesData.push_back(std::move(mesh.bonesData.value()));
+            bones.push_back(std::move(mesh.bonesData.value()));
             idsToLoad.push_back(path);
             anyBonesLoaded = true;
         }
+
         anyLoaded = true;
     }
 
     if (anyBonesLoaded)
     {
         m_onBoneUpdate.Emit(asset::BoneUpdateEventData{
-            std::span<const asset::BonesData>{m_bonesData.end() - idsToLoad.size(), m_bonesData.end()},
+            std::span<const asset::BonesData>{bones},
             std::move(idsToLoad),
             asset::UpdateAction::Load
         });
@@ -106,11 +101,11 @@ bool MeshAssetManager::Load(std::span<const std::string> paths, bool isExternal,
 
 bool MeshAssetManager::Unload(const std::string& path, asset_flags_type)
 {
-    auto pos = m_accessors.find(path);
-    if(pos == m_accessors.end())
+    const auto index = m_accessors.index(path);
+    if (index == StringTable::NullIndex)
         return false;
 
-    const auto [firstVertex, vertexCount, firstIndex, indexCount, unused] = pos->second;
+    const auto [firstVertex, vertexCount, firstIndex, indexCount, unused] = m_accessors.at(index);
     m_accessors.erase(path);
 
     auto indBeg = m_indexData.begin() + firstIndex;
@@ -123,7 +118,7 @@ bool MeshAssetManager::Unload(const std::string& path, asset_flags_type)
     assert(vertEnd <= m_vertexData.end());
     m_vertexData.erase(vertBeg, vertEnd);
 
-    for(auto& [uid, accessor] : m_accessors)
+    for(auto& accessor : m_accessors)
     {
         if(accessor.firstVertex > firstVertex)
             accessor.firstVertex -= vertexCount;
@@ -152,16 +147,11 @@ void MeshAssetManager::UnloadAll(asset_flags_type)
     m_accessors.clear();
     m_vertexData.clear();
     m_indexData.clear();
-    m_bonesData.clear();
 }
 
 auto MeshAssetManager::Acquire(const std::string& path, asset_flags_type) const -> MeshView
 {
-    const auto it = m_accessors.find(path);
-    if(it == m_accessors.cend())
-        throw NcError("Asset not loaded: " + path);
-    
-    return it->second;
+    return m_accessors.at(path);
 }
 
 bool MeshAssetManager::IsLoaded(const std::string& path, asset_flags_type) const
@@ -171,7 +161,7 @@ bool MeshAssetManager::IsLoaded(const std::string& path, asset_flags_type) const
 
 auto MeshAssetManager::GetAllLoaded() const -> std::vector<std::string_view>
 {
-    return GetPaths(m_accessors);
+    return GetPaths(m_accessors.keys());
 }
 
 auto MeshAssetManager::OnMeshUpdate() -> Signal<const asset::MeshUpdateEventData&>&

--- a/source/engine/assets/manager/MeshAssetManager.h
+++ b/source/engine/assets/manager/MeshAssetManager.h
@@ -25,6 +25,7 @@ class MeshAssetManager : public IAssetService<MeshView, std::string>
         void UnloadAll(asset_flags_type flags = AssetFlags::None) override;
         auto Acquire(const std::string& path, asset_flags_type flags = AssetFlags::None) const -> MeshView override;
         bool IsLoaded(const std::string& path, asset_flags_type flags = AssetFlags::None) const override;
+        auto GetPath(size_t id) const -> std::string_view override { return m_accessors.key_at(id); }
         auto GetAllLoaded() const -> std::vector<std::string_view> override;
         auto GetAssetType() const noexcept -> asset::AssetType override { return asset::AssetType::Mesh; }
         auto OnBoneUpdate() -> Signal<const asset::BoneUpdateEventData&>&;

--- a/source/engine/assets/manager/MeshAssetManager.h
+++ b/source/engine/assets/manager/MeshAssetManager.h
@@ -1,11 +1,10 @@
 #pragma once
 
 #include "assets/AssetService.h"
-#include "utility/Signal.h"
+#include "utility/StringMap.h"
+#include "ncengine/utility/Signal.h"
 
 #include "ncasset/AssetsFwd.h"
-
-#include <unordered_map>
 
 namespace nc
 {
@@ -19,7 +18,6 @@ class MeshAssetManager : public IAssetService<MeshView, std::string>
 {
     public:
         explicit MeshAssetManager(const std::string& assetDirectory);
-        ~MeshAssetManager() noexcept;
 
         bool Load(const std::string& path, bool isExternal, asset_flags_type flags = AssetFlags::None) override;
         bool Load(std::span<const std::string> paths, bool isExternal, asset_flags_type flags = AssetFlags::None) override;
@@ -34,9 +32,8 @@ class MeshAssetManager : public IAssetService<MeshView, std::string>
 
     private:
         std::vector<asset::MeshVertex> m_vertexData;
-        std::vector<asset::BonesData> m_bonesData;
         std::vector<uint32_t> m_indexData;
-        std::unordered_map<std::string, MeshView> m_accessors;
+        StringMap<MeshView> m_accessors;
         std::string m_assetDirectory;
         Signal<const asset::BoneUpdateEventData&> m_onBoneUpdate;
         Signal<const asset::MeshUpdateEventData&> m_onMeshUpdate;

--- a/source/engine/assets/manager/ShaderAssetManager.h
+++ b/source/engine/assets/manager/ShaderAssetManager.h
@@ -25,6 +25,7 @@ class ShaderAssetManager final : public IAssetService<ShaderView, std::string>
         bool Unload(const std::string& path, asset_flags_type flags = AssetFlags::None) override;
         void UnloadAll(asset_flags_type flags = AssetFlags::None) override;
         auto Acquire(const std::string& path, asset_flags_type flags = AssetFlags::None) const -> ShaderView override;
+        auto GetPath(size_t) const -> std::string_view override { throw NcError{"Not Implemented"};}
         auto GetAllLoaded() const -> std::vector<std::string_view> override;
         auto GetAssetType() const noexcept -> asset::AssetType override { return asset::AssetType::Shader; }
         bool IsLoaded(const std::string& path, asset_flags_type flags = AssetFlags::None) const override;

--- a/source/engine/assets/manager/SkeletalAnimationAssetManager.cpp
+++ b/source/engine/assets/manager/SkeletalAnimationAssetManager.cpp
@@ -92,9 +92,14 @@ void SkeletalAnimationAssetManager::UnloadAll(asset_flags_type)
 
 auto SkeletalAnimationAssetManager::Acquire(const std::string& path, asset_flags_type) const -> SkeletalAnimationView
 {
-    const auto index = m_table.index(path);
-    NC_ASSERT(index != StringTable::NullIndex, fmt::format("Asset is not loaded: {}", path));
-    return SkeletalAnimationView{.index = static_cast<uint32_t>(index)};
+    const auto hash = m_table.hash(path);
+    const auto index = m_table.index(hash);
+    NC_ASSERT(index != m_table.NullIndex, fmt::format("Asset is not loaded: {}", path));
+    return SkeletalAnimationView
+    {
+        .id = hash,
+        .index = static_cast<uint32_t>(index)
+    };
 }
 
 bool SkeletalAnimationAssetManager::IsLoaded(const std::string& path, asset_flags_type) const

--- a/source/engine/assets/manager/SkeletalAnimationAssetManager.cpp
+++ b/source/engine/assets/manager/SkeletalAnimationAssetManager.cpp
@@ -11,15 +11,13 @@ namespace nc
 SkeletalAnimationAssetManager::SkeletalAnimationAssetManager(const std::string& skeletalAnimationAssetDirectory, uint32_t maxSkeletalAnimations)
     : m_assetDirectory{skeletalAnimationAssetDirectory},
       m_maxSkeletalAnimationCount{maxSkeletalAnimations},
-      m_assetIds{},
-      m_skeletalAnimations{},
       m_onUpdate{}
 {
 }
 
 bool SkeletalAnimationAssetManager::Load(const std::string& path, bool isExternal, asset_flags_type)
 {
-    if (m_assetIds.size() + 1 >= m_maxSkeletalAnimationCount)
+    if (m_table.size() + 1 >= m_maxSkeletalAnimationCount)
     {
         throw NcError("Cannot exceed max skeletal animations count.");
     }
@@ -29,13 +27,12 @@ bool SkeletalAnimationAssetManager::Load(const std::string& path, bool isExterna
         return false;
     }
 
+    m_table.emplace(path);
     const auto fullPath = isExternal ? path : m_assetDirectory + path;
-    m_assetIds.emplace_back(path);
-    m_skeletalAnimations.emplace_back(asset::ImportSkeletalAnimation(fullPath));
-
+    auto animation = asset::ImportSkeletalAnimation(fullPath);
     m_onUpdate.Emit(asset::SkeletalAnimationUpdateEventData{
-        std::span<const std::string>{m_assetIds},
-        std::span<const asset::SkeletalAnimation>{m_skeletalAnimations},
+        std::span<const std::string>{m_table.keys()},
+        std::span<const asset::SkeletalAnimation>{&animation, 1},
         asset::UpdateAction::Load
     });
     return true;
@@ -43,13 +40,12 @@ bool SkeletalAnimationAssetManager::Load(const std::string& path, bool isExterna
 
 bool SkeletalAnimationAssetManager::Load(std::span<const std::string> paths, bool isExternal, asset_flags_type)
 {
-    if (m_assetIds.size() + paths.size() >= m_maxSkeletalAnimationCount)
+    if (m_table.size() + paths.size() >= m_maxSkeletalAnimationCount)
     {
         throw NcError("Cannot exceed max skeletal animations count.");
     }
 
-    bool anyLoaded = false;
-
+    auto animations = std::vector<asset::SkeletalAnimation>{};
     for(const auto& path : paths)
     {
         if (IsLoaded(path))
@@ -57,38 +53,33 @@ bool SkeletalAnimationAssetManager::Load(std::span<const std::string> paths, boo
             continue;
         }
 
+        m_table.emplace(path);
         const auto fullPath = isExternal ? path : m_assetDirectory + path;
-        m_assetIds.emplace_back(path);
-        m_skeletalAnimations.emplace_back(asset::ImportSkeletalAnimation(fullPath));
-        anyLoaded = true;
+        animations.push_back(asset::ImportSkeletalAnimation(fullPath));
     }
 
-    if (anyLoaded)
+    if (!animations.empty())
     {
         m_onUpdate.Emit(asset::SkeletalAnimationUpdateEventData{
-            std::span<const std::string>{m_assetIds},
-            std::span<const asset::SkeletalAnimation>{m_skeletalAnimations},
+            std::span<const std::string>{m_table.keys()},
+            std::span<const asset::SkeletalAnimation>{animations},
             asset::UpdateAction::Load
         });
+
+        return true;
     }
-    return anyLoaded;
+
+    return false;
 }
 
 bool SkeletalAnimationAssetManager::Unload(const std::string& path, asset_flags_type)
 {
-    const auto pos = std::ranges::find(m_assetIds, path);
-    if (pos == std::ranges::cend(m_assetIds))
-    {
+    if (!m_table.erase(path))
         return false;
-    }
-
-    const auto offset = std::ranges::distance(std::ranges::cbegin(m_assetIds), pos);
-    m_assetIds.erase(pos);
-    m_skeletalAnimations.erase(std::ranges::cbegin(m_skeletalAnimations) + offset);
 
     m_onUpdate.Emit(asset::SkeletalAnimationUpdateEventData{
-        std::span<const std::string>{m_assetIds},
-        std::span<const asset::SkeletalAnimation>{m_skeletalAnimations},
+        std::span<const std::string>{&path, 1},
+        {},
         asset::UpdateAction::Unload
     });
     return true;
@@ -96,32 +87,24 @@ bool SkeletalAnimationAssetManager::Unload(const std::string& path, asset_flags_
 
 void SkeletalAnimationAssetManager::UnloadAll(asset_flags_type)
 {
-    m_skeletalAnimations.clear();
-    m_assetIds.clear();
+    m_table.clear();
 }
 
 auto SkeletalAnimationAssetManager::Acquire(const std::string& path, asset_flags_type) const -> SkeletalAnimationView
 {
-    auto pos = std::find(m_assetIds.begin(), m_assetIds.end(), path);
-    if (pos == m_assetIds.end())
-    {
-        throw NcError("Asset is not loaded: " + path);
-    }
-
-    return SkeletalAnimationView
-    {
-        .index = static_cast<uint32_t>(pos - m_assetIds.begin())
-    };
+    const auto index = m_table.index(path);
+    NC_ASSERT(index != StringTable::NullIndex, fmt::format("Asset is not loaded: {}", path));
+    return SkeletalAnimationView{.index = static_cast<uint32_t>(index)};
 }
 
 bool SkeletalAnimationAssetManager::IsLoaded(const std::string& path, asset_flags_type) const
 {
-    return std::find(m_assetIds.begin(), m_assetIds.end(), path) != m_assetIds.end();
+    return m_table.contains(path);
 }
 
 auto SkeletalAnimationAssetManager::GetAllLoaded() const -> std::vector<std::string_view>
 {
-    return GetPaths(m_assetIds);
+    return GetPaths(m_table.keys());
 }
 
 auto SkeletalAnimationAssetManager::OnUpdate() -> Signal<const asset::SkeletalAnimationUpdateEventData&>&

--- a/source/engine/assets/manager/SkeletalAnimationAssetManager.h
+++ b/source/engine/assets/manager/SkeletalAnimationAssetManager.h
@@ -24,6 +24,7 @@ class SkeletalAnimationAssetManager : public IAssetService<SkeletalAnimationView
         void UnloadAll(asset_flags_type flags = AssetFlags::None) override;
         auto Acquire(const std::string& path, asset_flags_type flags = AssetFlags::None) const -> SkeletalAnimationView override;
         bool IsLoaded(const std::string& path, asset_flags_type flags = AssetFlags::None) const override;
+        auto GetPath(size_t id) const -> std::string_view override { return m_table.at(m_table.index(id)); }
         auto GetAllLoaded() const -> std::vector<std::string_view> override;
         auto GetAssetType() const noexcept -> asset::AssetType override { return asset::AssetType::SkeletalAnimation; }
         auto OnUpdate() -> Signal<const asset::SkeletalAnimationUpdateEventData&>&;

--- a/source/engine/assets/manager/SkeletalAnimationAssetManager.h
+++ b/source/engine/assets/manager/SkeletalAnimationAssetManager.h
@@ -1,10 +1,10 @@
 #pragma once
 
 #include "assets/AssetService.h"
-#include "ncasset/AssetsFwd.h"
-#include "utility/Signal.h"
+#include "utility/StringMap.h"
+#include "ncengine/utility/Signal.h"
 
-#include <vector>
+#include "ncasset/AssetsFwd.h"
 
 namespace nc
 {
@@ -29,10 +29,9 @@ class SkeletalAnimationAssetManager : public IAssetService<SkeletalAnimationView
         auto OnUpdate() -> Signal<const asset::SkeletalAnimationUpdateEventData&>&;
 
     private:
+        StringTable m_table;
         std::string m_assetDirectory;
         uint32_t m_maxSkeletalAnimationCount;
-        std::vector<std::string> m_assetIds;
-        std::vector<asset::SkeletalAnimation> m_skeletalAnimations;
         Signal<const asset::SkeletalAnimationUpdateEventData&> m_onUpdate;
 };
 } // namespace nc

--- a/source/engine/assets/manager/TextureAssetManager.h
+++ b/source/engine/assets/manager/TextureAssetManager.h
@@ -25,12 +25,13 @@ class TextureAssetManager : public IAssetService<TextureView, std::string>
         void UnloadAll(asset_flags_type flags = AssetFlags::None) override;
         auto Acquire(const std::string& path, asset_flags_type flags = AssetFlags::None) const -> TextureView override;
         bool IsLoaded(const std::string& path, asset_flags_type flags = AssetFlags::None) const override;
+        auto GetPath(size_t id) const -> std::string_view override { return m_table.at(m_table.index(id)); }
         auto GetAllLoaded() const -> std::vector<std::string_view> override;
         auto GetAssetType() const noexcept -> asset::AssetType override { return asset::AssetType::Texture; }
         auto OnUpdate() -> Signal<const asset::TextureUpdateEventData&>&;
 
     private:
-        StringTable m_data;
+        StringTable m_table;
         std::string m_assetDirectory;
         uint32_t m_maxTextureCount;
         Signal<const asset::TextureUpdateEventData&> m_onUpdate;

--- a/source/engine/assets/manager/TextureAssetManager.h
+++ b/source/engine/assets/manager/TextureAssetManager.h
@@ -1,10 +1,10 @@
 #pragma once
 
 #include "assets/AssetService.h"
-#include "utility/Signal.h"
+#include "utility/StringMap.h"
+#include "ncengine/utility/Signal.h"
 
 #include <string>
-#include <vector>
 
 namespace nc
 {
@@ -18,7 +18,6 @@ class TextureAssetManager : public IAssetService<TextureView, std::string>
 {
     public:
         explicit TextureAssetManager(const std::string& texturesAssetDirectory, uint32_t maxTextures);
-        ~TextureAssetManager() noexcept;
 
         bool Load(const std::string& path, bool isExternal, asset_flags_type flags = AssetFlags::None) override;
         bool Load(std::span<const std::string> paths, bool isExternal, asset_flags_type flags = AssetFlags::None) override;
@@ -31,7 +30,7 @@ class TextureAssetManager : public IAssetService<TextureView, std::string>
         auto OnUpdate() -> Signal<const asset::TextureUpdateEventData&>&;
 
     private:
-        std::vector<asset::TextureWithId> m_textureData;
+        StringTable m_data;
         std::string m_assetDirectory;
         uint32_t m_maxTextureCount;
         Signal<const asset::TextureUpdateEventData&> m_onUpdate;

--- a/source/engine/graphics/system/SkeletalAnimationSystem.cpp
+++ b/source/engine/graphics/system/SkeletalAnimationSystem.cpp
@@ -224,8 +224,7 @@ void SkeletalAnimationSystem::OnStateChanged(const anim::StateChange& stateChang
 void SkeletalAnimationSystem::Add(SkeletalAnimator& animator)
 {
     auto& signal = animator.Connect();
-    auto connectionState = std::make_unique<Connection<const anim::StateChange&>>(signal.Connect(this, &SkeletalAnimationSystem::OnStateChanged));
-    m_onStateChangedHandlers.emplace_back(std::move(connectionState));
+    m_onStateChangedHandlers.emplace_back(signal.Connect(this, &SkeletalAnimationSystem::OnStateChanged));
     m_handlerIndices.emplace_back(animator.ParentEntity().Index());
 }
 

--- a/source/engine/graphics/system/SkeletalAnimationSystem.h
+++ b/source/engine/graphics/system/SkeletalAnimationSystem.h
@@ -50,7 +50,7 @@ class SkeletalAnimationSystem : public StableAddress
         // Component registration
         Connection<graphics::SkeletalAnimator&> m_onAddConnection;
         Connection<Entity> m_onRemoveConnection;
-        std::vector<std::unique_ptr<Connection<const anim::StateChange&>>> m_onStateChangedHandlers;
+        std::vector<Connection<const anim::StateChange&>> m_onStateChangedHandlers;
         std::vector<Entity::index_type> m_handlerIndices;
 
         // Animation data sandbox

--- a/source/engine/utility/StringMap.h
+++ b/source/engine/utility/StringMap.h
@@ -18,19 +18,19 @@ class BasicStringTable
     public:
         static constexpr auto NullIndex = UINT64_MAX;
 
-        void emplace(const std::string_view key)
+        void emplace(std::string_view key)
         {
             m_ids.push_back(Hash(key));
             if constexpr (Policy::PreserveOriginalKeys)
                 m_keys.push_back(std::string{key});
         }
 
-        auto contains(const std::string_view key) const noexcept -> bool
+        auto contains(std::string_view key) const noexcept -> bool
         {
             return std::ranges::contains(m_ids, Hash(key));
         }
 
-        auto index(const std::string_view key) const noexcept -> size_t
+        auto index(std::string_view key) const noexcept -> size_t
         {
             const auto pos = std::ranges::find(m_ids, Hash(key));
             return pos != std::ranges::cend(m_ids)
@@ -122,26 +122,26 @@ class StringMap
     public:
         static constexpr auto NullIndex = UINT64_MAX;
 
-        auto emplace(const std::string_view key, T&& value) -> T&
+        auto emplace(std::string_view key, T&& value) -> T&
         {
             m_table.emplace(key);
             m_values.push_back(std::move(value));
             return m_values.back();
         }
 
-        auto emplace(const std::string_view key, const T& value) -> T&
+        auto emplace(std::string_view key, const T& value) -> T&
         {
             m_table.emplace(key);
             m_values.push_back(value);
             return m_values.back();
         }
 
-        auto contains(const std::string_view key) const noexcept -> bool
+        auto contains(std::string_view key) const noexcept -> bool
         {
             return m_table.contains(key);
         }
 
-        auto index(const std::string_view key) const -> size_t
+        auto index(std::string_view key) const -> size_t
         {
             return m_table.index(key);
         }
@@ -192,7 +192,7 @@ class StringMap
             m_values.shrink_to_fit();
         }
 
-        auto at(const std::string_view key) -> T&
+        auto at(std::string_view key) -> T&
         {
             const auto index = index(key);
             NC_ASSERT(index != NullIndex, fmt::format("Key does not exist '{}'", key));
@@ -205,7 +205,7 @@ class StringMap
             return m_values[index];
         }
 
-        auto at(const std::string_view key) const-> const T&
+        auto at(std::string_view key) const-> const T&
         {
             const auto i = index(key);
             NC_ASSERT(i != NullIndex, fmt::format("Key does not exist '{}'", key));

--- a/source/engine/utility/StringMap.h
+++ b/source/engine/utility/StringMap.h
@@ -1,0 +1,226 @@
+#pragma once
+
+#include <algorithm>
+#include <string_view>
+#include <vector>
+
+namespace nc
+{
+struct DefaultStringTablePolicy
+{
+    static constexpr auto StableOrder = true;
+    static constexpr auto PreserveOriginalKeys = true;
+};
+
+template<class Policy>
+class BasicStringTable
+{
+    public:
+        static constexpr auto NullIndex = UINT64_MAX;
+
+        void emplace(const std::string_view key)
+        {
+            m_ids.push_back(Hash(key));
+            if constexpr (Policy::PreserveOriginalKeys)
+                m_keys.push_back(std::string{key});
+        }
+
+        auto contains(const std::string_view key) const noexcept -> bool
+        {
+            return std::ranges::contains(m_ids, Hash(key));
+        }
+
+        auto index(const std::string_view key) const noexcept -> size_t
+        {
+            const auto pos = std::ranges::find(m_ids, Hash(key));
+            return pos != std::ranges::cend(m_ids)
+                ? std::ranges::distance(std::ranges::begin(m_ids), pos)
+                : NullIndex;
+        }
+
+        auto erase(std::string_view key) noexcept -> bool
+        {
+            return erase(index(key));
+        }
+
+        auto erase(size_t index) noexcept -> bool
+        {
+            if (index >= m_ids.size())
+                return false;
+
+            if constexpr (Policy::StableOrder)
+            {
+                m_ids.erase(m_ids.begin() + index);
+                if constexpr (Policy::PreserveOriginalKeys)
+                    m_keys.erase(m_keys.begin() + index);
+            }
+            else
+            {
+                if (index != m_ids.size() - 1)
+                {
+                    m_ids[index] = m_ids.back();
+                    m_ids.pop_back();
+                    if constexpr (Policy::PreserveOriginalKeys)
+                    {
+                        m_keys[index] = std::move(m_keys.back());
+                        m_keys.pop_back();
+                    }
+                }
+                else
+                {
+                    m_ids.pop_back();
+                    if constexpr (Policy::PreserveOriginalKeys)
+                        m_keys.pop_back();
+                }
+            }
+
+            return true;
+        }
+
+        void reserve(size_t count)
+        {
+            m_ids.reserve(count);
+            if constexpr (Policy::PreserveOriginalKeys)
+                m_keys.reserve(count);
+        }
+
+        auto keys() const noexcept -> const std::vector<std::string>&
+            requires Policy::PreserveOriginalKeys
+        {
+            return m_keys;
+        }
+
+        void clear() noexcept
+        {
+            m_ids.clear();
+            m_ids.shrink_to_fit();
+            if constexpr (Policy::PreserveOriginalKeys)
+            {
+                m_keys.clear();
+                m_keys.shrink_to_fit();
+            }
+        }
+
+        auto empty() const noexcept -> bool { return m_ids.empty(); }
+        auto size() const noexcept -> size_t { return m_ids.size(); }
+
+    private:
+        std::vector<size_t> m_ids;
+        std::vector<std::string> m_keys;
+
+        static auto Hash(std::string_view key) noexcept
+        {
+            return std::hash<std::string_view>{}(key);
+        }
+};
+
+using StringTable = BasicStringTable<DefaultStringTablePolicy>;
+
+template<class T, class Policy = DefaultStringTablePolicy>
+class StringMap
+{
+    public:
+        static constexpr auto NullIndex = UINT64_MAX;
+
+        auto emplace(const std::string_view key, T&& value) -> T&
+        {
+            m_table.emplace(key);
+            m_values.push_back(std::move(value));
+            return m_values.back();
+        }
+
+        auto emplace(const std::string_view key, const T& value) -> T&
+        {
+            m_table.emplace(key);
+            m_values.push_back(value);
+            return m_values.back();
+        }
+
+        auto contains(const std::string_view key) const noexcept -> bool
+        {
+            return m_table.contains(key);
+        }
+
+        auto index(const std::string_view key) const -> size_t
+        {
+            return m_table.index(key);
+        }
+
+        auto erase(std::string_view key) noexcept -> bool
+        {
+            const auto index = m_table.index(key);
+            if (index == BasicStringTable<Policy>::NullIndex)
+                return false;
+
+            m_table.erase(index);
+            if constexpr (Policy::StableOrder)
+            {
+                m_values.erase(m_values.begin() + index);
+            }
+            else
+            {
+                if (index != m_values.size() - 1)
+                {
+                    m_values[index] = std::move(m_values.back());
+                    m_values.pop_back();
+                }
+                else
+                {
+                    m_values.pop_back();
+                }
+            }
+
+            return true;
+        }
+
+        void reserve(size_t count)
+        {
+            m_table.reserve(count);
+            m_values.reserve(count);
+        }
+
+        auto keys() const noexcept -> const std::vector<std::string>&
+            requires Policy::PreserveOriginalKeys
+        {
+            return m_table.keys();
+        }
+
+        void clear() noexcept
+        {
+            m_table.clear();
+            m_values.clear();
+            m_values.shrink_to_fit();
+        }
+
+        auto at(const std::string_view key) -> T&
+        {
+            const auto index = index(key);
+            NC_ASSERT(index != NullIndex, fmt::format("Key does not exist '{}'", key));
+            return m_values[index];
+        }
+
+        auto at(size_t index) -> T&
+        {
+            NC_ASSERT(index != NullIndex, fmt::format("Index does not exist '{}'", index));
+            return m_values[index];
+        }
+
+        auto at(const std::string_view key) const-> const T&
+        {
+            const auto i = index(key);
+            NC_ASSERT(i != NullIndex, fmt::format("Key does not exist '{}'", key));
+            return m_values[i];
+        }
+
+        auto begin() noexcept { return m_values.begin(); }
+        auto begin() const noexcept { return m_values.cbegin(); }
+        auto end() noexcept { return m_values.end(); }
+        auto end() const noexcept { return m_values.cend(); }
+        auto empty() const noexcept -> bool { return m_values.empty(); }
+        auto size() const noexcept -> size_t { return m_values.size(); }
+
+    private:
+        BasicStringTable<Policy> m_table;
+        std::vector<T> m_values;
+};
+} // namespace nc

--- a/test/AssetServiceStub.h
+++ b/test/AssetServiceStub.h
@@ -16,12 +16,14 @@
 struct className : public nc::IAssetService<viewType, inputType>                                                            \
 {                                                                                                                           \
     viewType view;                                                                                                          \
+    const char* path = "test_path";                                                                                         \
                                                                                                                             \
     bool Load(const inputType&, bool, nc::asset_flags_type = nc::AssetFlags::None) override { return true; }                \
     bool Load(std::span<const inputType>, bool, nc::asset_flags_type = nc::AssetFlags::None) override { return true; }      \
     bool Unload(const inputType&, nc::asset_flags_type = nc::AssetFlags::None) override { return true; }                    \
     void UnloadAll(nc::asset_flags_type = nc::AssetFlags::None) override {}                                                 \
     bool IsLoaded(const inputType&, nc::asset_flags_type = nc::AssetFlags::None) const override { return true; }            \
+    auto GetPath(size_t) const -> std::string_view override { return path; }                                                \
     auto GetAllLoaded() const -> std::vector<std::string_view> override { return {}; }                                      \
     auto GetAssetType() const noexcept -> nc::asset::AssetType override { return assetType; }                               \
     auto Acquire(const inputType&, nc::asset_flags_type = nc::AssetFlags::None) const -> viewType override { return view; } \

--- a/test/assets/AudioClipAssetManager_tests.cpp
+++ b/test/assets/AudioClipAssetManager_tests.cpp
@@ -106,3 +106,23 @@ TEST_F(AudioClipAssetManager_tests, UnloadAll_Empty_Completes)
 {
     assetManager->UnloadAll(AssetFlags::None);
 }
+
+TEST_F(AudioClipAssetManager_tests, GetPath_Loaded_ReturnsPath)
+{
+    std::array<std::string, 2u> paths{SoundPath1, SoundPath2};
+    assetManager->Load(paths, false);
+    const auto& expected = paths.at(0);
+    const auto view = assetManager->Acquire(expected);
+    const auto actual = assetManager->GetPath(view.id);
+    EXPECT_EQ(expected, actual);
+}
+
+TEST_F(AudioClipAssetManager_tests, GetPath_NotLoaded_Throws)
+{
+    std::array<std::string, 2u> paths{SoundPath1, SoundPath2};
+    assetManager->Load(paths, false);
+    const auto& expected = paths.at(0);
+    const auto view = assetManager->Acquire(expected);
+    assetManager->UnloadAll();
+    EXPECT_THROW(assetManager->GetPath(view.id), nc::NcError);
+}

--- a/test/assets/ConcaveColliderAssetManager_tests.cpp
+++ b/test/assets/ConcaveColliderAssetManager_tests.cpp
@@ -106,3 +106,23 @@ TEST_F(ConcaveColliderAssetManager_tests, UnloadAll_Empty_Completes)
 {
     assetManager->UnloadAll(AssetFlags::None);
 }
+
+TEST_F(ConcaveColliderAssetManager_tests, GetPath_Loaded_ReturnsPath)
+{
+    std::array<std::string, 2u> paths{ConcavePath1, ConcavePath2};
+    assetManager->Load(paths, false);
+    const auto& expected = paths.at(0);
+    const auto view = assetManager->Acquire(expected);
+    const auto actual = assetManager->GetPath(view.id);
+    EXPECT_EQ(expected, actual);
+}
+
+TEST_F(ConcaveColliderAssetManager_tests, GetPath_NotLoaded_Throws)
+{
+    std::array<std::string, 2u> paths{ConcavePath1, ConcavePath2};
+    assetManager->Load(paths, false);
+    const auto& expected = paths.at(0);
+    const auto view = assetManager->Acquire(expected);
+    assetManager->UnloadAll();
+    EXPECT_THROW(assetManager->GetPath(view.id), nc::NcError);
+}

--- a/test/assets/CubeMapAssetManager_tests.cpp
+++ b/test/assets/CubeMapAssetManager_tests.cpp
@@ -140,3 +140,23 @@ TEST_F(CubeMapAssetManager_tests, Unload_FromEnd_AccessorsNotUpdated)
     EXPECT_EQ(view1.index, 0u);
     EXPECT_EQ(view2.index, 1u);
 }
+
+TEST_F(CubeMapAssetManager_tests, GetPath_Loaded_ReturnsPath)
+{
+    std::array<std::string, 2u> paths{skybox1, skybox2};
+    assetManager->Load(paths, false);
+    const auto& expected = paths.at(1);
+    const auto view = assetManager->Acquire(expected);
+    const auto actual = assetManager->GetPath(view.id);
+    EXPECT_EQ(expected, actual);
+}
+
+TEST_F(CubeMapAssetManager_tests, GetPath_NotLoaded_Throws)
+{
+    std::array<std::string, 2u> paths{skybox1, skybox2};
+    assetManager->Load(paths, false);
+    const auto& expected = paths.at(1);
+    const auto view = assetManager->Acquire(expected);
+    assetManager->UnloadAll();
+    EXPECT_THROW(assetManager->GetPath(view.id), nc::NcError);
+}

--- a/test/assets/HullColliderAssetManager_tests.cpp
+++ b/test/assets/HullColliderAssetManager_tests.cpp
@@ -106,3 +106,23 @@ TEST_F(HullColliderAssetManager_tests, UnloadAll_Empty_Completes)
 {
     assetManager->UnloadAll(AssetFlags::None);
 }
+
+TEST_F(HullColliderAssetManager_tests, GetPath_Loaded_ReturnsPath)
+{
+    std::array<std::string, 2u> paths{HullPath1, HullPath2};
+    assetManager->Load(paths, false);
+    const auto& expected = paths.at(1);
+    const auto view = assetManager->Acquire(expected);
+    const auto actual = assetManager->GetPath(view.id);
+    EXPECT_EQ(expected, actual);
+}
+
+TEST_F(HullColliderAssetManager_tests, GetPath_NotLoaded_Throws)
+{
+    std::array<std::string, 2u> paths{HullPath1, HullPath2};
+    assetManager->Load(paths, false);
+    const auto& expected = paths.at(1);
+    const auto view = assetManager->Acquire(expected);
+    assetManager->UnloadAll();
+    EXPECT_THROW(assetManager->GetPath(view.id), nc::NcError);
+}

--- a/test/assets/MeshAssetManager_tests.cpp
+++ b/test/assets/MeshAssetManager_tests.cpp
@@ -1,6 +1,8 @@
 #include "gtest/gtest.h"
 #include "assets/manager/MeshAssetManager.h"
 
+#include "ncasset/Assets.h"
+
 #include <array>
 #include <string>
 

--- a/test/assets/MeshAssetManager_tests.cpp
+++ b/test/assets/MeshAssetManager_tests.cpp
@@ -150,3 +150,23 @@ TEST_F(MeshAssetManager_tests, Unload_FromEnd_UpdatesAccesors)
     EXPECT_EQ(view2.firstIndex, view1.indexCount);
     EXPECT_EQ(view2.firstVertex, view1.vertexCount);
 }
+
+TEST_F(MeshAssetManager_tests, GetPath_Loaded_ReturnsPath)
+{
+    std::array<std::string, 2u> paths{meshPath1, meshPath2};
+    assetManager->Load(paths, false);
+    const auto& expected = paths.at(0);
+    const auto view = assetManager->Acquire(expected);
+    const auto actual = assetManager->GetPath(view.id);
+    EXPECT_EQ(expected, actual);
+}
+
+TEST_F(MeshAssetManager_tests, GetPath_NotLoaded_Throws)
+{
+    std::array<std::string, 2u> paths{meshPath1, meshPath2};
+    assetManager->Load(paths, false);
+    const auto& expected = paths.at(0);
+    const auto view = assetManager->Acquire(expected);
+    assetManager->UnloadAll();
+    EXPECT_THROW(assetManager->GetPath(view.id), nc::NcError);
+}

--- a/test/assets/SkeletalAnimationAssetManager_tests.cpp
+++ b/test/assets/SkeletalAnimationAssetManager_tests.cpp
@@ -105,3 +105,23 @@ TEST_F(SkeletalAnimationAssetManager_tests, UnloadAll_Empty_Completes)
 {
     assetManager->UnloadAll(AssetFlags::None);
 }
+
+TEST_F(SkeletalAnimationAssetManager_tests, GetPath_Loaded_ReturnsPath)
+{
+    std::array<std::string, 2u> paths{test_animation, test_animation_2};
+    assetManager->Load(paths, false);
+    const auto& expected = paths.at(0);
+    const auto view = assetManager->Acquire(expected);
+    const auto actual = assetManager->GetPath(view.id);
+    EXPECT_EQ(expected, actual);
+}
+
+TEST_F(SkeletalAnimationAssetManager_tests, GetPath_NotLoaded_Throws)
+{
+    std::array<std::string, 2u> paths{test_animation, test_animation_2};
+    assetManager->Load(paths, false);
+    const auto& expected = paths.at(0);
+    const auto view = assetManager->Acquire(expected);
+    assetManager->UnloadAll();
+    EXPECT_THROW(assetManager->GetPath(view.id), nc::NcError);
+}

--- a/test/assets/TextureAssetManager_tests.cpp
+++ b/test/assets/TextureAssetManager_tests.cpp
@@ -141,3 +141,23 @@ TEST_F(TextureAssetManager_tests, Unload_FromEnd_AccessorsNotUpdated)
     EXPECT_EQ(view1.index, 0u);
     EXPECT_EQ(view2.index, 1u);
 }
+
+TEST_F(TextureAssetManager_tests, GetPath_Loaded_ReturnsPath)
+{
+    std::array<std::string, 2u> paths{Texture_base, Texture_normal};
+    assetManager->Load(paths, false);
+    const auto& expected = paths.at(0);
+    const auto view = assetManager->Acquire(expected);
+    const auto actual = assetManager->GetPath(view.id);
+    EXPECT_EQ(expected, actual);
+}
+
+TEST_F(TextureAssetManager_tests, GetPath_NotLoaded_Throws)
+{
+    std::array<std::string, 2u> paths{Texture_base, Texture_normal};
+    assetManager->Load(paths, false);
+    const auto& expected = paths.at(0);
+    const auto view = assetManager->Acquire(expected);
+    assetManager->UnloadAll();
+    EXPECT_THROW(assetManager->GetPath(view.id), nc::NcError);
+}


### PR DESCRIPTION
- Most important change here is deduplicating assets stored in multiple places or redundantly:
  - We were storing textures cpu-side without ever using them. Changes this so we keep them on the stack for the gpu transfer and then discard them.
  - Same for `BonesData`
  - We had duplicate copies of `SkeletalAnimation` - one in the asset manager and one in the animation system. Against my personal preferences, I removed the ones from the asset manager. The magnitude of the change is much smaller that way.
- Added some map-like containers for string lookups and updated asset managers to use them. They perform a bit better with large asset collections, but there's no noticeable difference in the sample. It also will enable some serious future improvements: 
  - Added an 'id' field to each asset view which is just the path hash and a `GetPath(hash)` method to each manager. This will be used in a future PR to move the asset loading responsibility out of components and have them take views in their constructors rather than paths. The only reason they still do this is the editor really wants the string data, and it would be annoying to pass both the view and the path. Once this is in, several components (like `MeshRenderer` and `ToonRenderer`) just become structs containing asset views - no more need for getters or setters.
- Fixed a few bugs with texture loading
  - `TextureAssetManager` never actually used the flags it was given.
  - `TextureAssetManager` didn't notify subscribers on UnloadAll, resulting in incorrect buffers on a subsequent loads.
  - `GraphicsTest` didn't load image/normal textures correctly