### PR TITLE
Upstreaming game branch changes

### DIFF
--- a/include/ncengine/config/Config.h
+++ b/include/ncengine/config/Config.h
@@ -20,9 +20,10 @@ struct ProjectSettings
 /** @brief Settings for configuring the engine run loop and executor. */
 struct EngineSettings
 {
-    float timeStep = 0.01667f; // Set to 0 for variable time step
-    float maxTimeStep = 0.1f;  // Clamp delta time below this value
-    unsigned threadCount = 8u; // Set to 0 to use std::hardware_concurrency
+    float timeStep = 0.01667f;    // Set to 0 for variable time step
+    float maxTimeStep = 0.1f;     // Clamp delta time below this value
+    unsigned threadCount = 8u;    // Set to 0 to use std::hardware_concurrency
+    bool buildTasksOnInit = true; // Build tasks automatically on engine initialization or require explicit building
 };
 
 /**

--- a/include/ncengine/input/Input.h
+++ b/include/ncengine/input/Input.h
@@ -9,6 +9,14 @@ namespace nc::input
     using KeyCode_t = uint32_t;
     enum class KeyCode : KeyCode_t;
 
+    enum class KeyState
+    {
+        None,
+        Pressed,
+        Held,
+        Released
+    };
+
     auto MouseX() -> uint32_t;
     auto MouseY() -> uint32_t;
     auto MousePos() -> Vector2;
@@ -18,6 +26,7 @@ namespace nc::input
     auto GetYAxis() -> float;  // GetKey W & S; returns -1, 0, 1
     auto GetAxis() -> Vector2; // WASD results as a pair
 
+    auto Key(KeyCode keyCode) -> KeyState; // returns KeyState for a key
     auto KeyDown(KeyCode keyCode) -> bool; // true when key is first pressed
     auto KeyUp(KeyCode keyCode) -> bool;   // true when key is released
     auto KeyHeld(KeyCode keyCode) -> bool; // true while key is held

--- a/include/ncengine/math/Random.h
+++ b/include/ncengine/math/Random.h
@@ -106,7 +106,12 @@ class Random : public Module
          * @param max The maximum range value.
          * @return size_t
          */
-        auto Between(size_t min, size_t max) noexcept -> size_t { return m_generator() * (max - min) + min; }
+        auto Between(size_t min, size_t max) noexcept -> size_t
+        {
+            const auto minFloat = static_cast<float>(min);
+            const auto maxFloat = static_cast<float>(max);
+            return static_cast<size_t>(Get() * (maxFloat - minFloat) + minFloat);
+        }
 
         /**
          * @brief Generate a random Vector2 with components in the range [min, max].

--- a/include/ncengine/utility/detail/LogInternal.h
+++ b/include/ncengine/utility/detail/LogInternal.h
@@ -2,6 +2,7 @@
 
 #include "ncutility/platform/SourceLocation.h"
 
+#include <exception>
 #include <string_view>
 
 namespace nc

--- a/readme.md
+++ b/readme.md
@@ -114,6 +114,12 @@ While the default `Nc::Engine-dev` target can be built with a Release configurat
     Default: OFF
     Enabled profiling with Optick. This also requires the Optick application (https://www.optickprofiler.com) and the Optick shared library (installed to install-prefix/bin/OptickCore.dll).
 
+#### NC_PHYSICS_CONFIG
+Default Config: [DefaultPhysicsConstants](source/engine/physics/DefaultPhysicsConstants.h)
+
+    Default: undefined
+    Provide a custom header for compile-time physics configuration. If this is not defined, the default config is used. Custom headers must include all options from the default.
+
 ## More Information
 -------------------
 To learn more:

--- a/sample/config.ini
+++ b/sample/config.ini
@@ -6,6 +6,7 @@ log_max_file_size=1000000
 time_step=0.01667
 max_time_step=0.1
 thread_count=8
+build_tasks_on_init=1
 [asset_settings]
 audio_clips_path=nca/audio_clip/
 concave_colliders_path=nca/concave_collider/

--- a/source/engine/CMakeLists.txt
+++ b/source/engine/CMakeLists.txt
@@ -25,6 +25,11 @@ target_compile_options(${NC_ENGINE_LIB}
         ${NC_COMPILER_FLAGS}
 )
 
+if(NC_PHYSICS_CONFIG)
+    message("Using user-provided physics config: ${NC_PHYSICS_CONFIG}")
+    add_definitions(-DNC_PHYSICS_CONFIG="${NC_PHYSICS_CONFIG}")
+endif()
+
 # Link libraries
 target_link_libraries(${NC_ENGINE_LIB}
     INTERFACE

--- a/source/engine/config/Config.cpp
+++ b/source/engine/config/Config.cpp
@@ -25,6 +25,7 @@ constexpr auto LogMaxFileSizeKey = "log_max_file_size"sv;
 constexpr auto TimeStepKey = "time_step"sv;
 constexpr auto MaxTimeStepKey = "max_time_step"sv;
 constexpr auto ThreadCountKey = "thread_count"sv;
+constexpr auto BuildTasksOnInitKey = "build_tasks_on_init"sv;
 
 // asset
 constexpr auto AudioClipsPathKey = "audio_clips_path"sv;
@@ -180,6 +181,7 @@ auto BuildFromConfigMap(const std::unordered_map<std::string, std::string>& kvPa
         ParseValueIfExists(out.timeStep, TimeStepKey, kvPairs);
         ParseValueIfExists(out.maxTimeStep, MaxTimeStepKey, kvPairs);
         ParseValueIfExists(out.threadCount, ThreadCountKey, kvPairs);
+        ParseValueIfExists(out.buildTasksOnInit, BuildTasksOnInitKey, kvPairs);
     }
     else if constexpr (std::same_as<Struct_t, nc::config::AssetSettings>)
     {
@@ -329,6 +331,7 @@ void Write(std::ostream& stream, const Config& config, bool writeSections)
     ::WriteKVPair(stream, TimeStepKey, config.engineSettings.timeStep);
     ::WriteKVPair(stream, MaxTimeStepKey, config.engineSettings.maxTimeStep);
     ::WriteKVPair(stream, ThreadCountKey, config.engineSettings.threadCount);
+    ::WriteKVPair(stream, BuildTasksOnInitKey, config.engineSettings.buildTasksOnInit);
 
     if (writeSections) stream << "[asset_settings]\n";
     ::WriteKVPair(stream, AudioClipsPathKey, config.assetSettings.audioClipsPath);

--- a/source/engine/engine/NcEngineImpl.cpp
+++ b/source/engine/engine/NcEngineImpl.cpp
@@ -98,7 +98,7 @@ void NcEngineImpl::Start(std::unique_ptr<Scene> initialScene)
     NC_ASSERT(
         m_executor.IsContextInitialized(),
         "Task graph is not built. Make sure to call RebuildTaskGraph() "
-        "if EngineSettings::buildTasksOnInit == true."
+        "if EngineSettings::buildTasksOnInit == false."
     );
 
     m_isRunning = true;

--- a/source/engine/engine/NcEngineImpl.cpp
+++ b/source/engine/engine/NcEngineImpl.cpp
@@ -51,8 +51,9 @@ auto BuildTimer(const nc::config::EngineSettings& settings) -> nc::time::StepTim
 auto BuildExecutor(const nc::config::EngineSettings& settings, const nc::ModuleRegistry& modules) -> nc::task::Executor
 {
     const auto threadCount = settings.threadCount > 0 ? settings.threadCount : std::thread::hardware_concurrency();
+    auto ctx = settings.buildTasksOnInit ? nc::task::BuildContext(modules.GetAllModules()) : nc::task::ExecutorContext{};
     NC_LOG_INFO("Building Executor with {} threads", threadCount);
-    return nc::task::Executor{threadCount, nc::task::BuildContext(modules.GetAllModules())};
+    return nc::task::Executor{threadCount, std::move(ctx)};
 }
 } // anonymous namespace
 
@@ -94,6 +95,12 @@ NcEngineImpl::~NcEngineImpl() noexcept
 void NcEngineImpl::Start(std::unique_ptr<Scene> initialScene)
 {
     NC_LOG_INFO("Starting engine");
+    NC_ASSERT(
+        m_executor.IsContextInitialized(),
+        "Task graph is not built. Make sure to call RebuildTaskGraph() "
+        "if EngineSettings::buildTasksOnInit == true."
+    );
+
     m_isRunning = true;
     auto ncScene = m_modules->Get<NcScene>();
     ncScene->Queue(std::move(initialScene));

--- a/source/engine/input/Input.cpp
+++ b/source/engine/input/Input.cpp
@@ -9,22 +9,14 @@
 
 namespace
 {
-enum class KeyState
-{
-    None,
-    Pressed,
-    Held,
-    Released
-};
-
 auto ToKeyState(int action)
 {
     switch(action)
     {
-        case GLFW_PRESS: return KeyState::Pressed;
-        case GLFW_RELEASE: return KeyState::Released;
-        case GLFW_REPEAT: return KeyState::Held; // Note: 'Repeat' is not strictly the same as 'held', and we handle checking for and setting the 'held' state in Input::Flush. However, we know that if 'repeat' is true, 'held' is also true.
-        default: return KeyState::None;
+        case GLFW_PRESS: return nc::input::KeyState::Pressed;
+        case GLFW_RELEASE: return nc::input::KeyState::Released;
+        case GLFW_REPEAT: return nc::input::KeyState::Held; // Note: 'Repeat' is not strictly the same as 'held', and we handle checking for and setting the 'held' state in Input::Flush. However, we know that if 'repeat' is true, 'held' is also true.
+        default: return nc::input::KeyState::None;
     }
 }
 }
@@ -65,6 +57,11 @@ namespace nc::input
     Vector2 GetAxis()
     {
         return Vector2(GetXAxis(), GetYAxis());
+    }
+
+    auto Key(KeyCode keyCode) -> KeyState
+    {
+        return g_state.keyStates.contains(keyCode) ? g_state.keyStates[keyCode] : KeyState::None;
     }
 
     bool KeyDown(KeyCode keyCode)

--- a/source/engine/physics/PhysicsConstants.h
+++ b/source/engine/physics/PhysicsConstants.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#ifdef NC_PHYSICS_CONFIG
+#include NC_PHYSICS_CONFIG
+#else
+
 #include <cstdint>
 
 namespace nc::physics
@@ -37,3 +41,4 @@ constexpr bool EnableSleeping = false;   // Allow disabling simulation of inacti
 constexpr float SleepEpsilon = 0.01f;    // Velocity threshold for physics sleeping
 constexpr uint8_t FramesUntilSleep = 5u; // How many frames below epsilon until an object sleeps
 } // namespace nc::physics
+#endif

--- a/source/engine/serialize/ComponentSerialization.cpp
+++ b/source/engine/serialize/ComponentSerialization.cpp
@@ -178,7 +178,13 @@ void SerializePhysicsBody(std::ostream& stream, const physics::PhysicsBody& out,
     const auto entity = registry->GetPool<physics::PhysicsBody>().GetParent(&out);
     NC_ASSERT(entity.Valid(), "Invalid parent entity for PhysicsBody");
     serialize::Serialize(stream, ctx.entityMap.at(entity));
-    serialize::Serialize(stream, out.GetProperties());
+    auto properties = out.GetProperties();
+    if (properties.mass != 0.0f)
+    {
+        properties.mass = 1.0f / properties.mass;
+    }
+
+    serialize::Serialize(stream, properties);
 }
 
 auto DeserializePhysicsBody(std::istream& stream, const DeserializationContext& ctx, const std::any& userData) -> physics::PhysicsBody

--- a/source/engine/task/Executor.h
+++ b/source/engine/task/Executor.h
@@ -27,6 +27,9 @@ class Executor
         // Assign a new graph context.
         void SetContext(ExecutorContext ctx);
 
+        // Check if graph contexts are valid.
+        auto IsContextInitialized() const noexcept { return m_ctx.update && m_ctx.render; }
+
         // Blocking call to run the update graph. Throws any exceptions caught during execution.
         void RunUpdateTasks();
 

--- a/test/config/Config_tests.cpp
+++ b/test/config/Config_tests.cpp
@@ -110,6 +110,7 @@ TEST(ConfigTests, SaveLoad_roundTrip_preservesData)
     EXPECT_FLOAT_EQ(expected.engineSettings.timeStep, actual.engineSettings.timeStep);
     EXPECT_FLOAT_EQ(expected.engineSettings.maxTimeStep, actual.engineSettings.maxTimeStep);
     EXPECT_EQ(expected.engineSettings.threadCount, actual.engineSettings.threadCount);
+    EXPECT_EQ(expected.engineSettings.buildTasksOnInit, actual.engineSettings.buildTasksOnInit);
 
     EXPECT_EQ(expected.assetSettings.audioClipsPath, actual.assetSettings.audioClipsPath);
     EXPECT_EQ(expected.assetSettings.concaveCollidersPath, actual.assetSettings.concaveCollidersPath);

--- a/test/config/collateral/config.ini
+++ b/test/config/collateral/config.ini
@@ -10,6 +10,7 @@ log_max_file_size=1000000
 time_step=0.01667
 max_time_step=0.1
 thread_count=8
+build_tasks_on_init=1
 audio_clips_path=audio_clip/
 concave_colliders_path=concave_collider/
 hull_colliders_path=/ a path / with spaces / to hull_colliders/

--- a/test/math/Random_unit_tests.cpp
+++ b/test/math/Random_unit_tests.cpp
@@ -58,7 +58,7 @@ TEST(Random_unit_tests, Get_ReturnsValueWithinExpectedRange)
 
 TEST(Random_unit_tests, Between_ReturnsValueWithinExpectedRange)
 {
-    constexpr float min = -100.0f;
+    constexpr float min = -1.0f;
     constexpr float max = 28.0f;
     Random random{1};
 
@@ -89,6 +89,15 @@ TEST(Random_unit_tests, Between_ReturnsValueWithinExpectedRange)
     EXPECT_LE(v4.z, max);
     EXPECT_GE(v4.w, min);
     EXPECT_LE(v4.w, max);
+
+    constexpr size_t minSz = 2ull;
+    constexpr size_t maxSz = 5ull;
+    for (auto i = 0; i < 5; ++i)
+    {
+        const auto u64 = random.Between(minSz, maxSz);
+        EXPECT_GE(u64, minSz);
+        EXPECT_LE(u64, maxSz);
+    }
 }
 
 TEST(Random_unit_tests, Between_ZeroRange_ReturnsValueEqualToRangeOffset)

--- a/test/serialize/ComponentSerialization_integration_tests.cpp
+++ b/test/serialize/ComponentSerialization_integration_tests.cpp
@@ -280,7 +280,7 @@ TEST(ComponentSerializationTests, RoundTrip_physicsBody_preservesValues)
     nc::SerializePhysicsBody(stream, expected, serializeCtx, &g_registry);
     const auto actual = nc::DeserializePhysicsBody(stream, deserializeCtx, &g_registry);
     const auto& actualProperties = actual.GetProperties();
-    EXPECT_EQ(expectedProperties.mass, actualProperties.mass);
+    EXPECT_EQ(expectedProperties.mass, 1.0f / actualProperties.mass); // is inverse mass once stored in member
     EXPECT_EQ(expectedProperties.drag, actualProperties.drag);
     EXPECT_EQ(expectedProperties.angularDrag, actualProperties.angularDrag);
     EXPECT_EQ(expectedProperties.useGravity, actualProperties.useGravity);

--- a/test/serialize/ComponentSerialization_integration_tests.cpp
+++ b/test/serialize/ComponentSerialization_integration_tests.cpp
@@ -256,7 +256,14 @@ TEST(ComponentSerializationTests, RoundTrip_physicsBody_preservesValues)
     const auto entity = g_ecs.Emplace<nc::Entity>(nc::EntityInfo{});
     g_ecs.Emplace<nc::physics::Collider>(entity, nc::physics::BoxProperties{});
 
-    const auto expectedProperties = nc::physics::PhysicsProperties{};
+    const auto expectedProperties = nc::physics::PhysicsProperties{
+        .mass = 2.0f,
+        .drag = 0.5f,
+        .angularDrag = 0.5f,
+        .useGravity = false,
+        .isKinematic = true
+    };
+
     const auto& expected = g_ecs.Emplace<nc::physics::PhysicsBody>(
         entity,
         g_ecs.Get<nc::Transform>(entity),


### PR DESCRIPTION
Bringing in some changes from the game branch that aren't specific to the game:
- Fixing bugs in `PhysicsBody` serialization + `Random::Between()`
- Allowing a project to supply a header to override the physics constants
- Adding input function to directly get a key state. This is slightly more performant when you want to call Down, Held, and Up on the same key.
- Adding config option to skip building the task graph on engine initialization. If a project adds custom modules, we don't want to build the graph until they are registered.