### PR TITLE
Add Smoke Test

### DIFF
--- a/sample/source/SampleMain.cpp
+++ b/sample/source/SampleMain.cpp
@@ -1,4 +1,5 @@
 #include "scenes/PhysicsTest.h"
+#include "scenes/SmokeTest.h"
 #include "shared/SampleUI.h"
 #include "shared/Prefabs.h"
 
@@ -7,8 +8,13 @@
 
 #include <iostream>
 
-int main()
+int main(int argc, char** argv)
 {
+    const auto runSmokeTest = [argc, argv]()
+    {
+        return argc > 1 && argv[1] == std::string_view{"--run-test"};
+    }();
+
     std::unique_ptr<nc::NcEngine> engine;
 
     try
@@ -16,8 +22,18 @@ int main()
         const auto config = nc::config::Load("config.ini");
         engine = nc::InitializeNcEngine(config);
         nc::sample::InitializeResources();
-        auto ui = nc::sample::InitializeSampleUI(engine.get());
-        engine->Start(std::make_unique<nc::sample::PhysicsTest>(ui.get()));
+
+        if (runSmokeTest)
+        {
+            engine->Start(std::make_unique<nc::sample::SmokeTest>(
+                [instance = engine.get()](){ instance->Stop(); }
+            ));
+        }
+        else
+        {
+            auto ui = nc::sample::InitializeSampleUI(engine.get());
+            engine->Start(std::make_unique<nc::sample::PhysicsTest>(ui.get()));
+        }
     }
     catch(std::exception& e)
     {

--- a/sample/source/scenes/CMakeLists.txt
+++ b/sample/source/scenes/CMakeLists.txt
@@ -3,4 +3,5 @@ target_sources(${NC_SAMPLE_EXE}
         Benchmarks.cpp
         GraphicsTest.cpp
         PhysicsTest.cpp
+        SmokeTest.cpp
 )

--- a/sample/source/scenes/SmokeTest.cpp
+++ b/sample/source/scenes/SmokeTest.cpp
@@ -1,0 +1,138 @@
+#include "SmokeTest.h"
+
+#include "ncengine/asset/Assets.h"
+#include "ncengine/asset/DefaultAssets.h"
+#include "ncengine/audio/AudioSource.h"
+#include "ncengine/audio/NcAudio.h"
+#include "ncengine/ecs/Logic.h"
+#include "ncengine/ecs/InvokeFreeComponent.h"
+#include "ncengine/ecs/Registry.h"
+#include "ncengine/graphics/NcGraphics.h"
+#include "ncengine/graphics/Camera.h"
+#include "ncengine/graphics/ParticleEmitter.h"
+#include "ncengine/graphics/PointLight.h"
+#include "ncengine/graphics/MeshRenderer.h"
+#include "ncengine/graphics/ToonRenderer.h"
+#include "ncengine/graphics/SkeletalAnimator.h"
+#include "ncengine/physics/Collider.h"
+#include "ncengine/physics/PhysicsBody.h"
+#include "ncengine/physics/NcPhysics.h"
+#include "ncengine/scene/NcScene.h"
+#include "ncengine/serialize/SceneSerialization.h"
+
+#include <fstream>
+
+namespace
+{
+constexpr auto g_sceneFragment = "smokeTestScene";
+
+void SaveScene(nc::ecs::Ecs world, const nc::asset::AssetMap& assets)
+{
+    auto file = std::ofstream{g_sceneFragment, std::ios::binary | std::ios::trunc};
+    if (!file)
+    {
+        throw nc::NcError{fmt::format("Failed to open fragment for writing: '{}'", g_sceneFragment)};
+    }
+
+    nc::SaveSceneFragment(file, world, assets);
+}
+
+void LoadScene(nc::ecs::Ecs world, nc::asset::NcAsset& ncAsset)
+{
+    auto file = std::ifstream{g_sceneFragment, std::ios::binary};
+    if (!file)
+    {
+        throw nc::NcError{fmt::format("Failed to open fragment for reading: '{}'", g_sceneFragment)};
+    }
+
+    nc::LoadSceneFragment(file, world, ncAsset);
+}
+} // anonymous namespace
+
+namespace nc::sample
+{
+SmokeTest::SmokeTest(std::function<void()> quitEngineCallback)
+    : m_quitEngine{std::move(quitEngineCallback)}
+{
+}
+
+void SmokeTest::Load(Registry* registry, ModuleProvider modules)
+{
+    // Set up for a course integration test. We add a few components and set module state so that each system runs
+    // its primary logic. After a few frames, we save a scene fragment and reload the scene, this time also reading
+    // the fragment. After a few more frames, we quit. Ideally, this should be run with validation layers enabled.
+
+    auto world = registry->GetEcs();
+    static auto isSecondPass = false;
+    world.Emplace<FrameLogic>(
+        world.Emplace<Entity>({}),
+        [world, modules, quit = m_quitEngine](Entity, Registry*, float) mutable
+        {
+            static auto framesRun = 0ull;
+            constexpr auto framesUntilSceneChange = 60ull;
+            constexpr auto framesUntilQuit = 120ull;
+            ++framesRun;
+            if (framesRun == framesUntilSceneChange)
+            {
+                isSecondPass = true;
+                auto ncAsset = modules.Get<asset::NcAsset>();
+                ::SaveScene(world, ncAsset->GetLoadedAssets());
+                auto ncScene = modules.Get<NcScene>();
+                ncScene->Queue(std::make_unique<SmokeTest>(quit));
+                ncScene->ScheduleTransition();
+            }
+            else if (framesRun == framesUntilQuit)
+            {
+                quit();
+            }
+        }
+    );
+
+    if (isSecondPass)
+    {
+        UnloadAllAudioClipAssets();
+        UnloadAllConcaveColliderAssets();
+        UnloadAllConvexHullAssets();
+        UnloadAllCubeMapAssets();
+        UnloadAllMeshAssets();
+        UnloadAllTextureAssets();
+        UnloadAllSkeletalAnimationAssets();
+        ::LoadScene(world, *modules.Get<asset::NcAsset>());
+    }
+
+    const auto cameraHandle = world.Emplace<Entity>({.position = Vector3{0.0f, 0.0f, -15.0f}});
+    auto& camera = world.Emplace<graphics::Camera>(cameraHandle);
+    auto ncGraphics = modules.Get<graphics::NcGraphics>();
+    ncGraphics->SetCamera(&camera);
+    ncGraphics->SetSkybox(asset::DefaultSkyboxCubeMap);
+    modules.Get<audio::NcAudio>()->RegisterListener(cameraHandle);
+
+    const auto object = world.Emplace<Entity>({});
+    world.Emplace<audio::AudioSource>(
+        object,
+        std::vector<std::string>{
+            std::string{asset::DefaultAudioClip}
+        },
+        audio::AudioSourceProperties{
+            .flags = audio::AudioSourceFlags::Play |
+                     audio::AudioSourceFlags::Loop
+        }
+    );
+
+    world.Emplace<graphics::MeshRenderer>(object);
+    world.Emplace<graphics::ToonRenderer>(object);
+    world.Emplace<graphics::PointLight>(object);
+    world.Emplace<graphics::ParticleEmitter>(object, graphics::ParticleInfo{
+        .emission = {
+            .initialEmissionCount = 10,
+            .periodicEmissionCount = 10,
+            .periodicEmissionFrequency = 0.1f
+        }
+    });
+
+    world.Emplace<physics::Collider>(object, physics::BoxProperties{});
+    world.Emplace<physics::PhysicsBody>(object);
+
+    world.Emplace<Entity>({.parent = object});
+}
+} // namespace nc::sample

--- a/sample/source/scenes/SmokeTest.cpp
+++ b/sample/source/scenes/SmokeTest.cpp
@@ -127,7 +127,9 @@ void SmokeTest::Load(Registry* registry, ModuleProvider modules)
             .initialEmissionCount = 10,
             .periodicEmissionCount = 10,
             .periodicEmissionFrequency = 0.1f
-        }
+        },
+        .init = {},
+        .kinematic = {}
     });
 
     world.Emplace<physics::Collider>(object, physics::BoxProperties{});

--- a/sample/source/scenes/SmokeTest.h
+++ b/sample/source/scenes/SmokeTest.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "ncengine/scene/Scene.h"
+
+#include <functional>
+
+namespace nc::sample
+{
+class SmokeTest : public Scene
+{
+    public:
+        SmokeTest(std::function<void()> quitEngineCallback);
+
+        void Load(Registry* registry, ModuleProvider modules) override;
+
+    private:
+        std::function<void()> m_quitEngine;
+};
+} // nc::sample

--- a/source/engine/audio/AudioSource.cpp
+++ b/source/engine/audio/AudioSource.cpp
@@ -33,6 +33,7 @@ AudioSource::AudioSource(Entity entity,
                          AudioSourceProperties properties)
     : ComponentBase{entity},
       m_clips{::GetClips(clips)},
+      m_currentClipIndex{properties.flags & AudioSourceFlags::Play ? 0ull : NullClipIndex},
       m_properties{properties},
       m_coldData{std::make_unique<AudioSourceColdData>(std::move(clips))}
 {

--- a/source/engine/audio/AudioSource.cpp
+++ b/source/engine/audio/AudioSource.cpp
@@ -33,10 +33,14 @@ AudioSource::AudioSource(Entity entity,
                          AudioSourceProperties properties)
     : ComponentBase{entity},
       m_clips{::GetClips(clips)},
-      m_currentClipIndex{properties.flags & AudioSourceFlags::Play ? 0ull : NullClipIndex},
       m_properties{properties},
       m_coldData{std::make_unique<AudioSourceColdData>(std::move(clips))}
 {
+    if (IsPlaying())
+    {
+        NC_ASSERT(!m_clips.empty(), "AudioSource must have at least one clip when initialized with 'Play' flag.");
+        m_currentClipIndex = 0u;
+    }
 }
 
 void AudioSource::Play(uint32_t clipIndex)

--- a/test/audio/AudioSource_tests.cpp
+++ b/test/audio/AudioSource_tests.cpp
@@ -15,7 +15,7 @@ const auto g_clip1 = std::string{"clip1.nca"};
 const auto g_clip2 = std::string{"clip2.nca"};
 const auto g_clip3 = std::string{"clip3.nca"};
 
-TEST(AudioSourceTests, Constructor_playFlag_setsCorrectClipIndex)
+TEST(AudioSourceTests, Constructor_playFlag_handlesInitialClipSelection)
 {
     {
         const auto uut = nc::audio::AudioSource{g_entity, {g_clip1}};
@@ -26,6 +26,11 @@ TEST(AudioSourceTests, Constructor_playFlag_setsCorrectClipIndex)
         const auto props = nc::audio::AudioSourceProperties{.flags = nc::audio::AudioSourceFlags::Play};
         const auto uut = nc::audio::AudioSource{g_entity, {g_clip1}, props};
         EXPECT_EQ(0ull, uut.GetRecentClipIndex());
+    }
+
+    {
+        const auto props = nc::audio::AudioSourceProperties{.flags = nc::audio::AudioSourceFlags::Play};
+        EXPECT_THROW(nc::audio::AudioSource(g_entity, {}, props), nc::NcError);
     }
 }
 

--- a/test/audio/AudioSource_tests.cpp
+++ b/test/audio/AudioSource_tests.cpp
@@ -15,6 +15,20 @@ const auto g_clip1 = std::string{"clip1.nca"};
 const auto g_clip2 = std::string{"clip2.nca"};
 const auto g_clip3 = std::string{"clip3.nca"};
 
+TEST(AudioSourceTests, Constructor_playFlag_setsCorrectClipIndex)
+{
+    {
+        const auto uut = nc::audio::AudioSource{g_entity, {g_clip1}};
+        EXPECT_EQ(nc::audio::NullClipIndex, uut.GetRecentClipIndex());
+    }
+
+    {
+        const auto props = nc::audio::AudioSourceProperties{.flags = nc::audio::AudioSourceFlags::Play};
+        const auto uut = nc::audio::AudioSource{g_entity, {g_clip1}, props};
+        EXPECT_EQ(0ull, uut.GetRecentClipIndex());
+    }
+}
+
 TEST(AudioSourceTests, Play_validClipIndex_setsPlayState)
 {
     auto uut = nc::audio::AudioSource{g_entity, {g_clip1}};


### PR DESCRIPTION
part of #252

Adding a test scene to the sample that can be run from CI. Requires #601 before we can actually run it there, but it can be run locally with `./Sample --run-test`.

It caught a bug with `AudioSource`, so I fixed that and added some test coverage.