### PR TITLE
Update Task Dependency Handling

### DIFF
--- a/include/ncengine/audio/NcAudio.h
+++ b/include/ncengine/audio/NcAudio.h
@@ -39,8 +39,8 @@ struct AudioDevice
  * @brief Audio module interface.
  * 
  * Tasks:
- *   Process Audio
- *     Runs During: UpdatePhase::Free
+ *   AudioSourceUpdate
+ *     Depends On: None
  *     Component Access:
  *       Write: AudioSource
  *       Read: Transform

--- a/include/ncengine/ecs/NcEcs.h
+++ b/include/ncengine/ecs/NcEcs.h
@@ -22,7 +22,7 @@ class ComponentRegistry;
  * 
  * Tasks
  *   FrameLogicUpdate
- *     Depends On: DebugRendererNewFrame
+ *     Depends On: DebugRendererNewFrame (only in dev builds)
  *     Component Access: All
  *   CommitPendingChanges
  *     Depends On: ParticleEmitterUpdate, AudioSourceUpdate, FrameLogicUpdate

--- a/include/ncengine/ecs/NcEcs.h
+++ b/include/ncengine/ecs/NcEcs.h
@@ -21,11 +21,11 @@ class ComponentRegistry;
  * @brief Module managing ComponentRegistry operations.
  * 
  * Tasks
- *   Update FrameLogic Components
- *     Runs During: UpdatePhase::Logic
+ *   FrameLogicUpdate
+ *     Depends On: DebugRendererNewFrame
  *     Component Access: All
- *   Commit Pending Changes
- *     Runs During: UpdatePhase::Sync
+ *   CommitPendingChanges
+ *     Depends On: ParticleEmitterUpdate, AudioSourceUpdate, FrameLogicUpdate
  *     Component Access: All
  */
 class NcEcs : public Module

--- a/include/ncengine/graphics/NcGraphics.h
+++ b/include/ncengine/graphics/NcGraphics.h
@@ -17,10 +17,24 @@ class Registry;
 namespace nc::graphics
 {
 /** @brief Graphics module interface.
- *  
- *  Component Access:
- *      Write: Camera, MeshRenderer, ToonRenderer, ParticleEmitter, PointLight
- *      Read: Transform
+ * 
+ * Update Tasks
+ *   DebugRendererNewFrame (only in dev builds)
+ *     Depends On: None
+ *     Component Access: WireframeRenderer
+ *   ParticleEmitterUpdate
+ *     Depends On: None
+ *     Component Access: None
+ *  ParticleEmitterSync
+ *     Depends On: CommitStagedChanges
+ *     Component Access: ParticleEmitter
+ * 
+ * Render Tasks
+ *   Render
+ *     Depends On: None
+ *     Component Access:
+ *       Write: Camera, SkeletalAnimator, WireframeRenderer
+ *       Read: MeshRenderer, ToonRenderer, PointLight, Transform
 */
 struct NcGraphics : public Module
 {

--- a/include/ncengine/physics/NcPhysics.h
+++ b/include/ncengine/physics/NcPhysics.h
@@ -12,8 +12,12 @@ namespace nc::physics
 {
 /** @brief Physics module interface
  * 
- *  Component Access:
- *      Write: Collider, ConcaveCollider, PhysicsBody, Transform
+ * Tasks
+ *   PhysicsPipeline
+ *     Depends On: FrameLogicUpdate
+ *     Component Access:
+ *       Write: Collider, PhysicsBody, Transform
+ *       Read: ConcaveCollider, PhysicsMaterial, PositionClamp, VelocityRestriction
  */
 struct NcPhysics : public Module
 {

--- a/include/ncengine/task/TaskFwd.h
+++ b/include/ncengine/task/TaskFwd.h
@@ -11,8 +11,8 @@ namespace nc::task
 template<class Phase>
 class TaskGraph;
 
-enum class UpdatePhase : uint8_t;
-enum class RenderPhase : uint8_t;
+struct UpdatePhase;
+struct RenderPhase;
 using UpdateTasks = TaskGraph<UpdatePhase>;
 using RenderTasks = TaskGraph<RenderPhase>;
 } // namespace nc::task

--- a/include/ncengine/task/TaskGraph.h
+++ b/include/ncengine/task/TaskGraph.h
@@ -21,6 +21,7 @@ struct TaskGraphContext : StableAddress
     std::vector<std::unique_ptr<tf::Taskflow>> storage;
 };
 
+/** @brief Task state for an item scheduled on a TaskGraph. */
 struct Task
 {
     tf::Task task;

--- a/include/ncengine/task/TaskGraph.h
+++ b/include/ncengine/task/TaskGraph.h
@@ -9,47 +9,24 @@
 #include "taskflow/taskflow.hpp"
 #include "ncutility/NcError.h"
 
-#include <array>
 #include <vector>
 
 namespace nc::task
 {
-/**
- * @brief Identifies a phase in the engine's update task graph.
- *
- * Update loop execution is broken up into phases. Tasks and task graphs are
- * scheduled to run during particular phases. Generally, phases execute
- * sequentially, with the exception of Free, which runs parallel to other
- * update phases.
- */
-enum class UpdatePhase : uint8_t
-{
-    Begin,         // First phase to run
-    Free,          // Runs parallel to Logic and Physics
-    Logic,         // Update FrameLogic components
-    Physics,       // Run NcPhysics task graph and update FixedLogic components - depends on Logic
-    Sync,          // Commit Registry changes - depends on Free and Physics
-    Count          // Enum size helper (not a phase)
-};
-
-/**
- * @brief Identifies a phase in the engine's render task graph.
- * 
- * Render phases run sequentially after all update phases have finished.
- */
-enum class RenderPhase : uint8_t
-{
-    Render,        // Host-side rendering logic
-    PostRender,    // Runs after Render
-    Count          // Enum size helper (not a phase)
-};
-
 /** @brief Context object holding a TaskGraph's state. */
 struct TaskGraphContext : StableAddress
 {
     tf::Taskflow graph;
     ExceptionContext exceptionContext;
     std::vector<std::unique_ptr<tf::Taskflow>> storage;
+};
+
+struct Task
+{
+    tf::Task task;
+    size_t id;
+    std::vector<size_t> predecessors;
+    std::vector<size_t> successors;
 };
 
 /** @brief Task graph interface for building a TaskGraphContext with Module tasks. */
@@ -60,33 +37,45 @@ class TaskGraph
         /**
          * @brief Schedule a single task to run during a phase.
          * @tparam F A callable of the form void(*)().
-         * @param phase The target phase.
+         * @param id A unique id for the task.
          * @param name A user-friendly name for the task.
          * @param func The callable to schedule.
+         * @param predecessors An optional list of task ids to be scheduled before the task.
+         * @param successors An optional list of task ids to be scheduled after the task.
          * @return A handle to a scheduled task.
          * @note If func doesn't satisfy std::is_nothrow_invocable, it will be
          *       wrapped with a call to task::Guard().
          */
         template<std::invocable<> F>
-        auto Add(Phase phase, std::string_view name, F&& func) -> tf::Task
+        auto Add(size_t id,
+                 std::string_view name,
+                 F&& func,
+                 std::vector<size_t> predecessors = {},
+                 std::vector<size_t> successors = {}) -> tf::Task
         {
-            return Schedule(phase, Emplace(name, std::forward<F>(func)));
+            return Schedule(id, Emplace(name, std::forward<F>(func)), std::move(predecessors), std::move(successors));
         }
 
         /**
          * @brief Schedule a tf::Taskflow to run during a phase.
-         * @param phase The target phase.
+         * @param id A unique id for the task.
          * @param name A user-friendly name for the task graph.
          * @param graph The graph to be composed.
+         * @param predecessors An optional list of task ids to be scheduled before the task.
+         * @param successors An optional list of task ids to be scheduled after the task.
          * @return A handle to a scheduled task composed from the Taskflow.
          * @note Ensure exceptions cannot leak from the graph. Tasks may be
          *       wrapped with task::Guard() to delay throwing until execution
          *       has finished.
          */
-        auto Add(Phase phase, std::string_view name, std::unique_ptr<tf::Taskflow> graph) -> tf::Task
+        auto Add(size_t id,
+                 std::string_view name,
+                 std::unique_ptr<tf::Taskflow> graph,
+                 std::vector<size_t> predecessors = {},
+                 std::vector<size_t> successors = {}) -> tf::Task
         {
             NC_ASSERT(graph != nullptr, "Task graph should not be null.");
-            return Schedule(phase, Emplace(name, std::move(graph)));
+            return Schedule(id, Emplace(name, std::move(graph)), std::move(predecessors), std::move(successors));
         }
 
         /** @brief Take ownership of a tf::Tasflow without scheduling anything. Useful for
@@ -104,7 +93,7 @@ class TaskGraph
 
     protected:
         std::unique_ptr<TaskGraphContext> m_ctx;
-        std::array<std::vector<tf::Task>, static_cast<size_t>(Phase::Count)> m_taskBuckets;
+        std::vector<Task> m_tasks;
 
         TaskGraph()
             : m_ctx{std::make_unique<TaskGraphContext>()}
@@ -113,9 +102,9 @@ class TaskGraph
 
         ~TaskGraph() noexcept = default;
 
-        auto Schedule(Phase phase, tf::Task handle) -> tf::Task
+        auto Schedule(size_t id, tf::Task handle, std::vector<size_t> predecessors, std::vector<size_t> successors) -> tf::Task
         {
-            return m_taskBuckets.at(static_cast<size_t>(phase)).emplace_back(handle);
+            return m_tasks.emplace_back(handle, id, std::move(predecessors), std::move(successors)).task;
         }
 
         template<std::invocable<> F>
@@ -131,6 +120,12 @@ class TaskGraph
             return handle;
         }
 };
+
+/** @brief Tag type to identify the update graph. */
+struct UpdatePhase;
+
+/** @brief Tag type to identify the render graph. */
+struct RenderPhase;
 
 /** @brief Alias for the TaskGraph handling update tasks. */
 using UpdateTasks = TaskGraph<UpdatePhase>;

--- a/include/ncengine/type/EngineId.h
+++ b/include/ncengine/type/EngineId.h
@@ -8,10 +8,10 @@
 
 namespace nc
 {
-/** @brief Marks the beginning of the component and module id range reserved for engine use. */
+/** @brief Marks the beginning of the component, module, and task id range reserved for engine use. */
 constexpr size_t EngineIdRangeBegin = 1ull;
 
-/** @brief Marks the end of the component and module id range reserved for engine use. */
+/** @brief Marks the end of the component, module, and task id range reserved for engine use. */
 constexpr size_t EngineIdRangeEnd = 100ull;
 
 /** @{ */
@@ -48,4 +48,24 @@ constexpr size_t NcTimeId = 6ull;
 constexpr size_t NcRandomId = 7ull;
 constexpr size_t NcSceneId = 8ull;
 /** @} */
+
+namespace update_task_id
+{
+/** @brief Unique engine task id for update phase. */
+constexpr size_t DebugRendererNewFrame = 1ull;
+constexpr size_t ParticleEmitterUpdate = 2ull;
+constexpr size_t AudioSourceUpdate = 3ull;
+constexpr size_t FrameLogicUpdate = 4ull; // Depends on DebugRendererNewFrame
+constexpr size_t PhysicsPipeline = 5ull; // Depends on FrameLogicUpdate
+constexpr size_t CommitStagedChanges = 6ull; // Depends on all other update tasks
+constexpr size_t ParticleEmitterSync = 7ull; // Depends on CommitStagedChanges
+/** @} */
+} // namespace update_task_id
+
+namespace render_task_id
+{
+/** @brief Unique engine task id for render phase. */
+constexpr size_t Render = 50ull;
+/** @} */
+} // namespace render_task_id
 } // namespace nc

--- a/source/engine/audio/NcAudioImpl.cpp
+++ b/source/engine/audio/NcAudioImpl.cpp
@@ -66,6 +66,15 @@ struct NcAudioStub : public nc::audio::NcAudio
     nc::audio::AudioDevice nullDevice{"NoDevice", nc::audio::InvalidDeviceId};
     nc::Signal<const nc::audio::AudioDevice&> nullSignal;
 
+    void OnBuildTaskGraph(nc::task::UpdateTasks& update, nc::task::RenderTasks&)
+    {
+        update.Add(
+            nc::update_task_id::AudioSourceUpdate,
+            "AudioSourceUpdate(stub)",
+            []{}
+        );
+    }
+
     void RegisterListener(nc::Entity) noexcept override{}
     auto GetStreamTime() const noexcept -> double override { return 0.0; }
     void SetStreamTime(double) noexcept override {}
@@ -121,8 +130,12 @@ void NcAudioImpl::Clear() noexcept
 
 void NcAudioImpl::OnBuildTaskGraph(task::UpdateTasks& update, task::RenderTasks&)
 {
-    NC_LOG_TRACE("Building NcAudio workload");
-    update.Add(task::UpdatePhase::Free, "NcAudio", [this]{ Run(); });
+    NC_LOG_TRACE("Building NcAudio Tasks");
+    update.Add(
+        update_task_id::AudioSourceUpdate,
+        "AudioSourceUpdate",
+        [this]{ Run(); }
+    );
 }
 
 void NcAudioImpl::RegisterListener(Entity listener) noexcept

--- a/source/engine/ecs/NcEcsImpl.cpp
+++ b/source/engine/ecs/NcEcsImpl.cpp
@@ -34,8 +34,7 @@ void EcsModule::OnBuildTaskGraph(task::UpdateTasks& update, task::RenderTasks&)
     (
         update_task_id::FrameLogicUpdate,
         "FrameLogicUpdate",
-        [this] { RunFrameLogic(); },
-        {update_task_id::DebugRendererNewFrame}
+        [this] { RunFrameLogic(); }
     );
 
     update.Add

--- a/source/engine/ecs/NcEcsImpl.cpp
+++ b/source/engine/ecs/NcEcsImpl.cpp
@@ -29,18 +29,19 @@ EcsModule::EcsModule(ComponentRegistry& registry, SystemEvents& events) noexcept
 
 void EcsModule::OnBuildTaskGraph(task::UpdateTasks& update, task::RenderTasks&)
 {
-    NC_LOG_TRACE("Building EcsModule workload");
+    NC_LOG_TRACE("Building EcsModule Tasks");
     update.Add
     (
-        task::UpdatePhase::Logic,
-        "NcEcs - RunFrameLogic",
-        [this] { RunFrameLogic(); }
+        update_task_id::FrameLogicUpdate,
+        "FrameLogicUpdate",
+        [this] { RunFrameLogic(); },
+        {update_task_id::DebugRendererNewFrame}
     );
 
     update.Add
     (
-        task::UpdatePhase::Sync,
-        "NcEcs - Commit Staged Changes",
+        update_task_id::CommitStagedChanges,
+        "CommitStagedChanges",
         [this]
         {
             m_registry->CommitPendingChanges();
@@ -51,6 +52,11 @@ void EcsModule::OnBuildTaskGraph(task::UpdateTasks& update, task::RenderTasks&)
             }
 
             UpdateWorldSpaceMatrices();
+        },
+        {
+            update_task_id::AudioSourceUpdate,
+            update_task_id::ParticleEmitterUpdate,
+            update_task_id::PhysicsPipeline
         }
     );
 }

--- a/source/engine/graphics/NcGraphicsImpl.cpp
+++ b/source/engine/graphics/NcGraphicsImpl.cpp
@@ -20,6 +20,28 @@ namespace
     {
         NcGraphicsStub(nc::Registry*) {}
 
+        void OnBuildTaskGraph(nc::task::UpdateTasks& update, nc::task::RenderTasks& render)
+        {
+            update.Add(
+                nc::update_task_id::ParticleEmitterUpdate,
+                "ParticleEmitterUpdate(stub)",
+                []{}
+            );
+
+            render.Add(
+                nc::update_task_id::ParticleEmitterSync,
+                "ParticleEmitterSync(stub)",
+                []{},
+                {nc::update_task_id::CommitStagedChanges}
+            );
+
+            render.Add(
+                nc::render_task_id::Render,
+                "Render(stub)",
+                []{}
+            );
+        }
+
         void SetCamera(nc::graphics::Camera*) noexcept override {}
         auto GetCamera() noexcept -> nc::graphics::Camera* override { return nullptr; }
         void SetUi(nc::ui::IUI*) noexcept override {}
@@ -127,14 +149,33 @@ namespace nc::graphics
 
     void NcGraphicsImpl::OnBuildTaskGraph(task::UpdateTasks& update, task::RenderTasks& render)
     {
-        NC_LOG_TRACE("Building NcGraphics workload");
+        NC_LOG_TRACE("Building NcGraphics Tasks");
 
 #if NC_DEBUG_RENDERING_ENABLED
-        update.Add(task::UpdatePhase::Begin, "DebugRenderer", debug::DebugRendererNewFrame);
+        update.Add(
+            update_task_id::DebugRendererNewFrame,
+            "DebugRendererNewFrame",
+            debug::DebugRendererNewFrame
+        );
 #endif
-        update.Add(task::UpdatePhase::Free, "ParticleEmitterSystem", [this]{ m_systemResources.particleEmitters.Run(); });
-        render.Add(task::RenderPhase::Render, "NcGraphics", [this]{ Run(); });
-        render.Add(task::RenderPhase::PostRender, "ProcessParticleFrameEvents", [this]{ m_systemResources.particleEmitters.ProcessFrameEvents(); } );
+        update.Add(
+            update_task_id::ParticleEmitterUpdate,
+            "ParticleEmitterUpdate",
+            [this]{ m_systemResources.particleEmitters.Run(); }
+        );
+
+        update.Add(
+            update_task_id::ParticleEmitterSync,
+            "ParticleEmitterSync",
+            [this]{ m_systemResources.particleEmitters.ProcessFrameEvents(); },
+            {update_task_id::CommitStagedChanges}
+        );
+
+        render.Add(
+            render_task_id::Render,
+            "Render",
+            [this]{ Run(); }
+        );
     }
 
     void NcGraphicsImpl::Run()

--- a/source/engine/graphics/NcGraphicsImpl.cpp
+++ b/source/engine/graphics/NcGraphicsImpl.cpp
@@ -152,10 +152,14 @@ namespace nc::graphics
         NC_LOG_TRACE("Building NcGraphics Tasks");
 
 #if NC_DEBUG_RENDERING_ENABLED
+         // We must express FrameLogicUpdate dependency here (as a predecessor) so we don't have
+         // a missing task id in prod builds where this is excluded.
         update.Add(
             update_task_id::DebugRendererNewFrame,
             "DebugRendererNewFrame",
-            debug::DebugRendererNewFrame
+            debug::DebugRendererNewFrame,
+            {},
+            {update_task_id::FrameLogicUpdate}
         );
 #endif
         update.Add(

--- a/source/engine/physics/NcPhysicsImpl.cpp
+++ b/source/engine/physics/NcPhysicsImpl.cpp
@@ -34,6 +34,16 @@ class NcPhysicsStub : public nc::physics::NcPhysics
         void UnregisterClickable(IClickable*) noexcept override {}
         auto RaycastToClickables(LayerMask = LayerMaskAll) -> IClickable* override { return nullptr;}
 
+        void OnBuildTaskGraph(nc::task::UpdateTasks& update, nc::task::RenderTasks&)
+        {
+            update.Add(
+                nc::update_task_id::PhysicsPipeline,
+                "PhysicsPipeline(stub)",
+                []{},
+                {nc::update_task_id::FrameLogicUpdate}
+            );
+        }
+
     private:
         BspTreeStub m_bspStub;
 };
@@ -93,8 +103,13 @@ auto NcPhysicsImpl::RaycastToClickables(LayerMask mask) -> IClickable*
 
 void NcPhysicsImpl::OnBuildTaskGraph(task::UpdateTasks& update, task::RenderTasks&)
 {
-    NC_LOG_TRACE("Building NcPhysics workload");
-    update.Add(task::UpdatePhase::Physics, "NcPhysics", m_pipeline.BuildTaskGraph(update.GetExceptionContext()));
+    NC_LOG_TRACE("Building NcPhysics Tasks");
+    update.Add(
+        update_task_id::PhysicsPipeline,
+        "PhysicsPipeline",
+        m_pipeline.BuildTaskGraph(update.GetExceptionContext()),
+        {update_task_id::FrameLogicUpdate}
+    );
 }
 
 void NcPhysicsImpl::Clear() noexcept

--- a/test/task/TaskGraph_unit_tests.cpp
+++ b/test/task/TaskGraph_unit_tests.cpp
@@ -11,9 +11,9 @@ class TestTaskGraph : public nc::task::TaskGraph<nc::task::UpdatePhase>
             return m_ctx->graph;
         }
 
-        auto GetTaskBucket(nc::task::UpdatePhase phase) -> const std::vector<tf::Task>&
+        auto GetTasks() -> const std::vector<nc::task::Task>&
         {
-            return m_taskBuckets.at(static_cast<size_t>(phase));
+            return m_tasks;
         }
 
         auto GetGraphStorage() -> const std::vector<std::unique_ptr<tf::Taskflow>>&
@@ -24,39 +24,23 @@ class TestTaskGraph : public nc::task::TaskGraph<nc::task::UpdatePhase>
 
 TEST(TaskGraphTests, Add_callableOverload_addsToPhase)
 {
-    constexpr auto phase = nc::task::UpdatePhase::Logic;
     auto uut = TestTaskGraph{};
-    ASSERT_TRUE(uut.GetTaskBucket(phase).empty());
-    uut.Add(phase, "task1", [](){});
-    uut.Add(phase, "task2", [](){});
-    uut.Add(phase, "task3", [](){});
-    EXPECT_EQ(3, uut.GetTaskBucket(phase).size());
+    ASSERT_TRUE(uut.GetTasks().empty());
+    uut.Add(0, "task1", [](){});
+    uut.Add(1, "task2", [](){});
+    uut.Add(2, "task3", [](){});
+    EXPECT_EQ(3, uut.GetTasks().size());
 }
 
 TEST(TaskGraphTests, Add_taskflowOverload_addsToPhaseAndStorage)
 {
-    constexpr auto phase = nc::task::UpdatePhase::Begin;
     auto uut = TestTaskGraph{};
-    ASSERT_TRUE(uut.GetTaskBucket(phase).empty());
+    ASSERT_TRUE(uut.GetTasks().empty());
     ASSERT_TRUE(uut.GetGraphStorage().empty());
-    uut.Add(phase, "testTask", std::make_unique<tf::Taskflow>());
-    EXPECT_EQ(1, uut.GetTaskBucket(phase).size());
+    uut.Add(0, "testTask", std::make_unique<tf::Taskflow>());
+    EXPECT_EQ(1, uut.GetTasks().size());
     EXPECT_EQ(1, uut.GetGraphStorage().size());
 }
-
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wconversion"
-#endif
-TEST(TaskGraphTests, Add_invalidPhase_throws)
-{
-    constexpr auto phase = static_cast<nc::task::UpdatePhase>(1000);
-    auto uut = TestTaskGraph{};
-    EXPECT_THROW(uut.Add(phase, "", [](){}), std::exception);
-}
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
 
 TEST(TaskGraphTests, StoreGraph_addsToStorage)
 {


### PR DESCRIPTION
resolves #611

Removing task execution phases and replacing them with a scheduling mechanism based directly on task ids. Each task now has a unique id. When a task/graph is scheduled, instead of supplying the phase to run on, a list of predecessors and/or successors is given.

I also moved the particle emitter task that was on the render graph to the update graph. It couldn't be safely scheduled there before with the phase-based solution.