### PR TITLE
Missing unmap bug + minor gfx tweaks

### DIFF
--- a/source/engine/graphics/api/vulkan/buffers/StorageBuffer.cpp
+++ b/source/engine/graphics/api/vulkan/buffers/StorageBuffer.cpp
@@ -41,6 +41,9 @@ void StorageBuffer::Clear() noexcept
     {
         memset(dataContainer, 0u, m_alignedSize);
     }
+
+    m_allocator->Unmap(allocation);
+    m_previousDataSize = 0u;
 }
 
 void StorageBuffer::Bind(const void* dataToMap, uint32_t dataSize)
@@ -48,9 +51,11 @@ void StorageBuffer::Bind(const void* dataToMap, uint32_t dataSize)
     auto allocation = m_buffer.Allocation();
     void* dataContainer = m_allocator->Map(allocation);
 
-    if (m_previousDataSize > 0u)
+    if (m_previousDataSize > dataSize)
     {
-        memset(dataContainer, 0u, m_previousDataSize);
+        const auto tailStart = reinterpret_cast<char*>(dataContainer) + dataSize;
+        const auto tailLen = m_previousDataSize - dataSize;
+        memset(tailStart, 0u, tailLen);
     }
 
     memcpy(dataContainer, dataToMap, dataSize);

--- a/source/engine/graphics/api/vulkan/buffers/UniformBuffer.cpp
+++ b/source/engine/graphics/api/vulkan/buffers/UniformBuffer.cpp
@@ -29,6 +29,7 @@ void UniformBuffer::Clear()
 {
     void* mappedData = m_allocator->Map(m_buffer.Allocation());
     memset(mappedData, 0u, m_alignedSize);
+    m_allocator->Unmap(m_buffer.Allocation());
 }
 
 void UniformBuffer::Bind(const void* data, uint32_t size)
@@ -37,4 +38,4 @@ void UniformBuffer::Bind(const void* data, uint32_t size)
     memcpy(mappedData, data, size);
     m_allocator->Unmap(m_buffer.Allocation());
 }
-}
+} // namespace nc::graphics::vulkan

--- a/source/engine/graphics/system/ObjectSystem.cpp
+++ b/source/engine/graphics/system/ObjectSystem.cpp
@@ -40,9 +40,12 @@ auto ObjectSystem::Execute(uint32_t frameIndex,
     OPTICK_CATEGORY("ObjectSystem::Execute", Optick::Category::Rendering);
     const auto viewProjection = cameraState.view * cameraState.projection;
     auto frontendState = ObjectState{};
+    const auto maxPbrRenderers = pbrRenderers.size_upper_bound();
+    const auto maxToonRenderers = toonRenderers.size_upper_bound();
+    frontendState.pbrMeshes.reserve(maxPbrRenderers);
+    frontendState.toonMeshes.reserve(maxToonRenderers);
     m_objectData.clear();
-    frontendState.pbrMeshes.reserve(pbrRenderers.size_upper_bound());
-    frontendState.toonMeshes.reserve(toonRenderers.size_upper_bound());
+    m_objectData.reserve(maxPbrRenderers + maxToonRenderers);
 
     for (const auto& [renderer, transform] : pbrRenderers)
     {

--- a/source/engine/graphics/system/ObjectSystem.h
+++ b/source/engine/graphics/system/ObjectSystem.h
@@ -50,7 +50,6 @@ class ObjectSystem
         ObjectSystem(ShaderResourceBus* shaderResourceBus, uint32_t maxObjects)
             : m_objectDataBuffer{shaderResourceBus->CreateStorageBuffer(sizeof(ObjectData) * maxObjects, ShaderStage::Fragment | ShaderStage::Vertex, 0, 0, false)}
         {
-            m_objectData.reserve(maxObjects);
         }
 
         auto Execute(uint32_t frameIndex,


### PR DESCRIPTION
- Fix missing `Unmap()` calls on `Clear()` in `StorageBuffer` and `UniformBuffer`
- Updating `StorageBuffer::Bind()` to only zero out the tail bytes that won't be filled, rather than the whole buffer
- Minimizing host memory usage in `ObjectSystem`. Reserving maxObjects right off the bat can be a lot, depending on the config.