### PR TITLE
Use appropriate queue for present

### DIFF
--- a/source/engine/graphics/api/vulkan/Swapchain.cpp
+++ b/source/engine/graphics/api/vulkan/Swapchain.cpp
@@ -174,7 +174,7 @@ namespace nc::graphics::vulkan
         m_imagesInFlightFences.resize(m_swapChainImages.size(), nullptr);
     }
 
-    void Swapchain::PresentImageToSwapChain(PerFrameGpuContext* currentFrame, vk::Queue queue, uint32_t imageIndex, bool& isSwapChainValid)
+    auto Swapchain::PresentImageToSwapChain(PerFrameGpuContext* currentFrame, vk::Queue queue, uint32_t imageIndex) -> bool
     {
         const auto waitSemaphore = currentFrame->RenderFinishedSemaphore();
         vk::SwapchainKHR swapChains[] = {m_swapChain.get()};
@@ -192,16 +192,17 @@ namespace nc::graphics::vulkan
         const auto result = queue.presentKHR(&presentInfo);
         if (result == vk::Result::eErrorOutOfDateKHR || result == vk::Result::eSuboptimalKHR)
         {
-            isSwapChainValid = false;
-            return;
+            return false;
         }
-        
+
         if (result != vk::Result::eSuccess)
         {
             throw NcError("Could not present to the swapchain.");
         }
+
+        return true;
     }
-    
+
     void Swapchain::WaitImageReadyForBuffer(PerFrameGpuContext* currentFrame, uint32_t imageIndex)
     {
         if (m_imagesInFlightFences[imageIndex])

--- a/source/engine/graphics/api/vulkan/Swapchain.h
+++ b/source/engine/graphics/api/vulkan/Swapchain.h
@@ -24,7 +24,7 @@ namespace nc::graphics::vulkan
             ~Swapchain() noexcept;
 
             // Swap chain
-            void PresentImageToSwapChain(PerFrameGpuContext* currentFrame, vk::Queue queue, uint32_t imageIndex, bool& isSwapChainValid);
+            auto PresentImageToSwapChain(PerFrameGpuContext* currentFrame, vk::Queue queue, uint32_t imageIndex) -> bool;
             void Cleanup() noexcept;
             void Resize(const Device& device, const Vector2& dimensions);
 

--- a/source/engine/graphics/api/vulkan/VulkanGraphics.cpp
+++ b/source/engine/graphics/api/vulkan/VulkanGraphics.cpp
@@ -168,7 +168,7 @@ void VulkanGraphics::FrameEnd()
 
     // Returns the image to the swapchain
     bool isSwapChainValid = true;
-    m_swapchain->PresentImageToSwapChain(currentFrame, m_device->VkGraphicsQueue(), m_imageIndex, isSwapChainValid);
+    m_swapchain->PresentImageToSwapChain(currentFrame, m_device->VkPresentQueue(), m_imageIndex, isSwapChainValid);
 
     if (!isSwapChainValid)
     {

--- a/source/engine/graphics/api/vulkan/VulkanGraphics.cpp
+++ b/source/engine/graphics/api/vulkan/VulkanGraphics.cpp
@@ -166,14 +166,11 @@ void VulkanGraphics::FrameEnd()
     m_swapchain->WaitImageReadyForBuffer(currentFrame, m_imageIndex);
     currentFrame->SubmitBufferToQueue(m_device->VkGraphicsQueue());
 
-    // Returns the image to the swapchain
-    bool isSwapChainValid = true;
-    m_swapchain->PresentImageToSwapChain(currentFrame, m_device->VkPresentQueue(), m_imageIndex, isSwapChainValid);
-
-    if (!isSwapChainValid)
+    if (!m_swapchain->PresentImageToSwapChain(currentFrame, m_device->VkPresentQueue(), m_imageIndex))
     {
         Resize(m_dimensions);
     }
+
     m_frameManager->End();
 }
 } // namespace nc::graphics::vulkan


### PR DESCRIPTION
resolves #338 

We were passing the graphics queue to `presentKHR()`. Based on some very light research, I think this is totally fine in practice. It seems safe to assume that a graphics queue will always support present, but since we're never actually verifying the graphics index == present index, I this should 'technically' be more correct.

Also, this bad boy used an out param but returned void. Fixed.