### PR TITLE
Simulated Body Functions

### DIFF
--- a/include/ncengine/ecs/Transform.h
+++ b/include/ncengine/ecs/Transform.h
@@ -67,7 +67,7 @@ class Transform final : public ComponentBase
         /** @brief Get local space position */
         auto LocalPosition() const noexcept -> Vector3 { return ToVector3(LocalPositionXM()); }
 
-        /** @brief Get loca space position as an XMVECTOR */
+        /** @brief Get local space position as an XMVECTOR */
         auto LocalPositionXM() const noexcept -> DirectX::FXMVECTOR { return m_localMatrix.r[3]; }
 
         /** @brief Get world space rotation */

--- a/include/ncengine/ecs/Transform.h
+++ b/include/ncengine/ecs/Transform.h
@@ -59,28 +59,40 @@ class Transform final : public ComponentBase
         Transform& operator=(const Transform&) = delete;
 
         /** @brief Get world space position */
-        auto Position() const noexcept -> Vector3 { return ToVector3(m_worldMatrix.r[3]); }
+        auto Position() const noexcept -> Vector3 { return ToVector3(PositionXM()); }
 
-        /** @brief Get world space position as XMVECTOR */
+        /** @brief Get world space position as an XMVECTOR */
         auto PositionXM() const noexcept -> DirectX::FXMVECTOR { return m_worldMatrix.r[3]; }
 
         /** @brief Get local space position */
-        auto LocalPosition() const noexcept -> Vector3 { return ToVector3(m_localMatrix.r[3]); }
+        auto LocalPosition() const noexcept -> Vector3 { return ToVector3(LocalPositionXM()); }
+
+        /** @brief Get loca space position as an XMVECTOR */
+        auto LocalPositionXM() const noexcept -> DirectX::FXMVECTOR { return m_localMatrix.r[3]; }
 
         /** @brief Get world space rotation */
         auto Rotation() const noexcept -> Quaternion { return ToQuaternion(RotationXM()); }
 
-        /** @brief Get world space rotation as XMVECTOR */
+        /** @brief Get world space rotation as an XMVECTOR */
         auto RotationXM() const noexcept -> DirectX::XMVECTOR { return DecomposeRotation(m_worldMatrix); }
 
         /** @brief Get local space rotation */
-        auto LocalRotation() const noexcept -> Quaternion { return ToQuaternion(DecomposeRotation(m_localMatrix)); }
+        auto LocalRotation() const noexcept -> Quaternion { return ToQuaternion(LocalRotationXM()); }
+
+        /** @brief Get local space rotation as an XMVECTOR */
+        auto LocalRotationXM() const noexcept -> DirectX::XMVECTOR { return DecomposeRotation(m_localMatrix); }
 
         /** @brief Get world space scale */
-        auto Scale() const noexcept -> Vector3 { return ToVector3(DecomposeScale(m_worldMatrix)); }
+        auto Scale() const noexcept -> Vector3 { return ToVector3(ScaleXM()); }
+
+        /** @brief Get world space scale as an XMVECTOR */
+        auto ScaleXM() const noexcept -> DirectX::XMVECTOR { return DecomposeScale(m_worldMatrix); }
 
         /** @brief Get local space scale */
-        auto LocalScale() const noexcept -> Vector3 { return ToVector3(DecomposeScale(m_localMatrix)); }
+        auto LocalScale() const noexcept -> Vector3 { return ToVector3(LocalScaleXM()); }
+
+        /** @brief Get local space scale as an XMVECTOR */
+        auto LocalScaleXM() const noexcept -> DirectX::XMVECTOR { return DecomposeScale(m_localMatrix); }
 
         /** @brief Get world space matrix */
         auto TransformationMatrix() const noexcept -> DirectX::FXMMATRIX { return m_worldMatrix; }

--- a/include/ncengine/physics/RigidBody.h
+++ b/include/ncengine/physics/RigidBody.h
@@ -1,43 +1,113 @@
+/**
+ * @file RigidBody.h
+ * @copyright Jaremie Romer and McCallister Romer 2024
+ */
 #pragma once
 
 #include "ncengine/ecs/Component.h"
+#include "ncengine/ecs/Transform.h"
 
 #include "DirectXMath.h"
 
 namespace nc::physics
 {
-using BodyHandle = void*;
-using BodyInterface = void*;
+struct ComponentContext;
+class NcPhysicsImpl2;
+class RigidBody;
 
+/** @brief Handle to internal RigidBody state. */
+using BodyHandle = void*;
+
+/** @brief Flags for configuring RigidBody behavior. */
+struct RigidBodyFlags
+{
+    using Type = uint8_t;
+
+    /** @brief Disable all flags. */
+    static constexpr Type None = 0x0;
+
+    /** @brief Scale the body's shape using the associated Transform's scale.
+     * 
+     * For shapes with scaling restrictions, this may force updates to the Transform to prevent invalid shape scaling.
+     * E.g. placing a sphere on an object with non-uniform Transform scaling will update the Transform to have uniform
+     * scaling.
+     */
+    static constexpr Type ScaleWithTransform = 0x1;
+
+    /** @brief Default flag values. */
+    static constexpr Type Default = ScaleWithTransform;
+};
+
+/** @brief RigidBody shape options. */
 enum class Shape : uint8_t
 {
     Box,
     Sphere
 };
 
+/** @brief Determines movement and collision behavior of a RigidBody. */
 enum class BodyType : uint8_t
 {
-    Dynamic,
-    Static,
-    Kinematic
+    Dynamic,  // movable with velocities and forces; collides with all other bodies
+    Static,   // non-movable; does not collide with other static bodies
+    Kinematic // movable only with velocities; collides with all other bodies
 };
 
+/**
+ * @defgroup SimulatedBodyFunctions Simulated Body Functions
+ * @note Prefer using simulated body functions over the Transform equivalents for \ref Entity "entities" with a RigidBody.
+ * 
+ * Simulated body functions synchronize updating of properties shared between a Transform and RigidBody. They should only
+ * be used when strictly necessary, as directly modifying these properties can cause undesirable behavior in the simulation
+ * (e.g. when repositioning one body inside of another).
+ *
+ * @{
+ */
+
+/** @brief Set the position of an object's Transform and RigidBody. */
+void SetSimulatedBodyPosition(Transform& transform,
+                              RigidBody& rigidBody,
+                              const Vector3& position,
+                              bool wake = true);
+
+/** @brief Set the rotation of an object's Transform and RigidBody. */
+void SetSimulatedBodyRotation(Transform& transform,
+                              RigidBody& rigidBody,
+                              const Quaternion& rotation,
+                              bool wake = true);
+
+/**
+ * @brief Set the scale of an object's Transform and RigidBody.
+ * 
+ * The actual applied scale is returned and may differ from the requested value, depending on scaling requirements of the
+ * RigidBody Shape. If the body does not have ScaleWithTransform set, only the Transform will be modified - in this case,
+ * RigidBody::SetScale() may be used to update the body independently.
+ */
+auto SetSimulatedBodyScale(Transform& transform,
+                           RigidBody& rigidBody,
+                           const Vector3& scale,
+                           bool wake = true) -> Vector3;
+/** @} */ // End SimulatedBodyFunctions
+
+/** @brief Component managing physics simulation properties. */
 class RigidBody
 {
     public:
-        RigidBody(Entity self, Shape shape, BodyType bodyType)
+        RigidBody(Entity self, Shape shape, BodyType bodyType, RigidBodyFlags::Type flags = RigidBodyFlags::Default)
             : m_self{self},
               m_shape{shape},
-              m_bodyType{bodyType}
+              m_bodyType{bodyType},
+              m_flags{flags}
         {
         }
 
         RigidBody(RigidBody&& other) noexcept
             : m_self{std::exchange(other.m_self, Entity::Null())},
               m_handle{std::exchange(other.m_handle, nullptr)},
-              m_interface{std::exchange(other.m_interface, nullptr)},
+              m_ctx{std::exchange(other.m_ctx, nullptr)},
               m_shape{other.m_shape},
-              m_bodyType{other.m_bodyType}
+              m_bodyType{other.m_bodyType},
+              m_flags{other.m_flags}
         {
         }
 
@@ -45,9 +115,10 @@ class RigidBody
         {
             m_self = std::exchange(other.m_self, Entity::Null());
             m_handle = std::exchange(other.m_handle, nullptr);
-            m_interface = std::exchange(other.m_interface, nullptr);
+            m_ctx = std::exchange(other.m_ctx, nullptr);
             m_shape = other.m_shape;
             m_bodyType = other.m_bodyType;
+            m_flags = other.m_flags;
             return *this;
         }
 
@@ -58,20 +129,29 @@ class RigidBody
 
         auto GetEntity() const -> Entity { return m_self; }
         auto GetShape() const -> Shape { return m_shape; }
+        auto ScalesWithTransform() const -> bool { return m_flags & RigidBodyFlags::ScaleWithTransform; }
         auto GetBodyType() const -> BodyType { return m_bodyType; }
         auto GetHandle() const -> BodyHandle { return m_handle; }
 
         void AddImpulse(const Vector3& impulse);
         void AddTorque(const Vector3& torque);
 
-        void Init(BodyHandle handle, BodyInterface interface);
+        auto IsInitialized() const noexcept -> bool { return m_handle; }
+        void SetPosition(const Vector3& position, bool wake = true);
+        void SetRotation(const Quaternion& rotation, bool wake = true);
+        auto SetScale(const Vector3& scale, bool wake = true) -> Vector3;
 
     private:
+        friend class NcPhysicsImpl2;
+
         Entity m_self;
         BodyHandle m_handle = nullptr;
-        BodyInterface m_interface = nullptr;
+        ComponentContext* m_ctx = nullptr;
         Shape m_shape;
         BodyType m_bodyType;
+        RigidBodyFlags::Type m_flags;
+
+        void SetContext(BodyHandle handle, ComponentContext* ctx);
 };
 } // namespace nc::physics
 

--- a/include/ncengine/ui/editor/EditorContext.h
+++ b/include/ncengine/ui/editor/EditorContext.h
@@ -46,6 +46,7 @@ struct EditorContext
     Entity selectedEntity = Entity::Null();
     OpenState openState = OpenState::Closed;
     ImVec2 dimensions = ImVec2{};
+    bool rebuildStaticsOnTransformWrite = true;
 
     // Immutable state
     const Entity objectBucket = Entity::Null();

--- a/sample/source/scenes/PhysicsTest.cpp
+++ b/sample/source/scenes/PhysicsTest.cpp
@@ -21,12 +21,14 @@ std::function<void(unsigned)> DestroyFunc = nullptr;
 
 int SpawnCount = 1000;
 int DestroyCount = 1000;
+float forceMultiplier = 1.0f;
 
 void Widget()
 {
     ImGui::Text("Physics Test");
     if(ImGui::BeginChild("Widget", {0,0}, true))
     {
+        ui::DragFloat(forceMultiplier, "forceMultiplier");
         ImGui::Spacing(); ImGui::Separator(); ImGui::Spacing();
         const auto halfCellWidth = (ImGui::GetColumnWidth() * 0.5f) - 10.0f;
 
@@ -119,9 +121,9 @@ struct FollowCamera : public graphics::Camera
 #ifdef NC_USE_JOLT
 class VehicleController : public FreeComponent
 {
-    static constexpr auto force = 300.7f;
-    static constexpr auto torqueForce = 700.6f;
-    static constexpr auto jumpForce = 3700.0f;
+    static constexpr auto force = 50.0f;
+    static constexpr auto torqueForce = 50.0f;
+    static constexpr auto jumpForce = 400.0f;
     static constexpr auto jumpCooldownTime = 0.3f;
 
     public:
@@ -158,24 +160,24 @@ class VehicleController : public FreeComponent
         {
             auto& rBody = world.Get<physics::RigidBody>(ParentEntity());
 
-            if(KeyHeld(input::KeyCode::W)) rBody.AddImpulse(Vector3::Front() * force);
-            if(KeyHeld(input::KeyCode::S)) rBody.AddImpulse(Vector3::Back() * force);
-            if(KeyHeld(input::KeyCode::A)) rBody.AddImpulse(Vector3::Left() * force);
-            if(KeyHeld(input::KeyCode::D)) rBody.AddImpulse(Vector3::Right() * force);
-            if(KeyHeld(input::KeyCode::Q)) rBody.AddTorque(Vector3::Down() * torqueForce);
-            if(KeyHeld(input::KeyCode::E)) rBody.AddTorque(Vector3::Up() * torqueForce);
+            if(KeyHeld(input::KeyCode::W)) rBody.AddImpulse(Vector3::Front() * force * forceMultiplier);
+            if(KeyHeld(input::KeyCode::S)) rBody.AddImpulse(Vector3::Back() * force * forceMultiplier);
+            if(KeyHeld(input::KeyCode::A)) rBody.AddImpulse(Vector3::Left() * force * forceMultiplier);
+            if(KeyHeld(input::KeyCode::D)) rBody.AddImpulse(Vector3::Right() * force * forceMultiplier);
+            if(KeyHeld(input::KeyCode::Q)) rBody.AddTorque(Vector3::Down() * torqueForce * forceMultiplier);
+            if(KeyHeld(input::KeyCode::E)) rBody.AddTorque(Vector3::Up() * torqueForce * forceMultiplier);
 
             if(!m_jumpOnCooldown && KeyDown(input::KeyCode::Space))
             {
                 m_jumpOnCooldown = true;
-                const auto dir = Normalize(world.Get<Transform>(ParentEntity()).Forward()) * jumpForce * 2.0f;
+                const auto dir = Normalize(world.Get<Transform>(ParentEntity()).Forward()) * jumpForce * 2.0f * forceMultiplier;
                 rBody.AddImpulse(dir);
             }
 
             if (!m_jumpOnCooldown && KeyDown(input::KeyCode::LeftShift))
             {
                 m_jumpOnCooldown = true;
-                const auto dir = Vector3::Up() * jumpForce;
+                const auto dir = Vector3::Up() * jumpForce * forceMultiplier;
                 rBody.AddImpulse(dir);
             }
         }
@@ -363,7 +365,7 @@ auto BuildVehicle(ecs::Ecs world, physics::NcPhysics* ncPhysics) -> Entity
     world.Emplace<FrameLogic>(head, InvokeFreeComponent<VehicleController>{});
 
     auto wormMaterial = GreenToonMaterial;
-    wormMaterial.outlineWidth = 6;
+    wormMaterial.outlineWidth = 1;
     world.Emplace<graphics::ToonRenderer>(head, asset::CubeMesh, wormMaterial);
     world.Emplace<graphics::ToonRenderer>(segment1, asset::CubeMesh, wormMaterial);
     world.Emplace<graphics::ToonRenderer>(segment2, asset::CubeMesh, wormMaterial);

--- a/source/engine/physics2/jolt/ComponentContext.h
+++ b/source/engine/physics2/jolt/ComponentContext.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "ShapeFactory.h"
+
+#include "Jolt/Physics/Body/BodyInterface.h"
+
+namespace nc::physics
+{
+struct ComponentContext
+{
+    JPH::BodyInterface& interface;
+    ShapeFactory& shapeFactory;
+};
+} // namespace nc::physics

--- a/source/engine/physics2/jolt/Conversion.h
+++ b/source/engine/physics2/jolt/Conversion.h
@@ -7,6 +7,11 @@
 
 namespace nc::physics
 {
+inline auto ToJoltVec3(const nc::Vector3& in) -> JPH::Vec3
+{
+    return JPH::Vec3{reinterpret_cast<const JPH::Float3&>(in)};
+}
+
 inline auto ToJoltVec3(DirectX::FXMVECTOR in) -> JPH::Vec3
 {
 #ifdef JPH_FLOATING_POINT_EXCEPTIONS_ENABLED
@@ -14,6 +19,11 @@ inline auto ToJoltVec3(DirectX::FXMVECTOR in) -> JPH::Vec3
 #else
     return JPH::Vec3{in};
 #endif
+}
+
+inline auto ToJoltQuaternion(const nc::Quaternion& in) -> JPH::Quat
+{
+    return JPH::Quat{in.x, in.y, in.z, in.w};
 }
 
 inline auto ToJoltQuaternion(DirectX::FXMVECTOR in) -> JPH::Quat
@@ -34,6 +44,16 @@ inline auto ToXMVectorHomogeneous(const JPH::Vec3& in) -> DirectX::XMVECTOR
 inline auto ToXMQuaternion(const JPH::Quat& in) -> DirectX::XMVECTOR
 {
     return in.mValue.mValue;
+}
+
+inline auto ToVector3(const JPH::Vec3& in) -> Vector3
+{
+    return Vector3{in.GetX(), in.GetY(), in.GetZ()};
+}
+
+inline auto ToQuaternion(const JPH::Quat& in) -> Quaternion
+{
+    return Quaternion{in.GetX(), in.GetY(), in.GetZ(), in.GetW()};
 }
 
 inline auto ToMotionType(BodyType bodyType) -> JPH::EMotionType

--- a/source/engine/physics2/jolt/JoltApi.cpp
+++ b/source/engine/physics2/jolt/JoltApi.cpp
@@ -39,5 +39,7 @@ JoltApi::JoltApi()
         objectVsBroadphaseFilter,
         objectLayerPairFilter
     );
+
+    ctx = std::make_unique<ComponentContext>(physicsSystem.GetBodyInterface(), shapeFactory);
 }
 } // namespace nc::physics

--- a/source/engine/physics2/jolt/JoltApi.h
+++ b/source/engine/physics2/jolt/JoltApi.h
@@ -1,7 +1,9 @@
 #pragma once
 
 #include "Allocator.h"
+#include "ComponentContext.h"
 #include "Layers.h"
+#include "ShapeFactory.h"
 #include "ncengine/type/StableAddress.h"
 #include "ncutility/NcError.h"
 
@@ -43,6 +45,8 @@ struct JoltApi : public StableAddress
     ObjectVsBroadPhaseLayerFilter objectVsBroadphaseFilter;
     ObjectLayerPairFilter objectLayerPairFilter;
     JPH::PhysicsSystem physicsSystem;
+    ShapeFactory shapeFactory;
+    std::unique_ptr<ComponentContext> ctx;
 
     private:
         JoltApi();

--- a/source/engine/physics2/jolt/ShapeFactory.h
+++ b/source/engine/physics2/jolt/ShapeFactory.h
@@ -3,30 +3,66 @@
 #include "Conversion.h"
 
 #include "Jolt/Physics/Collision/Shape/BoxShape.h"
+#include "Jolt/Physics/Collision/Shape/ScaledShape.h"
 #include "Jolt/Physics/Collision/Shape/SphereShape.h"
 
 namespace nc::physics
 {
-inline auto MakeShape(Shape shape, const JPH::Vec3& transformScale) -> JPH::Ref<JPH::Shape>
+inline auto NormalizeScaleForShape(nc::physics::Shape shape, JPH::Vec3& scaleOut) -> bool
 {
     switch (shape)
     {
-        case Shape::Box:
+        case nc::physics::Shape::Box:
         {
-            constexpr auto convexRadius = 0.05f;
-            auto settings = JPH::BoxShapeSettings{transformScale * 0.5f, convexRadius};
-            auto result = settings.Create();
-            return result.Get();
+            return false;
         }
-        case Shape::Sphere:
+        case nc::physics::Shape::Sphere:
         {
-            auto settings = JPH::SphereShapeSettings(transformScale.GetX() * 0.5f);
-            auto result = settings.Create();
-            return result.Get();
-        }
-        /** @todo: 692, 693, 694 support additional shape types */
-    };
+            if (JPH::ScaleHelpers::IsUniformScale(scaleOut))
+            {
+                return false;
+            }
 
-    throw NcError(fmt::format("Unhandled Shape '{}'", std::to_underlying(shape)));
+            scaleOut = JPH::ScaleHelpers::MakeUniformScale(scaleOut);
+            return true;
+        }
+        default:
+        {
+            NC_ASSERT(false, fmt::format("Unhandled Shape: '{}'", std::to_underlying(shape)));
+            std::unreachable();
+        }
+    }
 }
+
+class ShapeFactory
+{
+    static constexpr auto boxConvexRadius = 0.05f;
+
+    public:
+        auto MakeShape(Shape shape, const JPH::Vec3& scale) -> JPH::Ref<JPH::Shape>
+        {
+            /** @todo: 692, 693, 694 support additional shape types */
+            switch (shape)
+            {
+                case Shape::Box:
+                    return MakeBox(scale * 0.5f);
+                case Shape::Sphere:
+                    NC_ASSERT(JPH::ScaleHelpers::IsUniformScale(scale), "Sphere requires uniform scale");
+                    return MakeSphere(scale.GetX() * 0.5f);
+                default:
+                    NC_ASSERT(false, fmt::format("Unhandled Shape '{}'", std::to_underlying(shape)));
+                    std::unreachable();
+            };
+        }
+
+        auto MakeBox(const JPH::Vec3& halfExtents) -> JPH::Ref<JPH::Shape>
+        {
+            return JPH::Ref<JPH::Shape>{new JPH::BoxShape(halfExtents, boxConvexRadius)};
+        }
+
+        auto MakeSphere(float radius) -> JPH::Ref<JPH::Shape>
+        {
+            return JPH::Ref<JPH::Shape>{new JPH::SphereShape(radius)};
+        }
+};
 } // namespace nc::physics

--- a/source/engine/ui/editor/impl/EditorUI.cpp
+++ b/source/engine/ui/editor/impl/EditorUI.cpp
@@ -142,10 +142,25 @@ void EditorUI::DrawMenu(EditorContext& ctx)
 
         if (ImGui::BeginMenu("Debug"))
         {
+            ImGui::Text("Display Options");
+            ImGui::Separator();
+            ImGui::Spacing();
+            ImGui::Spacing();
+
             if (ImGui::MenuItem("FPS Overlay"))
                 m_fpsOverlay.ToggleOpen();
-            if (ImGui::MenuItem("Rebuild Static Entity Data"))
+
+            ImGui::Spacing();
+            ImGui::Spacing();
+            ImGui::Text("Static Entity Options");
+            ImGui::Separator();
+            ImGui::Spacing();
+            ImGui::Spacing();
+
+            if (ImGui::MenuItem("Rebuild"))
                 ctx.events->rebuildStatics.Emit();
+
+            ui::Checkbox(ctx.rebuildStaticsOnTransformWrite, "Rebuild On Transform Update");
 
             ImGui::EndMenu();
         }

--- a/test/physics2/jolt/CMakeLists.txt
+++ b/test/physics2/jolt/CMakeLists.txt
@@ -17,6 +17,7 @@ target_compile_options(JoltApi_unit_tests
 
 target_link_libraries(JoltApi_unit_tests
     PRIVATE
+        NcMath
         NcUtility
         Jolt
         gtest_main
@@ -75,6 +76,34 @@ target_link_libraries(Layers_unit_tests
 
 add_test(Layers_unit_tests Layers_unit_tests)
 
+### RigidBody Tests ###
+add_executable(RigidBody_unit_tests
+    RigidBody_unit_tests.cpp
+    ${NC_SOURCE_DIR}/physics2/RigidBody.cpp
+    ${NC_SOURCE_DIR}/ecs/Transform.cpp
+)
+
+target_include_directories(RigidBody_unit_tests
+    PRIVATE
+        ${NC_INCLUDE_DIR}
+        ${NC_SOURCE_DIR}
+)
+
+target_compile_options(RigidBody_unit_tests
+    PUBLIC
+        ${NC_COMPILER_FLAGS}
+)
+
+target_link_libraries(RigidBody_unit_tests
+    PRIVATE
+        NcMath
+        NcUtility
+        Jolt
+        gtest_main
+)
+
+add_test(RigidBody_unit_tests RigidBody_unit_tests)
+
 ### PhysicsAllocator Tests ###
 add_executable(PhysicsAllocator_unit_tests
     PhysicsAllocator_unit_tests.cpp
@@ -93,6 +122,7 @@ target_compile_options(PhysicsAllocator_unit_tests
 
 target_link_libraries(PhysicsAllocator_unit_tests
     PRIVATE
+        NcMath
         NcUtility
         Jolt
         gtest_main

--- a/test/physics2/jolt/JoltConversion_unit_tests.cpp
+++ b/test/physics2/jolt/JoltConversion_unit_tests.cpp
@@ -1,7 +1,7 @@
 #include "gtest/gtest.h"
 #include "physics2/jolt/Conversion.h"
 
-TEST(JoltConversionTest, Vector3_roundTrip_preservesValue)
+TEST(JoltConversionTest, XMVector3_roundTrip_preservesValue)
 {
     const auto expectedVector = DirectX::XMVectorSet(1.0f, 2.0f, 3.0f, 0.0f);
     const auto joltVector = nc::physics::ToJoltVec3(expectedVector);
@@ -12,7 +12,7 @@ TEST(JoltConversionTest, Vector3_roundTrip_preservesValue)
     EXPECT_FLOAT_EQ(DirectX::XMVectorGetW(expectedVector), DirectX::XMVectorGetW(actualVector));
 }
 
-TEST(JoltConversionTest, Vector3Homogeneous_roundTrip_preservesValue)
+TEST(JoltConversionTest, XMVector3Homogeneous_roundTrip_preservesValue)
 {
     const auto expectedVector = DirectX::XMVectorSet(1.0f, 2.0f, 3.0f, 1.0f);
     const auto joltVector = nc::physics::ToJoltVec3(expectedVector);
@@ -23,7 +23,15 @@ TEST(JoltConversionTest, Vector3Homogeneous_roundTrip_preservesValue)
     EXPECT_FLOAT_EQ(DirectX::XMVectorGetW(expectedVector), DirectX::XMVectorGetW(actualVector));
 }
 
-TEST(JoltConversionTest, Quaternion_roundTrip_preservesValue)
+TEST(JoltConversionTest, Vector3_roundTrip_preservesValue)
+{
+    const auto expectedVector = nc::Vector3{1.0f, 2.0f, 3.0f};
+    const auto joltVector = nc::physics::ToJoltVec3(expectedVector);
+    const auto actualVector = nc::physics::ToVector3(joltVector);
+    EXPECT_EQ(expectedVector, actualVector);
+}
+
+TEST(JoltConversionTest, XMQuaternion_roundTrip_preservesValue)
 {
     const auto expectedQuat = DirectX::XMQuaternionRotationRollPitchYaw(3.14f, 0.0f, 1.07f);
     const auto joltQuat = nc::physics::ToJoltQuaternion(expectedQuat);
@@ -32,6 +40,14 @@ TEST(JoltConversionTest, Quaternion_roundTrip_preservesValue)
     EXPECT_FLOAT_EQ(DirectX::XMVectorGetY(expectedQuat), DirectX::XMVectorGetY(actualQuat));
     EXPECT_FLOAT_EQ(DirectX::XMVectorGetZ(expectedQuat), DirectX::XMVectorGetZ(actualQuat));
     EXPECT_FLOAT_EQ(DirectX::XMVectorGetW(expectedQuat), DirectX::XMVectorGetW(actualQuat));
+}
+
+TEST(JoltConversionTest, Quaternion_roundTrip_preservesValue)
+{
+    const auto expectedQuat = nc::Quaternion::FromEulerAngles(3.14f, 0.0f, 1.07f);
+    const auto joltQuat = nc::physics::ToJoltQuaternion(expectedQuat);
+    const auto actualQuat = nc::physics::ToQuaternion(joltQuat);
+    EXPECT_EQ(expectedQuat, actualQuat);
 }
 
 TEST(JoltConversionTest, ToMotionType_convertsBodyType)

--- a/test/physics2/jolt/RigidBody_unit_tests.cpp
+++ b/test/physics2/jolt/RigidBody_unit_tests.cpp
@@ -1,0 +1,80 @@
+#include "gtest/gtest.h"
+#include "ncengine/physics/RigidBody.h"
+
+namespace nc::physics
+{
+class NcPhysicsImpl2
+{
+    public:
+        void MockRegisterBody(RigidBody& body)
+        {
+            // Can use any values as long as we don't touch the interface (do that in the integration test)
+            body.SetContext(static_cast<BodyHandle>(this), nullptr);
+        }
+
+        void MockUnregisterBody(RigidBody& body)
+        {
+            // Unregister so the destructor doesn't try to delete anything
+            body.SetContext(nullptr, nullptr);
+        }
+};
+} // namespace nc::physics
+
+constexpr auto g_entity = nc::Entity{0, 0, nc::Entity::Flags::None};
+constexpr auto g_staticEntity = nc::Entity{0, 0, nc::Entity::Flags::Static};
+constexpr auto g_shape = nc::physics::Shape::Box;
+constexpr auto g_dynamicBodyType = nc::physics::BodyType::Dynamic;
+constexpr auto g_staticBodyType = nc::physics::BodyType::Static;
+constexpr auto g_flags = nc::physics::RigidBodyFlags::ScaleWithTransform;
+
+TEST(RigidBodyTests, IsInitialized_returnsCorrectState)
+{
+    auto uut = nc::physics::RigidBody{g_entity, g_shape, g_dynamicBodyType, g_flags};
+    EXPECT_FALSE(uut.IsInitialized());
+    auto mockModule = nc::physics::NcPhysicsImpl2{};
+    mockModule.MockRegisterBody(uut);
+    EXPECT_TRUE(uut.IsInitialized());
+    mockModule.MockUnregisterBody(uut);
+}
+
+TEST(RigidBodyTests, SetContext_staticEntityWithStaticBody_succeeds)
+{
+    auto uut = nc::physics::RigidBody{g_staticEntity, g_shape, g_staticBodyType};
+    auto mockModule = nc::physics::NcPhysicsImpl2{};
+    EXPECT_NO_THROW(mockModule.MockRegisterBody(uut));
+    mockModule.MockUnregisterBody(uut);
+}
+
+TEST(RigidBodyTests, SetContext_staticEntityWithDynamicBody_throws)
+{
+    auto uut = nc::physics::RigidBody{g_staticEntity, g_shape, g_dynamicBodyType};
+    auto mockModule = nc::physics::NcPhysicsImpl2{};
+    EXPECT_THROW(mockModule.MockRegisterBody(uut), nc::NcError);
+}
+
+TEST(RigidBodyTests, MoveOperations_transferRegistrationData)
+{
+    auto first = nc::physics::RigidBody{g_entity, g_shape, g_dynamicBodyType};
+    auto mockModule = nc::physics::NcPhysicsImpl2{};
+    mockModule.MockRegisterBody(first);
+    auto second = nc::physics::RigidBody{std::move(first)};
+    EXPECT_FALSE(first.GetEntity().Valid());
+    EXPECT_FALSE(first.IsInitialized());
+    EXPECT_TRUE(second.GetEntity().Valid());
+    EXPECT_TRUE(second.IsInitialized());
+    first = std::move(second);
+    EXPECT_TRUE(first.GetEntity().Valid());
+    EXPECT_TRUE(first.IsInitialized());
+    EXPECT_FALSE(second.GetEntity().Valid());
+    EXPECT_FALSE(second.IsInitialized());
+    mockModule.MockUnregisterBody(first);
+}
+
+TEST(RigidBodyTests, TrivialGetters_returnExpectedValues)
+{
+    const auto uut = nc::physics::RigidBody{g_entity, g_shape, g_dynamicBodyType, g_flags};
+    EXPECT_EQ(g_entity, uut.GetEntity());
+    EXPECT_EQ(g_shape, uut.GetShape());
+    EXPECT_EQ(g_dynamicBodyType, uut.GetBodyType());
+    EXPECT_TRUE(uut.ScalesWithTransform());
+}

--- a/test/physics2/jolt/ShapeFactory_unit_tests.cpp
+++ b/test/physics2/jolt/ShapeFactory_unit_tests.cpp
@@ -12,12 +12,47 @@ class ShapeFactoryTest : public ::testing::Test
             : m_jolt{nc::physics::JoltApi::Initialize()}
         {
         }
+
+    public:
+        nc::physics::ShapeFactory uut;
 };
+
+TEST(ShapeFactoryUtilityTest, NormalizeScaleForShape_box_doesNotModify)
+{
+    constexpr auto shape = nc::physics::Shape::Box;
+    const auto expectedScale1 = JPH::Vec3{1.0f, 1.0f, 1.0f};
+    const auto expectedScale2 = JPH::Vec3{1.0f, 2.0f, 3.0f};
+    auto actualScale1 = expectedScale1;
+    auto actualScale2 = expectedScale2;
+    EXPECT_FALSE(nc::physics::NormalizeScaleForShape(shape, actualScale1));
+    EXPECT_FALSE(nc::physics::NormalizeScaleForShape(shape, actualScale2));
+    EXPECT_EQ(expectedScale1, actualScale1);
+    EXPECT_EQ(expectedScale2, actualScale2);
+}
+
+TEST(ShapeFactoryUtilityTest, NormalizeScaleForShape_sphere_uniformScaling_doesNotModify)
+{
+    constexpr auto shape = nc::physics::Shape::Sphere;
+    const auto expectedScale = JPH::Vec3{3.0f, 3.0f, 3.0f};
+    auto actualScale = expectedScale;
+    EXPECT_FALSE(nc::physics::NormalizeScaleForShape(shape, actualScale));
+    EXPECT_EQ(expectedScale, actualScale);
+}
+
+TEST(ShapeFactoryUtilityTest, NormalizeScaleForShape_sphere_nonUniformScaling_fixesScale)
+{
+    constexpr auto shape = nc::physics::Shape::Sphere;
+    auto actualScale = JPH::Vec3{1.0f, 2.0f, 3.0f};
+    const auto averageScale = (actualScale.GetX() + actualScale.GetY() + actualScale.GetZ()) / 3.0f;
+    const auto expectedScale = JPH::Vec3::sReplicate(averageScale);
+    EXPECT_TRUE(nc::physics::NormalizeScaleForShape(shape, actualScale));
+    EXPECT_EQ(expectedScale, actualScale);
+}
 
 TEST_F(ShapeFactoryTest, MakeShape_box_returnsBoxShape)
 {
     const auto expectedScale = JPH::Vec3{1.0f, 2.0f, 3.0f};
-    const auto shape = nc::physics::MakeShape(nc::physics::Shape::Box, expectedScale);
+    const auto shape = uut.MakeShape(nc::physics::Shape::Box, expectedScale);
 
     ASSERT_EQ(JPH::EShapeType::Convex, shape->GetType());
     ASSERT_EQ(JPH::EShapeSubType::Box, shape->GetSubType());
@@ -31,7 +66,7 @@ TEST_F(ShapeFactoryTest, MakeShape_box_returnsBoxShape)
 TEST_F(ShapeFactoryTest, MakeShape_sphere_returnsBoxShape)
 {
     const auto expectedRadius = 0.75f;
-    const auto shape = nc::physics::MakeShape(nc::physics::Shape::Sphere, JPH::Vec3::sReplicate(expectedRadius * 2.0f));
+    const auto shape = uut.MakeShape(nc::physics::Shape::Sphere, JPH::Vec3::sReplicate(expectedRadius * 2.0f));
 
     ASSERT_EQ(JPH::EShapeType::Convex, shape->GetType());
     ASSERT_EQ(JPH::EShapeSubType::Sphere, shape->GetSubType());


### PR DESCRIPTION
resolves #689 

PR is into feature branch because it heavily depends on changes over there. CI run [here](https://github.com/NcStudios/NcEngine/actions/runs/10671239127) since it won't trigger.

- Adding functions for updating a `Transform` and `RigidBody` in a synchronized way. Updating a `Transform` through the editor will use these when the `Entity` has a `RigidBody`.
- Added a flag for decoupling the scale of a collision shape from the `Transform`. This is because not all scales are valid for all shapes, so, by default, we constrain `Transform` scaling when necessary. This may not always be desirable - maybe we want to apply non-uniform scaling to a mesh, but we want sphere collider on it. The editor respects this flag.
- Unrelated to physics, but static `Transform`s automatically rebuild when updated through the editor. The debug menu has an option to disable this behavior.

Small rant on the first point: I originally wanted to add these to `Transform` so that they would be discoverable alongside all their related `Transform` methods. However, this caused a cascade of undefined symbols in tests. After thinking about it some more, I believe they belong with physics code. The rationale being based on previous conversations about writing modules as though they were separate libraries. Under this model, `Transform` would necessarily belong to a 'core' lib that everything else would depend on, and could/should not refence anything in `nc::physics`. My two cents, feel free to counter.