### PR TITLE
Combine physics tasks

### DIFF
--- a/source/engine/physics/PhysicsPipeline.h
+++ b/source/engine/physics/PhysicsPipeline.h
@@ -72,17 +72,12 @@ auto PhysicsPipeline<Stages>::BuildTaskGraph(task::ExceptionContext& context) ->
         BuildFixedUpdateTask(context, registry)
     );
 
-    auto updateInertia = builder.Add(
-        "Update World Inertia Tensors",
-        BuildUpdateInertiaTask(context, registry),
+    auto updatePhysicsBodies = builder.Add(
+        "Update World Physics Bodies",
+        BuildUpdatePhysicsBodiesTask(context, registry, m_fixedTimeStep),
         {fixedUpdate}
     );
 
-    auto applyGravity = builder.Add(
-        "Apply Gravity",
-        BuildApplyGravityTask(context, registry, m_fixedTimeStep),
-        {fixedUpdate}
-    );
 
     auto updateManifolds = builder.Add(
         "Update Contact Manifolds",
@@ -129,19 +124,19 @@ auto PhysicsPipeline<Stages>::BuildTaskGraph(task::ExceptionContext& context) ->
     auto generateFreedomConstraints = builder.Add(
         "Solver - Generate Freedom Constraints",
         BuildGenerateFreedomConstraintsTask(context, m_solver, m_fixedTimeStep),
-        {updateInertia, applyGravity}
+        {updatePhysicsBodies}
     );
 
     auto generateContactConstraints = builder.Add(
         "Solver - Generate Contact Constraints",
         BuildGenerateContactConstraintsTask(context, m_solver, m_narrowPhase),
-        {updateInertia, applyGravity, mergeContacts}
+        {updatePhysicsBodies, mergeContacts}
     );
 
     auto updateJoints = builder.Add(
         "Joint System - Update",
         BuildUpdateJointsTask(context, m_jointSystem, m_fixedTimeStep),
-        {applyGravity, updateInertia}
+        {updatePhysicsBodies}
     );
 
     auto resolveConstraints = builder.Add(

--- a/source/engine/physics/PhysicsPipelineBuilder.h
+++ b/source/engine/physics/PhysicsPipelineBuilder.h
@@ -49,21 +49,12 @@ inline auto BuildFixedUpdateTask(task::ExceptionContext& ctx, Registry* registry
     });
 }
 
-inline auto BuildUpdateInertiaTask(task::ExceptionContext& ctx, Registry* registry)
-{
-    return task::Guard(ctx, [registry]
-    {
-        OPTICK_CATEGORY("UpdateWorldInertiaTensors", Optick::Category::Physics);
-        UpdateWorldInertiaTensors(registry);
-    });
-}
-
-inline auto BuildApplyGravityTask(task::ExceptionContext& ctx, Registry* registry, float fixedTimeStep)
+inline auto BuildUpdatePhysicsBodiesTask(task::ExceptionContext& ctx, Registry* registry, float fixedTimeStep)
 {
     return task::Guard(ctx, [registry, fixedTimeStep]
     {
-        OPTICK_CATEGORY("ApplyGravity", Optick::Category::Physics);
-        ApplyGravity(registry, fixedTimeStep);
+        OPTICK_CATEGORY("UpdatePhysicsBodies", Optick::Category::Physics);
+        UpdatePhysicsBodies(registry, fixedTimeStep);
     });
 }
 

--- a/source/engine/physics/dynamics/Dynamics.cpp
+++ b/source/engine/physics/dynamics/Dynamics.cpp
@@ -11,25 +11,18 @@ const auto GravityVector = DirectX::XMVectorSet(0.0f, nc::physics::Gravity, 0.0f
 
 namespace nc::physics
 {
-void UpdateWorldInertiaTensors(Registry* registry)
+void UpdatePhysicsBodies(Registry* registry, float dt)
 {
+    const auto g = DirectX::XMVectorScale(GravityVector, dt);
     for (auto [body, transform] : MultiView<PhysicsBody, Transform>{registry})
     {
         body->UpdateWorldInertia(transform);
-    }
-}
-
-void ApplyGravity(Registry* registry, float dt)
-{
-    const auto g = DirectX::XMVectorScale(GravityVector, dt);
-
-    for(auto& body : View<PhysicsBody>{registry})
-    {
-        if(body.UseGravity() && !body.IsKinematic())
+        if(body->UseGravity() && !body->IsKinematic())
         {
-            body.ApplyVelocity(g);
+            body->ApplyVelocity(g);
         }
     }
+
 }
 
 void Integrate(Registry* registry, float dt)

--- a/source/engine/physics/dynamics/Dynamics.h
+++ b/source/engine/physics/dynamics/Dynamics.h
@@ -4,11 +4,8 @@
 
 namespace nc::physics
 {
-/** Transform inertia tensors into updated world space. */
-void UpdateWorldInertiaTensors(Registry* registry);
-
-/** Apply gravity to linear velocity of each body. */
-void ApplyGravity(Registry* registry, float dt);
+/** Apply gravity and update inertia tensors. */
+void UpdatePhysicsBodies(Registry* registry, float dt);
 
 /** Apply linear and angular velocities of each body to transforms. */
 void Integrate(Registry* registry, float dt);


### PR DESCRIPTION
resolves #416 

Combining the physics tasks that apply gravity and update inertia since they're both iterate over all `PhysicsBody` components. There isn't a race condition, but there could theoretically be contention over cache lines, and I see no real reason to have them as separate tasks.