### PR TITLE
Updated Github Action and Docker File to Ubuntu 24.04/GCC 14

### DIFF
--- a/.devcontainer/ubuntu.dockerfile
+++ b/.devcontainer/ubuntu.dockerfile
@@ -1,12 +1,12 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 RUN apt update && apt -y install \
     git \
     make \
     cmake \
-    g++-12 \
+    g++-14 \
     libvulkan-dev \
     xorg-dev
 
-ENV CC=/usr/bin/gcc-12 \
-    CXX=/usr/bin/g++-12
+ENV CC=/usr/bin/gcc-14 \
+    CXX=/usr/bin/g++-14

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,8 +29,9 @@ jobs:
             generator: "Visual Studio 17 2022"
             shortName: Windows
           - os: ubuntu-24.04
-            cmakeEnv: "CXX=/usr/bin/g++-13"
             shortName: Linux
+            generator: "Unix Makefiles"
+            cmakeEnv: "CXX=/usr/bin/g++-14"
           - variant: Dev
             cmakeArgs: "-DNC_PROFILING_ENABLED=ON"
           - variant: Prod

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,9 +29,8 @@ jobs:
             generator: "Visual Studio 17 2022"
             shortName: Windows
           - os: ubuntu-24.04
+            cmakeEnv: "CXX=/usr/bin/g++-13"
             shortName: Linux
-            generator: "Unix Makefiles"
-            cmakeEnv: "CXX=/usr/bin/g++-14"
           - variant: Dev
             cmakeArgs: "-DNC_PROFILING_ENABLED=ON"
           - variant: Prod

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
   Build:
     strategy:
       matrix:
-        os: [windows-2022, ubuntu-22.04]
+        os: [windows-2022, ubuntu-24.04]
         config: [Debug, Release]
         variant: [Dev, Prod]
         include:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
           - os: ubuntu-22.04
             shortName: Linux
             generator: "Unix Makefiles"
-            cmakeEnv: "CXX=/usr/bin/g++-13"
+            cmakeEnv: "CXX=/usr/bin/g++-12"
           - variant: Dev
             cmakeArgs: "-DNC_PROFILING_ENABLED=ON"
           - variant: Prod

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,10 +28,10 @@ jobs:
           - os: windows-2022
             generator: "Visual Studio 17 2022"
             shortName: Windows
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             shortName: Linux
             generator: "Unix Makefiles"
-            cmakeEnv: "CXX=/usr/bin/g++-12"
+            cmakeEnv: "CXX=/usr/bin/g++-14"
           - variant: Dev
             cmakeArgs: "-DNC_PROFILING_ENABLED=ON"
           - variant: Prod


### PR DESCRIPTION
See title. Note: The 24.04 Github runner image is still actively in beta, but that's a better choice IMO than bringing the pipeline down for a while, because the 22.04 Github runner image reverted to GCC 12, and it doesn't support some features we use.