### PR TITLE
Shape Scaling and Position

### DIFF
--- a/include/ncengine/ecs/Entity.h
+++ b/include/ncengine/ecs/Entity.h
@@ -40,6 +40,14 @@ class Entity
         {
         }
 
+        static constexpr auto FromHash(uint64_t hash) noexcept -> Entity
+        {
+            const auto index = static_cast<Entity::index_type>((hash >> 16) & 0xFFFFFFFF);
+            const auto layer = static_cast<Entity::layer_type>((hash >> 8) & 0xFF);
+            const auto flags = static_cast<Entity::flags_type>(hash & 0xFF);
+            return Entity{index, layer, flags};
+        }
+
         static constexpr auto Null() noexcept { return Entity{}; }
         constexpr auto Valid() const noexcept { return m_index != NullIndex; }
         constexpr auto Index() const noexcept { return m_index; }
@@ -58,9 +66,9 @@ class Entity
         {
             constexpr auto operator()(const Entity& entity) const noexcept
             {
-                return static_cast<size_t>(entity.Index()) << 16
-                     | static_cast<size_t>(entity.Layer()) << 8
-                     | static_cast<size_t>(entity.Flags());
+                return static_cast<uint64_t>(entity.Index()) << 16
+                     | static_cast<uint64_t>(entity.Layer()) << 8
+                     | static_cast<uint64_t>(entity.Flags());
             }
         };
 

--- a/include/ncengine/physics/EventListeners.h
+++ b/include/ncengine/physics/EventListeners.h
@@ -1,0 +1,31 @@
+/**
+ * @file EventListener.h
+ * @copyright Jaremie Romer and McCallister Romer 2024
+ */
+#pragma once
+
+#include "ncengine/ecs/EcsFwd.h"
+#include "ncengine/physics/HitInfo.h"
+
+#include <functional>
+
+namespace nc::physics
+{
+/** @brief Callback type for collision enter events. */
+using OnCollisionEnter_t = std::function<void(Entity self,
+                                              Entity other,
+                                              const HitInfo& hit,
+                                              ecs::Ecs world)>;
+
+/** @brief Callback type for collision exit events. */
+using OnCollisionExit_t = std::function<void(Entity self,
+                                             Entity other,
+                                             ecs::Ecs world)>;
+
+/** @brief Component that receives collision event callbacks. */
+struct CollisionListener
+{
+    OnCollisionEnter_t onEnter = nullptr;
+    OnCollisionExit_t onExit = nullptr;
+};
+} // namespace nc::physics

--- a/include/ncengine/physics/HitInfo.h
+++ b/include/ncengine/physics/HitInfo.h
@@ -1,0 +1,48 @@
+/**
+ * @file HitInfo.h
+ * @copyright Jaremie Romer and McCallister Romer 2024
+ */
+#pragma once
+
+#include "ncengine/ecs/Entity.h"
+
+#include <array>
+#include <span>
+
+namespace nc::physics
+{
+/** @brief A list of contact points on a RigidBody. */
+class Contacts
+{
+    public:
+        explicit Contacts(const std::array<Vector3, 4>& points, size_t numPoints = 4)
+            : m_points{points},
+              m_numPoints{static_cast<uint32_t>(numPoints)}
+        {
+        }
+
+        auto GetPoints() const -> std::span<const Vector3>
+        {
+            return std::span<const Vector3>{m_points.begin(), m_numPoints};
+        }
+
+        auto GetCount() const -> uint32_t
+        {
+            return m_numPoints;
+        }
+
+    private:
+        std::array<Vector3, 4> m_points;
+        uint32_t m_numPoints;
+};
+
+/** @brief Collision event information. */
+struct HitInfo
+{
+    Vector3 offset = Vector3::Zero();
+    Vector3 normal = Vector3::Zero();
+    float depth = 0.0f;
+    Contacts contactsOnFirst;
+    Contacts contactsOnSecond;
+};
+} // namespace nc::physics

--- a/include/ncengine/physics/RigidBody.h
+++ b/include/ncengine/physics/RigidBody.h
@@ -134,9 +134,9 @@ class RigidBody
         void AddTorque(const Vector3& torque);
 
         auto IsInitialized() const noexcept -> bool { return m_handle; }
-        void SetPosition(const Vector3& position, bool wake = true);
-        void SetRotation(const Quaternion& rotation, bool wake = true);
-        auto SetScale(const Vector3& scale, bool wake = true) -> Vector3;
+        void SetBodyPosition(const Vector3& position, bool wake = true);
+        void SetBodyRotation(const Quaternion& rotation, bool wake = true);
+        auto SetBodyScale(const Vector3& previousScale, const Vector3& newScale, bool wake = true) -> Vector3;
 
     private:
         friend class NcPhysicsImpl2;

--- a/include/ncengine/physics/RigidBody.h
+++ b/include/ncengine/physics/RigidBody.h
@@ -4,10 +4,10 @@
  */
 #pragma once
 
+#include "Shape.h"
 #include "ncengine/ecs/Component.h"
 #include "ncengine/ecs/Transform.h"
-
-#include "DirectXMath.h"
+#include "ncengine/utility/MatrixUtilities.h"
 
 namespace nc::physics
 {
@@ -36,13 +36,6 @@ struct RigidBodyFlags
 
     /** @brief Default flag values. */
     static constexpr Type Default = ScaleWithTransform;
-};
-
-/** @brief RigidBody shape options. */
-enum class Shape : uint8_t
-{
-    Box,
-    Sphere
 };
 
 /** @brief Determines movement and collision behavior of a RigidBody. */
@@ -93,7 +86,10 @@ auto SetSimulatedBodyScale(Transform& transform,
 class RigidBody
 {
     public:
-        RigidBody(Entity self, Shape shape, BodyType bodyType, RigidBodyFlags::Type flags = RigidBodyFlags::Default)
+        RigidBody(Entity self,
+                  const Shape& shape = Shape::MakeBox(),
+                  BodyType bodyType = BodyType::Dynamic,
+                  RigidBodyFlags::Type flags = RigidBodyFlags::Default)
             : m_self{self},
               m_shape{shape},
               m_bodyType{bodyType},
@@ -128,10 +124,11 @@ class RigidBody
         RigidBody& operator=(RigidBody&) = delete;
 
         auto GetEntity() const -> Entity { return m_self; }
-        auto GetShape() const -> Shape { return m_shape; }
+        auto GetShape() const -> const Shape& { return m_shape; }
         auto ScalesWithTransform() const -> bool { return m_flags & RigidBodyFlags::ScaleWithTransform; }
         auto GetBodyType() const -> BodyType { return m_bodyType; }
         auto GetHandle() const -> BodyHandle { return m_handle; }
+        auto IsAwake() const -> bool;
 
         void AddImpulse(const Vector3& impulse);
         void AddTorque(const Vector3& torque);

--- a/include/ncengine/physics/RigidBody.h
+++ b/include/ncengine/physics/RigidBody.h
@@ -4,9 +4,9 @@
  */
 #pragma once
 
-#include "Shape.h"
 #include "ncengine/ecs/Component.h"
 #include "ncengine/ecs/Transform.h"
+#include "ncengine/physics/Shape.h"
 #include "ncengine/utility/MatrixUtilities.h"
 
 namespace nc::physics
@@ -45,42 +45,6 @@ enum class BodyType : uint8_t
     Static,   // non-movable; does not collide with other static bodies
     Kinematic // movable only with velocities; collides with all other bodies
 };
-
-/**
- * @defgroup SimulatedBodyFunctions Simulated Body Functions
- * @note Prefer using simulated body functions over the Transform equivalents for \ref Entity "entities" with a RigidBody.
- * 
- * Simulated body functions synchronize updating of properties shared between a Transform and RigidBody. They should only
- * be used when strictly necessary, as directly modifying these properties can cause undesirable behavior in the simulation
- * (e.g. when repositioning one body inside of another).
- *
- * @{
- */
-
-/** @brief Set the position of an object's Transform and RigidBody. */
-void SetSimulatedBodyPosition(Transform& transform,
-                              RigidBody& rigidBody,
-                              const Vector3& position,
-                              bool wake = true);
-
-/** @brief Set the rotation of an object's Transform and RigidBody. */
-void SetSimulatedBodyRotation(Transform& transform,
-                              RigidBody& rigidBody,
-                              const Quaternion& rotation,
-                              bool wake = true);
-
-/**
- * @brief Set the scale of an object's Transform and RigidBody.
- * 
- * The actual applied scale is returned and may differ from the requested value, depending on scaling requirements of the
- * RigidBody Shape. If the body does not have ScaleWithTransform set, only the Transform will be modified - in this case,
- * RigidBody::SetScale() may be used to update the body independently.
- */
-auto SetSimulatedBodyScale(Transform& transform,
-                           RigidBody& rigidBody,
-                           const Vector3& scale,
-                           bool wake = true) -> Vector3;
-/** @} */ // End SimulatedBodyFunctions
 
 /** @brief Component managing physics simulation properties. */
 class RigidBody
@@ -134,9 +98,38 @@ class RigidBody
         void AddTorque(const Vector3& torque);
 
         auto IsInitialized() const noexcept -> bool { return m_handle; }
-        void SetBodyPosition(const Vector3& position, bool wake = true);
-        void SetBodyRotation(const Quaternion& rotation, bool wake = true);
-        auto SetBodyScale(const Vector3& previousScale, const Vector3& newScale, bool wake = true) -> Vector3;
+
+        /**
+         * @defgroup SimulatedBodyFunctions Simulated Body Functions
+         * @note Prefer using simulated body functions over the Transform equivalents for \ref Entity "entities" with a RigidBody.
+         * 
+         * Simulated body functions synchronize updating of properties shared between a Transform and RigidBody. They should only
+         * be used when strictly necessary, as directly modifying these properties can cause undesirable behavior in the simulation
+         * (e.g. when repositioning one body inside of another).
+         *
+         * @{
+         */
+
+        /** @brief Set the position of an object's Transform and RigidBody. */
+        void SetSimulatedBodyPosition(Transform& transform,
+                                      const Vector3& position,
+                                      bool wake = true);
+
+        /** @brief Set the rotation of an object's Transform and RigidBody. */
+        void SetSimulatedBodyRotation(Transform& transform,
+                                      const Quaternion& rotation,
+                                      bool wake = true);
+
+        /**
+         * @brief Set the scale of an object's Transform and RigidBody.
+         * 
+         * The actual applied scale is returned and may differ from the requested value, depending on scaling requirements of the
+         * RigidBody Shape. If the body does not have ScaleWithTransform set, only the Transform will be modified.
+         */
+        auto SetSimulatedBodyScale(Transform& transform,
+                                   const Vector3& scale,
+                                   bool wake = true) -> Vector3;
+        /** @} */ // End SimulatedBodyFunctions
 
     private:
         friend class NcPhysicsImpl2;

--- a/include/ncengine/physics/Shape.h
+++ b/include/ncengine/physics/Shape.h
@@ -1,0 +1,49 @@
+/**
+ * @file Shape.h
+ * @copyright Jaremie Romer and McCallister Romer 2024
+ */
+#pragma once
+
+#include "ncmath/Vector.h"
+
+namespace nc::physics
+{
+/** @brief Options for Shape geometry. */
+enum class ShapeType : uint8_t
+{
+    Box,
+    Sphere
+};
+
+/** @brief Describes collision geometry for physics types. */
+struct Shape
+{
+    /** @brief Make a primitive box shape. */
+    static constexpr auto MakeBox(const Vector3& extents = Vector3::Splat(1.0f),
+                                  const Vector3& localPosition = Vector3::Zero()) -> Shape
+    {
+        return Shape{localPosition, extents, ShapeType::Box};
+    }
+
+    /** @brief Make a primitive sphere shape. */
+    static constexpr auto MakeSphere(float radius = 0.5f,
+                                     const Vector3& localPosition = Vector3::Zero()) -> Shape
+    {
+        return Shape{localPosition, Vector3::Splat(radius * 2.0f), ShapeType::Sphere};
+    }
+
+    auto GetLocalPosition() const -> const Vector3& { return m_localPosition; }
+    auto GetLocalScale() const -> const Vector3& { return m_localScale; }
+    auto GetType() const -> ShapeType { return m_type; }
+
+    private:
+        constexpr Shape(const Vector3& position, const Vector3& scale, ShapeType type)
+            : m_localPosition{position}, m_localScale{scale}, m_type{type}
+        {
+        }
+
+        Vector3 m_localPosition;
+        Vector3 m_localScale;
+        ShapeType m_type;
+};
+} // namespace nc::physics

--- a/include/ncengine/physics/Shape.h
+++ b/include/ncengine/physics/Shape.h
@@ -8,12 +8,21 @@
 
 namespace nc::physics
 {
+/** @brief Minimum allowed scale for physics shapes. */
+constexpr auto g_minimumShapeScale = 0.0001f;
+
 /** @brief Options for Shape geometry. */
 enum class ShapeType : uint8_t
 {
     Box,
-    Sphere
+    Sphere,
+    Capsule
 };
+
+/** @brief Get a valid scale for a shape given its current and desired scale values. */
+auto NormalizeScaleForShape(nc::physics::ShapeType shape,
+                            const Vector3& currentScale,
+                            const Vector3& newScale) -> Vector3;
 
 /** @brief Describes collision geometry for physics types. */
 struct Shape
@@ -30,6 +39,14 @@ struct Shape
                                      const Vector3& localPosition = Vector3::Zero()) -> Shape
     {
         return Shape{localPosition, Vector3::Splat(radius * 2.0f), ShapeType::Sphere};
+    }
+
+    /** @brief Make a primitive capsule shape. */
+    static constexpr auto MakeCapsule(float height = 2.0f,
+                                      float radius = 0.5f,
+                                      const Vector3& localPosition = Vector3::Zero()) -> Shape
+    {
+        return Shape{localPosition, Vector3{radius * 2.0f, height * 0.5f, radius * 2.0f}, ShapeType::Capsule};
     }
 
     auto GetLocalPosition() const -> const Vector3& { return m_localPosition; }

--- a/include/ncengine/type/EngineId.h
+++ b/include/ncengine/type/EngineId.h
@@ -40,6 +40,7 @@ constexpr size_t PositionClampId = 21ull;
 constexpr size_t SpotLightId = 22ull;
 constexpr size_t OrientationClampId = 23ull;
 constexpr size_t RigidBodyId = 24ull;
+constexpr size_t CollisionListenerId = 25ull;
 /** @} */
 
 /** @{ */

--- a/sample/source/scenes/Benchmarks.cpp
+++ b/sample/source/scenes/Benchmarks.cpp
@@ -76,6 +76,7 @@ auto AssetCombo(std::string& selection) -> bool
     return nc::ui::Combobox(selection, "##assetcombo", g_assets);
 }
 
+[[maybe_unused]]
 auto AddColliderForMesh(nc::ecs::Ecs world, nc::Entity entity, std::string_view mesh) -> nc::physics::Collider&
 {
     if (mesh == nc::asset::CubeMesh)
@@ -90,6 +91,7 @@ auto AddColliderForMesh(nc::ecs::Ecs world, nc::Entity entity, std::string_view 
     throw nc::NcError(fmt::format("Unexpected mesh '{}'", mesh));
 }
 
+[[maybe_unused]]
 auto AddRigidBodyForMesh(nc::ecs::Ecs world, nc::Entity entity, std::string_view mesh) -> nc::physics::RigidBody&
 {
     if (mesh == nc::asset::CubeMesh)

--- a/sample/source/scenes/PhysicsTest.cpp
+++ b/sample/source/scenes/PhysicsTest.cpp
@@ -1,4 +1,5 @@
 #include "PhysicsTest.h"
+#include "shared/GameLog.h"
 #include "shared/GameLogic.h"
 #include "shared/Prefabs.h"
 #include "shared/spawner/Spawner.h"
@@ -9,6 +10,7 @@
 #include "ncengine/graphics/SceneNavigationCamera.h"
 #include "ncengine/input/Input.h"
 #include "ncengine/physics/Constraints.h"
+#include "ncengine/physics/EventListeners.h"
 #include "ncengine/physics/NcPhysics.h"
 #include "ncengine/physics/PhysicsMaterial.h"
 #include "ncengine/physics/RigidBody.h"
@@ -340,7 +342,7 @@ class VehicleController : public FreeComponent
 auto BuildVehicle(ecs::Ecs world, physics::NcPhysics* ncPhysics) -> Entity
 {
     const auto head = world.Emplace<Entity>({
-        .scale = Vector3::Splat(2.0f),
+        .scale = Vector3::Splat(1.0f),
         .tag = "Worm Head"
     });
 
@@ -391,6 +393,15 @@ auto BuildVehicle(ecs::Ecs world, physics::NcPhysics* ncPhysics) -> Entity
     world.Emplace<physics::RigidBody>(segment1, physics::Shape::MakeBox());
     world.Emplace<physics::RigidBody>(segment2, physics::Shape::MakeBox());
     world.Emplace<physics::RigidBody>(segment3, physics::Shape::MakeBox());
+    world.Emplace<physics::CollisionListener>(
+        head,
+        [](Entity, Entity other, const physics::HitInfo&, ecs::Ecs){
+            GameLog::Log(fmt::format("Player collision enter with {}", other.Index()));
+        },
+        [](Entity, Entity other, ecs::Ecs){
+            GameLog::Log(fmt::format("Player collsion exit with {}", other.Index()));
+        }
+    );
 
     world.Emplace<physics::VelocityRestriction>(head);
     world.Emplace<physics::VelocityRestriction>(segment1);

--- a/sample/source/scenes/PhysicsTest.cpp
+++ b/sample/source/scenes/PhysicsTest.cpp
@@ -121,8 +121,8 @@ struct FollowCamera : public graphics::Camera
 #ifdef NC_USE_JOLT
 class VehicleController : public FreeComponent
 {
-    static constexpr auto force = 50.0f;
-    static constexpr auto torqueForce = 50.0f;
+    static constexpr auto force = 150.0f;
+    static constexpr auto torqueForce = 150.0f;
     static constexpr auto jumpForce = 400.0f;
     static constexpr auto jumpCooldownTime = 0.3f;
 
@@ -340,6 +340,7 @@ class VehicleController : public FreeComponent
 auto BuildVehicle(ecs::Ecs world, physics::NcPhysics* ncPhysics) -> Entity
 {
     const auto head = world.Emplace<Entity>({
+        .scale = Vector3::Splat(2.0f),
         .tag = "Worm Head"
     });
 
@@ -386,10 +387,10 @@ auto BuildVehicle(ecs::Ecs world, physics::NcPhysics* ncPhysics) -> Entity
     world.Emplace<physics::PhysicsBody>(segment2, segment2Transform, segment2Collider, physics::PhysicsProperties{.mass = 1.0f});
     world.Emplace<physics::PhysicsBody>(segment3, segment3Transform, segment3Collider, physics::PhysicsProperties{.mass = 0.2f});
 
-    world.Emplace<physics::RigidBody>(head, physics::Shape::Box, physics::BodyType::Dynamic);
-    world.Emplace<physics::RigidBody>(segment1, physics::Shape::Box, physics::BodyType::Dynamic);
-    world.Emplace<physics::RigidBody>(segment2, physics::Shape::Box, physics::BodyType::Dynamic);
-    world.Emplace<physics::RigidBody>(segment3, physics::Shape::Box, physics::BodyType::Dynamic);
+    world.Emplace<physics::RigidBody>(head, physics::Shape::MakeBox());
+    world.Emplace<physics::RigidBody>(segment1, physics::Shape::MakeBox());
+    world.Emplace<physics::RigidBody>(segment2, physics::Shape::MakeBox());
+    world.Emplace<physics::RigidBody>(segment3, physics::Shape::MakeBox());
 
     world.Emplace<physics::VelocityRestriction>(head);
     world.Emplace<physics::VelocityRestriction>(segment1);
@@ -458,7 +459,7 @@ void BuildGround(ecs::Ecs world)
     world.Emplace<physics::Collider>(leftWall, physics::BoxProperties{});
     world.Emplace<physics::Collider>(rightWall, physics::BoxProperties{});
 
-    world.Emplace<physics::RigidBody>(ground, physics::Shape::Box, physics::BodyType::Static);
+    world.Emplace<physics::RigidBody>(ground, physics::Shape::MakeBox(), physics::BodyType::Static);
 }
 
 void BuildBridge(ecs::Ecs world, physics::NcPhysics* ncPhysics)
@@ -769,7 +770,7 @@ void BuildSpawner(ecs::Ecs world, Random* ncRandom)
             world.Emplace<graphics::ToonRenderer>(handle, asset::CubeMesh, DefaultToonMaterial);
             auto& collider = world.Emplace<physics::Collider>(handle, physics::BoxProperties{}, false);
             world.Emplace<physics::PhysicsBody>(handle, world.Get<Transform>(handle), collider, physics::PhysicsProperties{.mass = 5.0f});
-            world.Emplace<physics::RigidBody>(handle, physics::Shape::Box, physics::BodyType::Dynamic);
+            world.Emplace<physics::RigidBody>(handle, physics::Shape::MakeBox(), physics::BodyType::Dynamic);
         }
     );
 

--- a/source/engine/engine/registration/PhysicsTypes.cpp
+++ b/source/engine/engine/registration/PhysicsTypes.cpp
@@ -2,6 +2,7 @@
 #include "ncengine/physics/Collider.h"
 #include "ncengine/physics/ConcaveCollider.h"
 #include "ncengine/physics/Constraints.h"
+#include "ncengine/physics/EventListeners.h"
 #include "ncengine/physics/PhysicsBody.h"
 #include "ncengine/physics/PhysicsMaterial.h"
 #include "ncengine/physics/RigidBody.h"
@@ -93,6 +94,13 @@ void RegisterPhysicsTypes(ecs::ComponentRegistry& registry, size_t maxEntities)
         maxEntities,
         RigidBodyId,
         "RigidBody"
+    );
+
+    Register<physics::CollisionListener>(
+        registry,
+        maxEntities,
+        CollisionListenerId,
+        "CollisionListener"
     );
 }
 } // namespace nc

--- a/source/engine/graphics/system/WidgetSystem.cpp
+++ b/source/engine/graphics/system/WidgetSystem.cpp
@@ -77,6 +77,11 @@ auto GetMeshView(nc::physics::ShapeType shape) -> nc::asset::MeshView
             static const auto view = AssetService<MeshView>::Get()->Acquire(SphereMesh);
             return view;
         }
+        case nc::physics::ShapeType::Capsule:
+        {
+            static const auto view = AssetService<MeshView>::Get()->Acquire(CapsuleMesh);
+            return view;
+        }
         default:
         {
             throw nc::NcError("Unknown Shape");

--- a/source/engine/graphics/system/WidgetSystem.h
+++ b/source/engine/graphics/system/WidgetSystem.h
@@ -14,6 +14,7 @@ class Transform;
 namespace physics
 {
 class Collider;
+class RigidBody;
 } // namespace physics
 
 namespace graphics
@@ -41,7 +42,8 @@ class WidgetSystem
                                       MeshRenderer,
                                       ToonRenderer,
                                       WireframeRenderer,
-                                      physics::Collider> worldView) -> WidgetState;
+                                      physics::Collider,
+                                      physics::RigidBody> worldView) -> WidgetState;
 };
 } // namespace graphics
 } // namespace nc

--- a/source/engine/physics2/CMakeLists.txt
+++ b/source/engine/physics2/CMakeLists.txt
@@ -2,6 +2,7 @@ target_sources(${NC_ENGINE_LIB}
     PRIVATE
         NcPhysicsImpl2.cpp
         RigidBody.cpp
+        Shape.cpp
 )
 
 add_subdirectory(jolt)

--- a/source/engine/physics2/CMakeLists.txt
+++ b/source/engine/physics2/CMakeLists.txt
@@ -1,5 +1,6 @@
 target_sources(${NC_ENGINE_LIB}
     PRIVATE
+        EventDispatch.cpp
         NcPhysicsImpl2.cpp
         RigidBody.cpp
         Shape.cpp

--- a/source/engine/physics2/EventDispatch.cpp
+++ b/source/engine/physics2/EventDispatch.cpp
@@ -1,0 +1,60 @@
+#include "EventDispatch.h"
+#include "jolt/ContactListener.h"
+
+#include "ncengine/ecs/Ecs.h"
+#include "ncengine/physics/EventListeners.h"
+
+namespace
+{
+void CheckDispatchOnEnter(nc::Entity target,
+                          nc::Entity other,
+                          const nc::physics::HitInfo& hit,
+                          nc::ecs::Ecs& world,
+                          nc::ecs::ComponentPool<nc::physics::CollisionListener>& pool)
+{
+    if (target.ReceivesCollisionEvents() && pool.Contains(target))
+    {
+        auto& listener = pool.Get(target);
+        if (listener.onEnter)
+        {
+            listener.onEnter(target, other, hit, world);
+        }
+    }
+}
+
+void CheckDispatchOnExit(nc::Entity target,
+                         nc::Entity other,
+                         nc::ecs::ComponentPool<nc::physics::CollisionListener>& pool,
+                         nc::ecs::Ecs& world)
+{
+    if (target.ReceivesCollisionEvents() && pool.Contains(target))
+    {
+        auto& listener = pool.Get(target);
+        if (listener.onExit)
+        {
+            listener.onExit(target, other, world);
+        }
+    }
+}
+} // anonymous namespace
+
+namespace nc::physics
+{
+void DispatchPhysicsEvents(ContactListener& events, ecs::Ecs world)
+{
+    auto& listenerPool = world.GetPool<CollisionListener>();
+    for (const auto& [pair, hit] : events.GetAdded())
+    {
+        CheckDispatchOnEnter(pair.first, pair.second, hit, world, listenerPool);
+        CheckDispatchOnEnter(pair.second, pair.first, hit, world, listenerPool);
+    }
+
+    for (const auto& [_, first, second] : events.GetRemoved())
+    {
+        CheckDispatchOnExit(first, second, listenerPool, world);
+        CheckDispatchOnExit(second, first, listenerPool, world);
+    }
+
+    events.CommitPendingChanges();
+}
+} // namespace nc::physics

--- a/source/engine/physics2/EventDispatch.h
+++ b/source/engine/physics2/EventDispatch.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "ncengine/ecs/EcsFwd.h"
+
+namespace nc::physics
+{
+class ContactListener;
+
+void DispatchPhysicsEvents(ContactListener& events, ecs::Ecs world);
+} // namespace nc::physics

--- a/source/engine/physics2/NcPhysicsImpl2.cpp
+++ b/source/engine/physics2/NcPhysicsImpl2.cpp
@@ -100,18 +100,19 @@ void NcPhysicsImpl2::OnAddRigidBody(RigidBody& body)
     const auto [transformScale, transformRotation, transformPosition] = DecomposeMatrix(transform.TransformationMatrix());
     const auto& shape = body.GetShape();
     const auto bodyType = body.GetBodyType();
-    auto allowedScaling = JPH::Vec3::sReplicate(1.0f);
+    auto allowedScaling = Vector3::One();
     if (body.ScalesWithTransform())
     {
-        allowedScaling = ToJoltVec3(transformScale);
-        if (NormalizeScaleForShape(shape.GetType(), allowedScaling))
+        const auto currentScale = nc::ToVector3(transformScale);
+        allowedScaling = NormalizeScaleForShape(shape.GetType(), currentScale, currentScale);
+        if (allowedScaling != currentScale)
         {
-            transform.SetScale(ToVector3(allowedScaling)); // update Transform to prevent invalid scales
+            transform.SetScale(allowedScaling); // update Transform to prevent invalid scales
         }
     }
 
     const auto bodySettings = JPH::BodyCreationSettings{
-        m_jolt.shapeFactory.MakeShape(shape, allowedScaling),
+        m_jolt.shapeFactory.MakeShape(shape, ToJoltVec3(allowedScaling)),
         ToJoltVec3(transformPosition),
         ToJoltQuaternion(transformRotation),
         ToMotionType(bodyType),

--- a/source/engine/physics2/NcPhysicsImpl2.cpp
+++ b/source/engine/physics2/NcPhysicsImpl2.cpp
@@ -1,4 +1,5 @@
 #include "NcPhysicsImpl2.h"
+#include "EventDispatch.h"
 #include "jolt/Conversion.h"
 #include "jolt/ShapeFactory.h"
 
@@ -59,28 +60,9 @@ NcPhysicsImpl2::NcPhysicsImpl2(const config::PhysicsSettings&, Registry* registr
 
 void NcPhysicsImpl2::Run()
 {
-    // @todo: 689 need to update api bodies for all dirty non-static objects
     m_jolt.Update(time::DeltaTime());
-
-    for (auto& body : m_ecs.GetAll<RigidBody>())
-    {
-        // @todo: 691 not sure how kinematic behave yet, assuming they won't get updated
-        if (body.GetBodyType() != BodyType::Dynamic)
-        {
-            continue;
-        }
-
-        auto* apiBody = reinterpret_cast<JPH::Body*>(body.GetHandle());
-        if (!apiBody->IsActive())
-        {
-            continue;
-        }
-
-        const auto position = ToXMVectorHomogeneous(apiBody->GetPosition());
-        const auto orientation = ToXMQuaternion(apiBody->GetRotation());
-        auto& transform = m_ecs.Get<Transform>(body.GetEntity());
-        transform.SetPositionAndRotationXM(position, orientation);
-    }
+    SyncTransforms();
+    DispatchPhysicsEvents(m_jolt.contactListener, m_ecs);
 }
 
 void NcPhysicsImpl2::OnBuildTaskGraph(task::UpdateTasks& update, task::RenderTasks&)
@@ -111,7 +93,7 @@ void NcPhysicsImpl2::OnAddRigidBody(RigidBody& body)
         }
     }
 
-    const auto bodySettings = JPH::BodyCreationSettings{
+    auto bodySettings = JPH::BodyCreationSettings{
         m_jolt.shapeFactory.MakeShape(shape, ToJoltVec3(allowedScaling)),
         ToJoltVec3(transformPosition),
         ToJoltQuaternion(transformRotation),
@@ -119,10 +101,34 @@ void NcPhysicsImpl2::OnAddRigidBody(RigidBody& body)
         ToObjectLayer(bodyType)
     };
 
-    auto& iBody = m_jolt.physicsSystem.GetBodyInterface(); // @todo: 697 try non-locking interface
+    bodySettings.mUserData = Entity::Hash{}(body.GetEntity());
+    auto& iBody = m_jolt.physicsSystem.GetBodyInterfaceNoLock();
     auto apiBody = iBody.CreateBody(bodySettings);
     iBody.AddBody(apiBody->GetID(), JPH::EActivation::Activate);
     body.SetContext(apiBody, m_jolt.ctx.get());
+}
+
+void NcPhysicsImpl2::SyncTransforms()
+{
+    for (auto& body : m_ecs.GetAll<RigidBody>())
+    {
+        // @todo: 691 not sure how kinematic behave yet, assuming they won't get updated
+        if (body.GetBodyType() != BodyType::Dynamic)
+        {
+            continue;
+        }
+
+        auto* apiBody = reinterpret_cast<JPH::Body*>(body.GetHandle());
+        if (!apiBody->IsActive())
+        {
+            continue;
+        }
+
+        const auto position = ToXMVectorHomogeneous(apiBody->GetPosition());
+        const auto orientation = ToXMQuaternion(apiBody->GetRotation());
+        auto& transform = m_ecs.Get<Transform>(body.GetEntity());
+        transform.SetPositionAndRotationXM(position, orientation);
+    }
 }
 
 void NcPhysicsImpl2::Clear() noexcept

--- a/source/engine/physics2/NcPhysicsImpl2.h
+++ b/source/engine/physics2/NcPhysicsImpl2.h
@@ -19,8 +19,6 @@ struct PhysicsSettings;
 
 namespace physics
 {
-using PhysicsEcsFilter = ecs::ExplicitEcs<Transform, RigidBody>;
-
 class NcPhysicsImpl2 final : public NcPhysics
 {
     public:
@@ -38,11 +36,12 @@ class NcPhysicsImpl2 final : public NcPhysics
         auto RaycastToClickables(LayerMask = LayerMaskAll) -> IClickable* override { return nullptr; }
 
     private:
-        PhysicsEcsFilter m_ecs;
+        ecs::Ecs m_ecs;
         JoltApi m_jolt;
         Connection<RigidBody&> m_onAddRigidBodyConnection;
 
         void OnAddRigidBody(RigidBody& body);
+        void SyncTransforms();
 };
 } // namespace physics
 } // namespace nc

--- a/source/engine/physics2/RigidBody.cpp
+++ b/source/engine/physics2/RigidBody.cpp
@@ -63,6 +63,11 @@ RigidBody::~RigidBody() noexcept
     }
 }
 
+auto RigidBody::IsAwake() const -> bool
+{
+    return ToBody(m_handle)->IsActive();
+}
+
 void RigidBody::AddImpulse(const Vector3& impulse)
 {
     m_ctx->interface.AddImpulse(ToBody(m_handle)->GetID(), ToJoltVec3(impulse));
@@ -85,11 +90,11 @@ void RigidBody::SetRotation(const Quaternion& rotation, bool wake)
 
 auto RigidBody::SetScale(const Vector3& scale, bool wake) -> Vector3
 {
-    auto shapeScale = ToJoltVec3(scale);
-    NormalizeScaleForShape(m_shape, shapeScale);
-    auto newShape = m_ctx->shapeFactory.MakeShape(m_shape, shapeScale);
+    auto allowedScaling = ToJoltVec3(scale);
+    NormalizeScaleForShape(m_shape.GetType(), allowedScaling);
+    auto newShape = m_ctx->shapeFactory.MakeShape(m_shape, allowedScaling);
     m_ctx->interface.SetShape(ToBody(m_handle)->GetID(), newShape, true, ToActivationMode(wake));
-    return ToVector3(shapeScale);
+    return ToVector3(allowedScaling);
 }
 
 void RigidBody::SetContext(BodyHandle handle, ComponentContext* ctx)

--- a/source/engine/physics2/RigidBody.cpp
+++ b/source/engine/physics2/RigidBody.cpp
@@ -22,37 +22,6 @@ auto ToActivationMode(bool wake) -> JPH::EActivation
 
 namespace nc::physics
 {
-void SetSimulatedBodyPosition(Transform& transform,
-                              RigidBody& rigidBody,
-                              const Vector3& position,
-                              bool wake)
-{
-    transform.SetPosition(position);
-    rigidBody.SetBodyPosition(position, wake);
-}
-
-void SetSimulatedBodyRotation(Transform& transform,
-                              RigidBody& rigidBody,
-                              const Quaternion& rotation,
-                              bool wake)
-{
-    transform.SetRotation(rotation);
-    rigidBody.SetBodyRotation(rotation, wake);
-}
-
-auto SetSimulatedBodyScale(Transform& transform,
-                           RigidBody& rigidBody,
-                           const Vector3& scale,
-                           bool wake) -> Vector3
-{
-    const auto appliedScale = rigidBody.ScalesWithTransform()
-        ? rigidBody.SetBodyScale(transform.Scale(), scale, wake)
-        : scale;
-
-    transform.SetScale(appliedScale);
-    return appliedScale;
-}
-
 RigidBody::~RigidBody() noexcept
 {
     if (IsInitialized())
@@ -78,22 +47,36 @@ void RigidBody::AddTorque(const Vector3& torque)
     m_ctx->interface.AddTorque(ToBody(m_handle)->GetID(), ToJoltVec3(torque));
 }
 
-void RigidBody::SetBodyPosition(const Vector3& position, bool wake)
+void RigidBody::SetSimulatedBodyPosition(Transform& transform,
+                                         const Vector3& position,
+                                         bool wake)
 {
+    transform.SetPosition(position);
     m_ctx->interface.SetPosition(ToBody(m_handle)->GetID(), ToJoltVec3(position), ToActivationMode(wake));
 }
 
-void RigidBody::SetBodyRotation(const Quaternion& rotation, bool wake)
+void RigidBody::SetSimulatedBodyRotation(Transform& transform,
+                                         const Quaternion& rotation,
+                                         bool wake)
 {
+    transform.SetRotation(rotation);
     m_ctx->interface.SetRotation(ToBody(m_handle)->GetID(), ToJoltQuaternion(rotation), ToActivationMode(wake));
 }
 
-auto RigidBody::SetBodyScale(const Vector3& previousScale, const Vector3& scale, bool wake) -> Vector3
+auto RigidBody::SetSimulatedBodyScale(Transform& transform,
+                                      const Vector3& scale,
+                                      bool wake) -> Vector3
 {
-    const auto allowedScaling = NormalizeScaleForShape(m_shape.GetType(), previousScale, scale);
-    const auto newShape = m_ctx->shapeFactory.MakeShape(m_shape, ToJoltVec3(allowedScaling));
-    m_ctx->interface.SetShape(ToBody(m_handle)->GetID(), newShape, true, ToActivationMode(wake));
-    return allowedScaling;
+    auto appliedScale = scale;
+    if (ScalesWithTransform())
+    {
+        appliedScale = NormalizeScaleForShape(m_shape.GetType(), transform.Scale(), scale);
+        const auto newShape = m_ctx->shapeFactory.MakeShape(m_shape, ToJoltVec3(appliedScale));
+        m_ctx->interface.SetShape(ToBody(m_handle)->GetID(), newShape, true, ToActivationMode(wake));
+    }
+
+    transform.SetScale(appliedScale);
+    return appliedScale;
 }
 
 void RigidBody::SetContext(BodyHandle handle, ComponentContext* ctx)

--- a/source/engine/physics2/Shape.cpp
+++ b/source/engine/physics2/Shape.cpp
@@ -2,6 +2,8 @@
 
 #include "ncutility/NcError.h"
 
+#include <utility>
+
 namespace
 {
 void EnsureGreaterThanZeroScale(nc::Vector3& out)

--- a/source/engine/physics2/Shape.cpp
+++ b/source/engine/physics2/Shape.cpp
@@ -1,0 +1,78 @@
+#include "ncengine/physics/Shape.h"
+
+#include "ncutility/NcError.h"
+
+namespace
+{
+void EnsureGreaterThanZeroScale(nc::Vector3& out)
+{
+    if (out.x <= 0.0f)
+        out.x = nc::physics::g_minimumShapeScale;
+    if (out.y <= 0.0f)
+        out.y = nc::physics::g_minimumShapeScale;
+    if (out.z <= 0.0f)
+        out.z = nc::physics::g_minimumShapeScale;
+}
+
+void FixSphereScale(const nc::Vector3& current, nc::Vector3& desired)
+{
+    if (!nc::FloatEqual(current.x, desired.x))
+        desired =  nc::Vector3::Splat(desired.x);
+    else if (!nc::FloatEqual(current.y, desired.y))
+        desired = nc::Vector3::Splat(desired.y);
+    else
+        desired = nc::Vector3::Splat(desired.z);
+}
+
+void FixCapsuleScale(const nc::Vector3& current, nc::Vector3& desired)
+{
+    if (!nc::FloatEqual(current.x, desired.x))
+        desired.z = desired.x;
+    else
+        desired.x = desired.z;
+}
+} // anonymous namespace
+
+namespace nc::physics
+{
+auto NormalizeScaleForShape(nc::physics::ShapeType shape,
+                            const Vector3& currentScale,
+                            const Vector3& newScale) -> Vector3
+{
+    auto allowedScale = newScale;
+    EnsureGreaterThanZeroScale(allowedScale);
+
+    switch (shape)
+    {
+        case nc::physics::ShapeType::Box:
+        {
+            break;
+        }
+        case nc::physics::ShapeType::Sphere:
+        {
+            if (!HasUniformElements(allowedScale))
+            {
+                FixSphereScale(currentScale, allowedScale);
+            }
+
+            break;
+        }
+        case nc::physics::ShapeType::Capsule:
+        {
+            if (!FloatEqual(allowedScale.x, allowedScale.z))
+            {
+                FixCapsuleScale(currentScale, allowedScale);
+            }
+
+            break;
+        }
+        default:
+        {
+            NC_ASSERT(false, fmt::format("Unhandled Shape: '{}'", std::to_underlying(shape)));
+            std::unreachable();
+        }
+    }
+
+    return allowedScale;
+}
+} // namespace nc::physics

--- a/source/engine/physics2/Shape.cpp
+++ b/source/engine/physics2/Shape.cpp
@@ -19,7 +19,7 @@ void EnsureGreaterThanZeroScale(nc::Vector3& out)
 void FixSphereScale(const nc::Vector3& current, nc::Vector3& desired)
 {
     if (!nc::FloatEqual(current.x, desired.x))
-        desired =  nc::Vector3::Splat(desired.x);
+        desired = nc::Vector3::Splat(desired.x);
     else if (!nc::FloatEqual(current.y, desired.y))
         desired = nc::Vector3::Splat(desired.y);
     else

--- a/source/engine/physics2/jolt/CMakeLists.txt
+++ b/source/engine/physics2/jolt/CMakeLists.txt
@@ -1,4 +1,5 @@
 target_sources(${NC_ENGINE_LIB}
     PRIVATE
+        ContactListener.cpp
         JoltApi.cpp
 )

--- a/source/engine/physics2/jolt/ContactListener.cpp
+++ b/source/engine/physics2/jolt/ContactListener.cpp
@@ -1,0 +1,129 @@
+#include "ContactListener.h"
+#include "Conversion.h"
+
+#include "Jolt/Physics/PhysicsSystem.h"
+#include "ncutility/NcError.h"
+
+#include <ranges>
+
+namespace
+{
+auto FillPoints(std::array<nc::Vector3, 4>& points, const JPH::ContactPoints& source) -> size_t
+{
+    const auto count = source.size();
+    NC_ASSERT(count <= 4u, "Unexpected contact count");
+    for (auto i = 0u; i < count; ++i)
+    {
+        points[i] = nc::physics::ToVector3(source[i]);
+    }
+
+    return count;
+}
+} // anonymous namespace
+
+namespace nc::physics
+{
+// note: This is called from multiple threads with all bodies locked.
+void ContactListener::OnContactAdded(const JPH::Body& body1,
+                                     const JPH::Body& body2,
+                                     const JPH::ContactManifold& manifold,
+                                     JPH::ContactSettings&)
+{
+    if (m_physicsSystem->WereBodiesInContact(body1.GetID(), body2.GetID()))
+    {
+        return; // not the first contact between bodies
+    }
+
+    const auto hash = JPH::SubShapeIDPair{
+        body1.GetID(),
+        manifold.mSubShapeID1,
+        body2.GetID(),
+        manifold.mSubShapeID2
+    }.GetHash();
+
+    if (m_pairs.contains(hash))
+    {
+        return; // ignore wake up events
+    }
+
+    const auto pair = OverlappingPair{
+        hash,
+        Entity::FromHash(body1.GetUserData()),
+        Entity::FromHash(body2.GetUserData())
+    };
+
+    const auto firstReceivesEvents = pair.first.ReceivesCollisionEvents() && !pair.first.IsStatic();
+    const auto secondReceivesEvents = pair.second.ReceivesCollisionEvents() && !pair.second.IsStatic();
+    if (!(firstReceivesEvents || secondReceivesEvents))
+    {
+        return; // our api doesn't allow this event to be dispatched
+    }
+
+    auto pointsOnFirst = std::array<Vector3, 4>{};
+    auto pointsOnSecond = std::array<Vector3, 4>{};
+    const auto numPointsOnFirst = FillPoints(pointsOnFirst, manifold.mRelativeContactPointsOn1);
+    const auto numPointsOnSecond = FillPoints(pointsOnSecond, manifold.mRelativeContactPointsOn2);
+
+    {
+        auto lock = std::lock_guard{m_addedMutex};
+        m_added.emplace_back(
+            pair,
+            HitInfo{
+                ToVector3(manifold.mBaseOffset),
+                ToVector3(manifold.mWorldSpaceNormal),
+                manifold.mPenetrationDepth,
+                Contacts{pointsOnFirst, numPointsOnFirst},
+                Contacts{pointsOnSecond, numPointsOnSecond}
+            }
+        );
+    }
+}
+
+// note: This called from multiple threads with all bodies locked.
+void ContactListener::OnContactRemoved(const JPH::SubShapeIDPair& pairID)
+{
+    const auto id1 = pairID.GetBody1ID();
+    const auto id2 = pairID.GetBody2ID();
+    if (m_physicsSystem->WereBodiesInContact(id1, id2))
+    {
+        return; // not the last contact between bodies
+    }
+
+    auto& interface = m_physicsSystem->GetBodyInterfaceNoLock();
+    if (interface.IsAdded(id1) && interface.IsAdded(id2))
+    {
+        if (!interface.IsActive(id1) && !interface.IsActive(id2))
+        {
+            return; // ignore sleep events
+        }
+    }
+
+    const auto pos = m_pairs.find(pairID.GetHash());
+    if (pos == m_pairs.cend())
+    {
+        return;
+    }
+
+    {
+        auto lock = std::lock_guard{m_removedMutex};
+        m_removed.push_back(pos->second);
+    }
+}
+
+void ContactListener::CommitPendingChanges()
+{
+    for (const auto& overlappinPair : m_removed)
+    {
+        m_pairs.erase(overlappinPair.hash);
+    }
+
+    m_removed.clear();
+
+    for (const auto& collisionPair : m_added)
+    {
+        m_pairs.emplace(collisionPair.pair.hash, collisionPair.pair);
+    }
+
+    m_added.clear();
+}
+} // namespace nc::physics

--- a/source/engine/physics2/jolt/ContactListener.h
+++ b/source/engine/physics2/jolt/ContactListener.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include "ncengine/physics/HitInfo.h"
+
+#include "Jolt/Jolt.h"
+#include "Jolt/Physics/Collision/ContactListener.h"
+
+#include <mutex>
+#include <span>
+#include <unordered_map>
+#include <vector>
+
+namespace JPH
+{
+class PhysicsSystem;
+} // namespace JPH
+
+namespace nc::physics
+{
+struct OverlappingPair
+{
+    uint64_t hash;
+    Entity first;
+    Entity second;
+};
+
+struct CollisionPair
+{
+    OverlappingPair pair;
+    HitInfo hit;
+};
+
+class ContactListener final : public JPH::ContactListener
+{
+    public:
+        explicit ContactListener(JPH::PhysicsSystem& physicsSystem)
+            : m_physicsSystem{&physicsSystem}
+        {
+        }
+
+        void OnContactAdded(const JPH::Body& body1,
+                            const JPH::Body& body2,
+                            const JPH::ContactManifold& manifold,
+                            JPH::ContactSettings& settings) override;
+
+        void OnContactRemoved(const JPH::SubShapeIDPair& pair) override;
+
+        auto GetAdded() const -> std::span<const CollisionPair> { return m_added; }
+        auto GetRemoved() const -> std::span<const OverlappingPair> { return m_removed; }
+        void CommitPendingChanges();
+
+    private:
+        JPH::PhysicsSystem* m_physicsSystem;
+        std::unordered_map<size_t, OverlappingPair> m_pairs;
+
+        std::vector<CollisionPair> m_added;
+        std::mutex m_addedMutex;
+
+        std::vector<OverlappingPair> m_removed;
+        std::mutex m_removedMutex;
+};
+} // namespace nc::physics

--- a/source/engine/physics2/jolt/Conversion.h
+++ b/source/engine/physics2/jolt/Conversion.h
@@ -5,6 +5,9 @@
 
 #include "DirectXMath.h"
 
+
+#include <type_traits>
+
 namespace nc::physics
 {
 inline auto ToJoltVec3(const nc::Vector3& in) -> JPH::Vec3

--- a/source/engine/physics2/jolt/JoltApi.cpp
+++ b/source/engine/physics2/jolt/JoltApi.cpp
@@ -29,6 +29,7 @@ JoltApi::~JoltApi() noexcept
 }
 
 JoltApi::JoltApi()
+    : contactListener{physicsSystem}
 {
     physicsSystem.Init(
         maxBodies,
@@ -40,6 +41,7 @@ JoltApi::JoltApi()
         objectLayerPairFilter
     );
 
-    ctx = std::make_unique<ComponentContext>(physicsSystem.GetBodyInterface(), shapeFactory);
+    physicsSystem.SetContactListener(&contactListener);
+    ctx = std::make_unique<ComponentContext>(physicsSystem.GetBodyInterfaceNoLock(), shapeFactory);
 }
 } // namespace nc::physics

--- a/source/engine/physics2/jolt/JoltApi.h
+++ b/source/engine/physics2/jolt/JoltApi.h
@@ -2,6 +2,7 @@
 
 #include "Allocator.h"
 #include "ComponentContext.h"
+#include "ContactListener.h"
 #include "Layers.h"
 #include "ShapeFactory.h"
 #include "ncengine/type/StableAddress.h"
@@ -46,6 +47,7 @@ struct JoltApi : public StableAddress
     ObjectLayerPairFilter objectLayerPairFilter;
     JPH::PhysicsSystem physicsSystem;
     ShapeFactory shapeFactory;
+    ContactListener contactListener;
     std::unique_ptr<ComponentContext> ctx;
 
     private:

--- a/source/engine/physics2/jolt/ShapeFactory.h
+++ b/source/engine/physics2/jolt/ShapeFactory.h
@@ -23,7 +23,7 @@ class ShapeFactory
             const auto localScale = ToJoltVec3(shape.GetLocalScale());
             const auto worldScale = localScale * additionalScaling;
 
-            /** @todo: 692, 693, 694 support additional shape types */
+            /** @todo: 693, 694 support additional shape types */
             switch (type)
             {
                 case ShapeType::Box:

--- a/source/engine/physics2/jolt/ShapeFactory.h
+++ b/source/engine/physics2/jolt/ShapeFactory.h
@@ -4,19 +4,20 @@
 
 #include "Jolt/Physics/Collision/Shape/BoxShape.h"
 #include "Jolt/Physics/Collision/Shape/ScaledShape.h"
+#include "Jolt/Physics/Collision/Shape/RotatedTranslatedShape.h"
 #include "Jolt/Physics/Collision/Shape/SphereShape.h"
 
 namespace nc::physics
 {
-inline auto NormalizeScaleForShape(nc::physics::Shape shape, JPH::Vec3& scaleOut) -> bool
+inline auto NormalizeScaleForShape(nc::physics::ShapeType shape, JPH::Vec3& scaleOut) -> bool
 {
     switch (shape)
     {
-        case nc::physics::Shape::Box:
+        case nc::physics::ShapeType::Box:
         {
             return false;
         }
-        case nc::physics::Shape::Sphere:
+        case nc::physics::ShapeType::Sphere:
         {
             if (JPH::ScaleHelpers::IsUniformScale(scaleOut))
             {
@@ -39,30 +40,49 @@ class ShapeFactory
     static constexpr auto boxConvexRadius = 0.05f;
 
     public:
-        auto MakeShape(Shape shape, const JPH::Vec3& scale) -> JPH::Ref<JPH::Shape>
+        auto MakeShape(const Shape& shape,
+                        const JPH::Vec3& additionalScaling) -> JPH::Ref<JPH::Shape>
         {
+            const auto type = shape.GetType();
+            const auto localPosition = ToJoltVec3(shape.GetLocalPosition());
+            const auto localScale = ToJoltVec3(shape.GetLocalScale());
+            const auto worldScale = localScale * additionalScaling;
+
             /** @todo: 692, 693, 694 support additional shape types */
-            switch (shape)
+            switch (type)
             {
-                case Shape::Box:
-                    return MakeBox(scale * 0.5f);
-                case Shape::Sphere:
-                    NC_ASSERT(JPH::ScaleHelpers::IsUniformScale(scale), "Sphere requires uniform scale");
-                    return MakeSphere(scale.GetX() * 0.5f);
+                case ShapeType::Box:
+                    return MakeBox(worldScale * 0.5f, localPosition * additionalScaling);
+                case ShapeType::Sphere:
+                    NC_ASSERT(JPH::ScaleHelpers::IsUniformScale(worldScale), "Sphere requires uniform scale");
+                    return MakeSphere(worldScale.GetX() * 0.5f, localPosition * additionalScaling);
                 default:
-                    NC_ASSERT(false, fmt::format("Unhandled Shape '{}'", std::to_underlying(shape)));
+                    NC_ASSERT(false, fmt::format("Unhandled ShapeType '{}'", std::to_underlying(type)));
                     std::unreachable();
             };
         }
 
-        auto MakeBox(const JPH::Vec3& halfExtents) -> JPH::Ref<JPH::Shape>
+        auto MakeBox(const JPH::Vec3& halfExtents, const JPH::Vec3& localPosition) -> JPH::Ref<JPH::Shape>
         {
-            return JPH::Ref<JPH::Shape>{new JPH::BoxShape(halfExtents, boxConvexRadius)};
+            return ApplyLocalOffsets(MakeRef<JPH::BoxShape>(halfExtents, boxConvexRadius), localPosition);
         }
 
-        auto MakeSphere(float radius) -> JPH::Ref<JPH::Shape>
+        auto MakeSphere(float radius, const JPH::Vec3& localPosition) -> JPH::Ref<JPH::Shape>
         {
-            return JPH::Ref<JPH::Shape>{new JPH::SphereShape(radius)};
+            return ApplyLocalOffsets(MakeRef<JPH::SphereShape>(radius), localPosition);
+        }
+
+    private:
+        template<class T, class... Args>
+        auto MakeRef(Args&&... args) -> JPH::Ref<JPH::Shape>
+        {
+            return JPH::Ref<JPH::Shape>{new T(std::forward<Args>(args)...)};
+        }
+
+        auto ApplyLocalOffsets(const JPH::Ref<JPH::Shape>& shape,
+                               const JPH::Vec3& localPosition) -> JPH::Ref<JPH::Shape>
+        {
+            return MakeRef<JPH::RotatedTranslatedShape>(localPosition, JPH::Quat::sIdentity(), shape.GetPtr());
         }
 };
 } // namespace nc::physics

--- a/source/engine/ui/editor/impl/ComponentWidgets.cpp
+++ b/source/engine/ui/editor/impl/ComponentWidgets.cpp
@@ -269,7 +269,7 @@ void TransformUIWidget(Transform& transform, EditorContext& ctx, const std::any&
         if (ctx.world.Contains<physics::RigidBody>(self))
         {
             auto& body = ctx.world.Get<physics::RigidBody>(self);
-            physics::SetSimulatedBodyPosition(transform, body, pos, true);
+            body.SetSimulatedBodyPosition(transform, pos, true);
         }
         else
         {
@@ -292,7 +292,7 @@ void TransformUIWidget(Transform& transform, EditorContext& ctx, const std::any&
         if (ctx.world.Contains<physics::RigidBody>(self))
         {
             auto& body = ctx.world.Get<physics::RigidBody>(self);
-            physics::SetSimulatedBodyRotation(transform, body, newRotation, true);
+            body.SetSimulatedBodyRotation(transform, newRotation, true);
         }
         else
         {
@@ -307,7 +307,7 @@ void TransformUIWidget(Transform& transform, EditorContext& ctx, const std::any&
         {
             auto& body = ctx.world.Get<physics::RigidBody>(self);
             scl = physics::NormalizeScaleForShape(body.GetShape().GetType(), prevScl, scl);
-            physics::SetSimulatedBodyScale(transform, body, scl, true);
+            body.SetSimulatedBodyScale(transform, scl, true);
         }
         else
         {

--- a/source/engine/ui/editor/impl/ComponentWidgets.cpp
+++ b/source/engine/ui/editor/impl/ComponentWidgets.cpp
@@ -253,9 +253,11 @@ void TagUIWidget(Tag& tag, EditorContext&, const std::any&)
 
 void TransformUIWidget(Transform& transform, EditorContext& ctx, const std::any&)
 {
+    IMGUI_SCOPE(ui::ImGuiId, "Transform");
     const auto self = ctx.selectedEntity;
     const auto decomposedMatrix = DecomposeMatrix(transform.LocalTransformationMatrix());
     auto scl = ToVector3(decomposedMatrix.scale);
+    const auto prevScl = scl;
     auto pos = ToVector3(decomposedMatrix.position);
     auto curRot = ToQuaternion(decomposedMatrix.rotation).ToEulerAngles();
     const auto prevRot = curRot;
@@ -304,6 +306,7 @@ void TransformUIWidget(Transform& transform, EditorContext& ctx, const std::any&
         if (ctx.world.Contains<physics::RigidBody>(self))
         {
             auto& body = ctx.world.Get<physics::RigidBody>(self);
+            scl = physics::NormalizeScaleForShape(body.GetShape().GetType(), prevScl, scl);
             physics::SetSimulatedBodyScale(transform, body, scl, true);
         }
         else

--- a/test/ecs/Entity_unit_tests.cpp
+++ b/test/ecs/Entity_unit_tests.cpp
@@ -127,3 +127,19 @@ TEST(Entity_unit_tests, Hash_AllValues_ReturnsExpectedHash)
     constexpr auto expected = size_t{0x00000123456789AB}; // top 4 bytes empty | index | layer | flags
     EXPECT_EQ(expected, actual);
 }
+
+TEST(Entity_unit_tests, FromHash_NoFlags_ReconstructsEntity)
+{
+    constexpr auto expectedEntity = Entity{42u, 0u, 0u};
+    constexpr auto hash = Entity::Hash{}(expectedEntity);
+    constexpr auto actualEntity = Entity::FromHash(hash);
+    EXPECT_EQ(expectedEntity, actualEntity);
+}
+
+TEST(Entity_unit_tests, FromHash_AllValues_ReconstructsEntity)
+{
+    constexpr auto expectedEntity = Entity{128u, 7u, nc::Entity::Flags::Static | nc::Entity::Flags::NoSerialize};
+    constexpr auto hash = Entity::Hash{}(expectedEntity);
+    constexpr auto actualEntity = Entity::FromHash(hash);
+    EXPECT_EQ(expectedEntity, actualEntity);
+}

--- a/test/physics2/CMakeLists.txt
+++ b/test/physics2/CMakeLists.txt
@@ -1,1 +1,27 @@
+### Shape Tests ###
+add_executable(Shape_unit_tests
+    Shape_unit_tests.cpp
+    ${NC_SOURCE_DIR}/physics2/Shape.cpp
+)
+
+target_include_directories(Shape_unit_tests
+    PRIVATE
+        ${NC_INCLUDE_DIR}
+        ${NC_SOURCE_DIR}
+)
+
+target_compile_options(Shape_unit_tests
+    PUBLIC
+        ${NC_COMPILER_FLAGS}
+)
+
+target_link_libraries(Shape_unit_tests
+    PRIVATE
+        NcMath
+        NcUtility
+        gtest_main
+)
+
+add_test(Shape_unit_tests Shape_unit_tests)
+
 add_subdirectory(jolt)

--- a/test/physics2/CMakeLists.txt
+++ b/test/physics2/CMakeLists.txt
@@ -1,4 +1,28 @@
 ### Shape Tests ###
+add_executable(Contacts_unit_tests
+    Contacts_unit_tests.cpp
+)
+
+target_include_directories(Contacts_unit_tests
+    PRIVATE
+        ${NC_INCLUDE_DIR}
+)
+
+target_compile_options(Contacts_unit_tests
+    PUBLIC
+        ${NC_COMPILER_FLAGS}
+)
+
+target_link_libraries(Contacts_unit_tests
+    PRIVATE
+        NcMath
+        NcUtility
+        gtest_main
+)
+
+add_test(Contacts_unit_tests Contacts_unit_tests)
+
+### Shape Tests ###
 add_executable(Shape_unit_tests
     Shape_unit_tests.cpp
     ${NC_SOURCE_DIR}/physics2/Shape.cpp

--- a/test/physics2/Contacts_unit_tests.cpp
+++ b/test/physics2/Contacts_unit_tests.cpp
@@ -1,0 +1,51 @@
+#include "gtest/gtest.h"
+#include "ncengine/physics/HitInfo.h"
+
+#include <algorithm>
+
+TEST(ContactsTest, InitializeWithMaxSize_hasExpectedPoints)
+{
+    constexpr auto expectedPoints = std::array{
+        nc::Vector3{1.0f, 2.0f, 3.0f},
+        nc::Vector3{4.0f, 5.0f, 6.0f},
+        nc::Vector3{7.0f, 8.0f, 9.0f},
+        nc::Vector3{10.0f, 11.0f, 12.0f}
+    };
+
+    const auto uut = nc::physics::Contacts{expectedPoints, 4};
+    const auto actualPoints = uut.GetPoints();
+    EXPECT_EQ(4, actualPoints.size());
+    EXPECT_EQ(4, uut.GetCount());
+    EXPECT_TRUE(std::ranges::equal(expectedPoints, actualPoints));
+}
+
+TEST(ContactsTest, InitializeWithPartialSize_hasExpectedPoints)
+{
+    constexpr auto expectedPoints = std::array{
+        nc::Vector3{1.0f, 2.0f, 3.0f},
+        nc::Vector3{4.0f, 5.0f, 6.0f},
+        nc::Vector3{0.0f, 0.0f, 0.0f},
+        nc::Vector3{0.0f, 0.0f, 0.0f}
+    };
+
+    const auto uut = nc::physics::Contacts{expectedPoints, 2};
+    const auto actualPoints = uut.GetPoints();
+    EXPECT_EQ(2, actualPoints.size());
+    EXPECT_EQ(2, uut.GetCount());
+
+    EXPECT_TRUE(std::ranges::equal(
+        expectedPoints.begin(),
+        expectedPoints.begin() + 2,
+        actualPoints.begin(),
+        actualPoints.end()
+    ));
+}
+
+TEST(ContactsTest, InitializeWithPartialSize_hasNoPoints)
+{
+    constexpr auto expectedPoints = std::array<nc::Vector3, 4>{};
+    const auto uut = nc::physics::Contacts{expectedPoints, 0};
+    const auto actualPoints = uut.GetPoints();
+    EXPECT_EQ(0, actualPoints.size());
+    EXPECT_EQ(0, uut.GetCount());
+}

--- a/test/physics2/Shape_unit_tests.cpp
+++ b/test/physics2/Shape_unit_tests.cpp
@@ -61,7 +61,7 @@ TEST(ShapeTest, NormalizeScaleForShape_capsule_uniformXZScaling_doesNotModify)
     constexpr auto shape = nc::physics::ShapeType::Capsule;
     const auto initialScale = nc::Vector3{0.5f, 2.0f, 0.5f};
     const auto expectedScale = nc::Vector3{1.0f, 2.0f, 1.0f};
-    auto actualScale = nc::physics::NormalizeScaleForShape(shape, nc::Vector3::One(), expectedScale);
+    auto actualScale = nc::physics::NormalizeScaleForShape(shape, initialScale, expectedScale);
     EXPECT_EQ(expectedScale, actualScale);
 }
 

--- a/test/physics2/Shape_unit_tests.cpp
+++ b/test/physics2/Shape_unit_tests.cpp
@@ -1,0 +1,89 @@
+#include "gtest/gtest.h"
+#include "ncengine/physics/Shape.h"
+
+TEST(ShapeTest, NormalizeScaleForShape_box_doesNotModify)
+{
+    constexpr auto shape = nc::physics::ShapeType::Box;
+    const auto expectedScale1 = nc::Vector3{1.0f, 1.0f, 1.0f};
+    const auto expectedScale2 = nc::Vector3{1.0f, 2.0f, 3.0f};
+    auto actualScale1 = nc::physics::NormalizeScaleForShape(shape, expectedScale2, expectedScale1);
+    auto actualScale2 = nc::physics::NormalizeScaleForShape(shape, expectedScale1, expectedScale2);
+    EXPECT_EQ(expectedScale1, actualScale1);
+    EXPECT_EQ(expectedScale2, actualScale2);
+}
+
+TEST(ShapeTest, NormalizeScaleForShape_box_zeroScale_setsToMinimumScale)
+{
+    constexpr auto shape = nc::physics::ShapeType::Box;
+    const auto badScale = nc::Vector3{0.0f, 1.0f, 1.0f};
+    const auto expectedScale = nc::Vector3{nc::physics::g_minimumShapeScale, 1.0f, 1.0f};
+    auto actualScale = nc::physics::NormalizeScaleForShape(shape, nc::Vector3::One(), badScale);
+    EXPECT_EQ(expectedScale, actualScale);
+}
+
+TEST(ShapeTest, NormalizeScaleForShape_sphere_uniformScaling_doesNotModify)
+{
+    constexpr auto shape = nc::physics::ShapeType::Sphere;
+    const auto expectedScale = nc::Vector3{3.0f, 3.0f, 3.0f};
+    auto actualScale = nc::physics::NormalizeScaleForShape(shape, nc::Vector3::One(), expectedScale);
+    EXPECT_EQ(expectedScale, actualScale);
+}
+
+TEST(ShapeTest, NormalizeScaleForShape_sphere_nonUniformScaling_fixesScale)
+{
+    constexpr auto shape = nc::physics::ShapeType::Sphere;
+    const auto initialScale = nc::Vector3::One();
+    const auto attemptScaleX = nc::Vector3{3.0f, 1.0f, 1.0f};
+    const auto attemptScaleY = nc::Vector3{1.0f, 0.5f, 1.0f};
+    const auto attemptScaleZ = nc::Vector3{1.0f, 1.0f, 10.0f};
+    const auto expectedUniformFromX = nc::Vector3::Splat(3.0f);
+    const auto expectedUniformFromY = nc::Vector3::Splat(0.5f);
+    const auto expectedUniformFromZ = nc::Vector3::Splat(10.0f);
+    const auto actualUniformFromX = nc::physics::NormalizeScaleForShape(shape, initialScale, attemptScaleX);
+    const auto actualUniformFromY = nc::physics::NormalizeScaleForShape(shape, initialScale, attemptScaleY);
+    const auto actualUniformFromZ = nc::physics::NormalizeScaleForShape(shape, initialScale, attemptScaleZ);
+    EXPECT_EQ(expectedUniformFromX, actualUniformFromX);
+    EXPECT_EQ(expectedUniformFromY, actualUniformFromY);
+    EXPECT_EQ(expectedUniformFromZ, actualUniformFromZ);
+}
+
+TEST(ShapeTest, NormalizeScaleForShape_sphere_zeroScale_fixesScale)
+{
+    constexpr auto shape = nc::physics::ShapeType::Sphere;
+    const auto badScale = nc::Vector3{1.0f, 0.0f, 1.0f};
+    const auto expectedScale = nc::Vector3::Splat(nc::physics::g_minimumShapeScale);
+    auto actualScale = nc::physics::NormalizeScaleForShape(shape, nc::Vector3::One(), badScale);
+    EXPECT_EQ(expectedScale, actualScale);
+}
+
+TEST(ShapeTest, NormalizeScaleForShape_capsule_uniformXZScaling_doesNotModify)
+{
+    constexpr auto shape = nc::physics::ShapeType::Capsule;
+    const auto initialScale = nc::Vector3{0.5f, 2.0f, 0.5f};
+    const auto expectedScale = nc::Vector3{1.0f, 2.0f, 1.0f};
+    auto actualScale = nc::physics::NormalizeScaleForShape(shape, nc::Vector3::One(), expectedScale);
+    EXPECT_EQ(expectedScale, actualScale);
+}
+
+TEST(ShapeTest, NormalizeScaleForShape_sphere_nonUniformXZScaling_fixesScale)
+{
+    constexpr auto shape = nc::physics::ShapeType::Capsule;
+    const auto initialScale = nc::Vector3{1.0f, 2.0f, 1.0f};
+    const auto attemptScaleX = nc::Vector3{3.0f, 2.0f, 1.0f};
+    const auto attemptScaleZ = nc::Vector3{1.0f, 2.0f, 0.5f};
+    const auto expectedUniformFromX = nc::Vector3{3.0f, 2.0f, 3.0f};
+    const auto expectedUniformFromZ = nc::Vector3{0.5f, 2.0f, 0.5f};
+    const auto actualUniformFromX = nc::physics::NormalizeScaleForShape(shape, initialScale, attemptScaleX);
+    const auto actualUniformFromZ = nc::physics::NormalizeScaleForShape(shape, initialScale, attemptScaleZ);
+    EXPECT_EQ(expectedUniformFromX, actualUniformFromX);
+    EXPECT_EQ(expectedUniformFromZ, actualUniformFromZ);
+}
+
+TEST(ShapeTest, NormalizeScaleForShape_capsule_zeroScale_fixesScale)
+{
+    constexpr auto shape = nc::physics::ShapeType::Capsule;
+    const auto badScale = nc::Vector3{1.0f, 1.0f, 0.0f};
+    const auto expectedScale = nc::Vector3{nc::physics::g_minimumShapeScale, 1.0f, nc::physics::g_minimumShapeScale};
+    auto actualScale = nc::physics::NormalizeScaleForShape(shape, nc::Vector3::One(), badScale);
+    EXPECT_EQ(expectedScale, actualScale);
+}

--- a/test/physics2/jolt/CMakeLists.txt
+++ b/test/physics2/jolt/CMakeLists.txt
@@ -1,7 +1,36 @@
+### ContactListener Tests ###
+add_executable(ContactListener_integration_tests
+    ContactListener_integration_tests.cpp
+    ${NC_SOURCE_DIR}/physics2/jolt/JoltApi.cpp
+    ${NC_SOURCE_DIR}/physics2/jolt/ContactListener.cpp
+)
+
+target_include_directories(ContactListener_integration_tests
+    PRIVATE
+        ${NC_INCLUDE_DIR}
+        ${NC_SOURCE_DIR}
+)
+
+target_compile_options(ContactListener_integration_tests
+    PUBLIC
+        ${NC_COMPILER_FLAGS}
+)
+
+target_link_libraries(ContactListener_integration_tests
+    PRIVATE
+        NcMath
+        NcUtility
+        Jolt
+        gtest_main
+)
+
+add_test(ContactListener_integration_tests ContactListener_integration_tests)
+
 ### JoltApi Tests ###
 add_executable(JoltApi_unit_tests
     JoltApi_unit_tests.cpp
     ${NC_SOURCE_DIR}/physics2/jolt/JoltApi.cpp
+    ${NC_SOURCE_DIR}/physics2/jolt/ContactListener.cpp
 )
 
 target_include_directories(JoltApi_unit_tests
@@ -131,9 +160,10 @@ target_link_libraries(PhysicsAllocator_unit_tests
 
 add_test(PhysicsAllocator_unit_tests PhysicsAllocator_unit_tests)
 
-### ShapeFactor Tests ###
+### ShapeFactory Tests ###
 add_executable(ShapeFactory_unit_tests
     ShapeFactory_unit_tests.cpp
+    ${NC_SOURCE_DIR}/physics2/jolt/ContactListener.cpp
     ${NC_SOURCE_DIR}/physics2/jolt/JoltApi.cpp
 )
 

--- a/test/physics2/jolt/CMakeLists.txt
+++ b/test/physics2/jolt/CMakeLists.txt
@@ -80,6 +80,7 @@ add_test(Layers_unit_tests Layers_unit_tests)
 add_executable(RigidBody_unit_tests
     RigidBody_unit_tests.cpp
     ${NC_SOURCE_DIR}/physics2/RigidBody.cpp
+    ${NC_SOURCE_DIR}/physics2/Shape.cpp
     ${NC_SOURCE_DIR}/ecs/Transform.cpp
 )
 

--- a/test/physics2/jolt/ContactListener_integration_tests.cpp
+++ b/test/physics2/jolt/ContactListener_integration_tests.cpp
@@ -1,0 +1,232 @@
+#include "gtest/gtest.h"
+#include "physics2/jolt/ContactListener.h"
+#include "physics2/jolt/JoltApi.h"
+
+#include "Jolt/Physics/Body/BodyCreationSettings.h"
+
+#include <ranges>
+
+class ContactListenerTest : public ::testing::Test
+{
+    protected:
+        ContactListenerTest()
+            : joltApi{nc::physics::JoltApi::Initialize()},
+              uut{joltApi.contactListener}
+        {
+        }
+
+    public:
+        nc::physics::JoltApi joltApi;
+        nc::physics::ContactListener& uut;
+        std::vector<nc::physics::CollisionPair> lastOnEnter;
+        std::vector<nc::physics::OverlappingPair> lastOnExit;
+
+        void Step()
+        {
+            joltApi.physicsSystem.Update(1.0f / 60.0f, 1, &joltApi.tempAllocator, &joltApi.jobSystem);
+            lastOnEnter.clear();
+            lastOnExit.clear();
+            std::ranges::copy(uut.GetAdded(), std::back_inserter(lastOnEnter));
+            std::ranges::copy(uut.GetRemoved(), std::back_inserter(lastOnExit));
+            uut.CommitPendingChanges();
+        }
+
+        auto CreateBody(nc::Entity entity,
+                        nc::physics::BodyType type,
+                        const JPH::Vec3& position,
+                        const JPH::Vec3& halfExtents) -> JPH::Body*
+        {
+            auto settings = JPH::BodyCreationSettings{
+                new JPH::BoxShape{halfExtents},
+                position,
+                JPH::Quat::sIdentity(),
+                nc::physics::ToMotionType(type),
+                nc::physics::ToObjectLayer(type)
+            };
+
+            settings.mUserData = nc::Entity::Hash{}(entity);
+            auto& interface = joltApi.physicsSystem.GetBodyInterfaceNoLock();
+            auto body = interface.CreateBody(settings);
+            interface.AddBody(body->GetID(), JPH::EActivation::Activate);
+            return body;
+        }
+
+        void DestroyBody(JPH::BodyID id)
+        {
+            auto& interface = joltApi.physicsSystem.GetBodyInterfaceNoLock();
+            interface.RemoveBody(id);
+            interface.DestroyBody(id);
+        }
+};
+
+TEST_F(ContactListenerTest, EmptyFrame_succeeds)
+{
+    Step();
+    EXPECT_EQ(0u, lastOnEnter.size());
+    EXPECT_EQ(0u, lastOnExit.size());
+}
+
+TEST_F(ContactListenerTest, InteractingObjects_generatesExpectedEvents)
+{
+    auto& interface = joltApi.physicsSystem.GetBodyInterfaceNoLock();
+
+    const auto entity1 = nc::Entity{42, 0, 0};
+    const auto entity2 = nc::Entity{100, 0, 0};
+    auto body1 = CreateBody(
+        entity1,
+        nc::physics::BodyType::Static,
+        JPH::Vec3::sReplicate(0.0f),
+        JPH::Vec3{5.0f, 0.5f, 5.0f}
+    );
+
+    auto body2 = CreateBody(
+        entity2,
+        nc::physics::BodyType::Dynamic,
+        JPH::Vec3{0.0f, 1.0f, 0.0f},
+        JPH::Vec3::sReplicate(0.5f)
+    );
+
+    // expect enter event on start
+    Step();
+    EXPECT_EQ(1u, lastOnEnter.size());
+    EXPECT_EQ(0u, lastOnExit.size());
+    const auto& enter = lastOnEnter.at(0);
+    EXPECT_TRUE(
+        (entity1 == enter.pair.first && entity2 == enter.pair.second) ||
+        (entity1 == enter.pair.second && entity2 == enter.pair.first)
+    );
+
+    // still colliding, but no events
+    Step();
+    EXPECT_EQ(0u, lastOnEnter.size());
+    EXPECT_EQ(0u, lastOnExit.size());
+
+    // expect no events on sleep
+    interface.DeactivateBody(body2->GetID());
+    Step();
+    EXPECT_EQ(0u, lastOnEnter.size());
+    EXPECT_EQ(0u, lastOnExit.size());
+
+    // expect no events on wake
+    interface.ActivateBody(body2->GetID());
+    Step();
+    EXPECT_EQ(0u, lastOnEnter.size());
+    EXPECT_EQ(0u, lastOnExit.size());
+
+    // expect exit event when moved apart
+    interface.SetPosition(body2->GetID(), JPH::Vec3{0.0f, 2.0f, 0.0f}, JPH::EActivation::Activate);
+    Step();
+    EXPECT_EQ(0u, lastOnEnter.size());
+    EXPECT_EQ(1u, lastOnExit.size());
+    const auto& exit = lastOnExit.at(0);
+    EXPECT_TRUE(
+        (entity1 == exit.first && entity2 == exit.second) ||
+        (entity1 == exit.second && entity2 == exit.first)
+    );
+
+    // expect enter event to be retriggered in near future
+    auto frames = 0;
+    while (true)
+    {
+        if (++frames > 60)
+        {
+            ADD_FAILURE() << "Objects did no collide within frame limit";
+            break;
+        }
+
+        Step();
+        EXPECT_EQ(0u, lastOnExit.size());
+        if (lastOnEnter.size() > 0)
+        {
+            EXPECT_EQ(1u, lastOnEnter.size());
+            const auto& reenter = lastOnEnter.at(0);
+            EXPECT_TRUE(
+                (entity1 == reenter.pair.first && entity2 == reenter.pair.second) ||
+                (entity1 == reenter.pair.second && entity2 == reenter.pair.first)
+            );
+
+            break;
+        }
+    }
+
+    DestroyBody(body1->GetID());
+    DestroyBody(body2->GetID());
+}
+
+TEST_F(ContactListenerTest, Events_staticVsStatic_generatesNoEvents)
+{
+    const auto entity1 = nc::Entity{42, 0, nc::Entity::Flags::Static};
+    const auto entity2 = nc::Entity{100, 0, nc::Entity::Flags::Static};
+    auto body1 = CreateBody(
+        entity1,
+        nc::physics::BodyType::Static,
+        JPH::Vec3{0.0f, 0.0f, 0.0f},
+        JPH::Vec3::sReplicate(2.0f)
+    );
+
+    auto body2 = CreateBody(
+        entity2,
+        nc::physics::BodyType::Static,
+        JPH::Vec3{0.0f, 1.0f, 0.0f},
+        JPH::Vec3::sReplicate(2.0f)
+    );
+
+    Step();
+    EXPECT_EQ(0u, lastOnEnter.size());
+    EXPECT_EQ(0u, lastOnExit.size());
+
+    DestroyBody(body1->GetID());
+    DestroyBody(body2->GetID());
+}
+
+TEST_F(ContactListenerTest, Events_noCollisionEventsVsNoCollisionEvents_generatesNoEvents)
+{
+    const auto entity1 = nc::Entity{42, 0, nc::Entity::Flags::NoCollisionNotifications};
+    const auto entity2 = nc::Entity{100, 0, nc::Entity::Flags::NoCollisionNotifications};
+    auto body1 = CreateBody(
+        entity1,
+        nc::physics::BodyType::Dynamic,
+        JPH::Vec3{0.0f, 0.0f, 0.0f},
+        JPH::Vec3::sReplicate(2.0f)
+    );
+
+    auto body2 = CreateBody(
+        entity2,
+        nc::physics::BodyType::Dynamic,
+        JPH::Vec3{0.0f, 1.0f, 0.0f},
+        JPH::Vec3::sReplicate(2.0f)
+    );
+
+    Step();
+    EXPECT_EQ(0u, lastOnEnter.size());
+    EXPECT_EQ(0u, lastOnExit.size());
+
+    DestroyBody(body1->GetID());
+    DestroyBody(body2->GetID());
+}
+
+TEST_F(ContactListenerTest, Events_staticVsNoCollisionEvents_generatesNoEvents)
+{
+    const auto entity1 = nc::Entity{42, 0, nc::Entity::Flags::Static};
+    const auto entity2 = nc::Entity{100, 0, nc::Entity::Flags::NoCollisionNotifications};
+    auto body1 = CreateBody(
+        entity1,
+        nc::physics::BodyType::Static,
+        JPH::Vec3{0.0f, 0.0f, 0.0f},
+        JPH::Vec3::sReplicate(2.0f)
+    );
+
+    auto body2 = CreateBody(
+        entity2,
+        nc::physics::BodyType::Dynamic,
+        JPH::Vec3{0.0f, 1.0f, 0.0f},
+        JPH::Vec3::sReplicate(2.0f)
+    );
+
+    Step();
+    EXPECT_EQ(0u, lastOnEnter.size());
+    EXPECT_EQ(0u, lastOnExit.size());
+
+    DestroyBody(body1->GetID());
+    DestroyBody(body2->GetID());
+}

--- a/test/physics2/jolt/JoltConversion_unit_tests.cpp
+++ b/test/physics2/jolt/JoltConversion_unit_tests.cpp
@@ -56,10 +56,3 @@ TEST(JoltConversionTest, ToMotionType_convertsBodyType)
     EXPECT_EQ(JPH::EMotionType::Static, ToMotionType(nc::physics::BodyType::Static));
     EXPECT_EQ(JPH::EMotionType::Kinematic, ToMotionType(nc::physics::BodyType::Kinematic));
 }
-
-TEST(JoltConversionTest, ToObjectLayer_convertsBodyType)
-{
-    EXPECT_EQ(nc::physics::ObjectLayer::Dynamic, ToObjectLayer(nc::physics::BodyType::Dynamic));
-    EXPECT_EQ(nc::physics::ObjectLayer::Dynamic, ToObjectLayer(nc::physics::BodyType::Kinematic));
-    EXPECT_EQ(nc::physics::ObjectLayer::Static, ToObjectLayer(nc::physics::BodyType::Static));
-}

--- a/test/physics2/jolt/RigidBody_unit_tests.cpp
+++ b/test/physics2/jolt/RigidBody_unit_tests.cpp
@@ -22,7 +22,7 @@ class NcPhysicsImpl2
 
 constexpr auto g_entity = nc::Entity{0, 0, nc::Entity::Flags::None};
 constexpr auto g_staticEntity = nc::Entity{0, 0, nc::Entity::Flags::Static};
-constexpr auto g_shape = nc::physics::Shape::Box;
+constexpr auto g_shape = nc::physics::Shape::MakeBox();
 constexpr auto g_dynamicBodyType = nc::physics::BodyType::Dynamic;
 constexpr auto g_staticBodyType = nc::physics::BodyType::Static;
 constexpr auto g_flags = nc::physics::RigidBodyFlags::ScaleWithTransform;
@@ -74,7 +74,7 @@ TEST(RigidBodyTests, TrivialGetters_returnExpectedValues)
 {
     const auto uut = nc::physics::RigidBody{g_entity, g_shape, g_dynamicBodyType, g_flags};
     EXPECT_EQ(g_entity, uut.GetEntity());
-    EXPECT_EQ(g_shape, uut.GetShape());
+    EXPECT_EQ(g_shape.GetType(), uut.GetShape().GetType());
     EXPECT_EQ(g_dynamicBodyType, uut.GetBodyType());
     EXPECT_TRUE(uut.ScalesWithTransform());
 }

--- a/test/physics2/jolt/ShapeFactory_unit_tests.cpp
+++ b/test/physics2/jolt/ShapeFactory_unit_tests.cpp
@@ -17,38 +17,6 @@ class ShapeFactoryTest : public ::testing::Test
         nc::physics::ShapeFactory uut;
 };
 
-TEST(ShapeFactoryUtilityTest, NormalizeScaleForShape_box_doesNotModify)
-{
-    constexpr auto shape = nc::physics::ShapeType::Box;
-    const auto expectedScale1 = JPH::Vec3{1.0f, 1.0f, 1.0f};
-    const auto expectedScale2 = JPH::Vec3{1.0f, 2.0f, 3.0f};
-    auto actualScale1 = expectedScale1;
-    auto actualScale2 = expectedScale2;
-    EXPECT_FALSE(nc::physics::NormalizeScaleForShape(shape, actualScale1));
-    EXPECT_FALSE(nc::physics::NormalizeScaleForShape(shape, actualScale2));
-    EXPECT_EQ(expectedScale1, actualScale1);
-    EXPECT_EQ(expectedScale2, actualScale2);
-}
-
-TEST(ShapeFactoryUtilityTest, NormalizeScaleForShape_sphere_uniformScaling_doesNotModify)
-{
-    constexpr auto shape = nc::physics::ShapeType::Sphere;
-    const auto expectedScale = JPH::Vec3{3.0f, 3.0f, 3.0f};
-    auto actualScale = expectedScale;
-    EXPECT_FALSE(nc::physics::NormalizeScaleForShape(shape, actualScale));
-    EXPECT_EQ(expectedScale, actualScale);
-}
-
-TEST(ShapeFactoryUtilityTest, NormalizeScaleForShape_sphere_nonUniformScaling_fixesScale)
-{
-    constexpr auto shape = nc::physics::ShapeType::Sphere;
-    auto actualScale = JPH::Vec3{1.0f, 2.0f, 3.0f};
-    const auto averageScale = (actualScale.GetX() + actualScale.GetY() + actualScale.GetZ()) / 3.0f;
-    const auto expectedScale = JPH::Vec3::sReplicate(averageScale);
-    EXPECT_TRUE(nc::physics::NormalizeScaleForShape(shape, actualScale));
-    EXPECT_EQ(expectedScale, actualScale);
-}
-
 TEST_F(ShapeFactoryTest, MakeShape_box_returnsBoxShape)
 {
     const auto inShape = nc::physics::Shape::MakeBox(nc::Vector3{1.0f, 2.0f, 3.0f}, nc::Vector3::Zero());
@@ -140,11 +108,4 @@ TEST_F(ShapeFactoryTest, MakeShape_sphere_withTransformScaling_returnsBoxShape)
     const auto expectedRadius = inShape.GetLocalScale().x * transformScale.x * 0.5f;
     const auto actualRadius = sphere->GetRadius();
     EXPECT_FLOAT_EQ(expectedRadius, actualRadius);
-}
-
-TEST_F(ShapeFactoryTest, MakeShape_sphere_nonUniformTransformScaling_throws)
-{
-    const auto transformScale = nc::Vector3{1.0f, 2.0f, 3.0f};
-    const auto inShape = nc::physics::Shape::MakeSphere(0.5, nc::Vector3{1.0f, 1.0f, 1.0f});
-    EXPECT_THROW(uut.MakeShape(inShape, nc::physics::ToJoltVec3(transformScale)), nc::NcError);
 }

--- a/test/physics2/jolt/ShapeFactory_unit_tests.cpp
+++ b/test/physics2/jolt/ShapeFactory_unit_tests.cpp
@@ -19,7 +19,7 @@ class ShapeFactoryTest : public ::testing::Test
 
 TEST(ShapeFactoryUtilityTest, NormalizeScaleForShape_box_doesNotModify)
 {
-    constexpr auto shape = nc::physics::Shape::Box;
+    constexpr auto shape = nc::physics::ShapeType::Box;
     const auto expectedScale1 = JPH::Vec3{1.0f, 1.0f, 1.0f};
     const auto expectedScale2 = JPH::Vec3{1.0f, 2.0f, 3.0f};
     auto actualScale1 = expectedScale1;
@@ -32,7 +32,7 @@ TEST(ShapeFactoryUtilityTest, NormalizeScaleForShape_box_doesNotModify)
 
 TEST(ShapeFactoryUtilityTest, NormalizeScaleForShape_sphere_uniformScaling_doesNotModify)
 {
-    constexpr auto shape = nc::physics::Shape::Sphere;
+    constexpr auto shape = nc::physics::ShapeType::Sphere;
     const auto expectedScale = JPH::Vec3{3.0f, 3.0f, 3.0f};
     auto actualScale = expectedScale;
     EXPECT_FALSE(nc::physics::NormalizeScaleForShape(shape, actualScale));
@@ -41,7 +41,7 @@ TEST(ShapeFactoryUtilityTest, NormalizeScaleForShape_sphere_uniformScaling_doesN
 
 TEST(ShapeFactoryUtilityTest, NormalizeScaleForShape_sphere_nonUniformScaling_fixesScale)
 {
-    constexpr auto shape = nc::physics::Shape::Sphere;
+    constexpr auto shape = nc::physics::ShapeType::Sphere;
     auto actualScale = JPH::Vec3{1.0f, 2.0f, 3.0f};
     const auto averageScale = (actualScale.GetX() + actualScale.GetY() + actualScale.GetZ()) / 3.0f;
     const auto expectedScale = JPH::Vec3::sReplicate(averageScale);
@@ -51,26 +51,100 @@ TEST(ShapeFactoryUtilityTest, NormalizeScaleForShape_sphere_nonUniformScaling_fi
 
 TEST_F(ShapeFactoryTest, MakeShape_box_returnsBoxShape)
 {
-    const auto expectedScale = JPH::Vec3{1.0f, 2.0f, 3.0f};
-    const auto shape = uut.MakeShape(nc::physics::Shape::Box, expectedScale);
+    const auto inShape = nc::physics::Shape::MakeBox(nc::Vector3{1.0f, 2.0f, 3.0f}, nc::Vector3::Zero());
+    const auto wrappedShape = uut.MakeShape(inShape, JPH::Vec3::sReplicate(1.0f));
 
-    ASSERT_EQ(JPH::EShapeType::Convex, shape->GetType());
-    ASSERT_EQ(JPH::EShapeSubType::Box, shape->GetSubType());
+    ASSERT_EQ(JPH::EShapeType::Decorated, wrappedShape->GetType());
+    ASSERT_EQ(JPH::EShapeSubType::RotatedTranslated, wrappedShape->GetSubType());
+    const auto decoratedShape = static_cast<const JPH::RotatedTranslatedShape*>(wrappedShape.GetPtr());
+    const auto innerShape = decoratedShape->GetInnerShape();
+    ASSERT_EQ(JPH::EShapeType::Convex, innerShape->GetType());
+    ASSERT_EQ(JPH::EShapeSubType::Box, innerShape->GetSubType());
+    const auto box = static_cast<const JPH::BoxShape*>(innerShape);
 
-    const auto box = static_cast<const JPH::BoxShape*>(shape.GetPtr());
-    const auto actualScale = box->GetHalfExtent() * 2.0f;
+    const auto expectedScale = inShape.GetLocalScale();
+    const auto actualScale = nc::physics::ToVector3(box->GetHalfExtent() * 2.0f);
+    EXPECT_EQ(expectedScale, actualScale);
 
+    const auto expectedPosition = inShape.GetLocalPosition();
+    const auto actualPosition = nc::physics::ToVector3(decoratedShape->GetPosition());
+    EXPECT_EQ(expectedPosition, actualPosition);
+}
+
+TEST_F(ShapeFactoryTest, MakeShape_box_withTransformScaling_returnsBoxShape)
+{
+    const auto transformScale = nc::Vector3{2.0f, 2.0f, 2.0f};
+    const auto inShape = nc::physics::Shape::MakeBox(nc::Vector3{2.0f, 2.0f, 2.0f}, nc::Vector3{0.0f, 1.0f, 0.0f});
+    const auto wrappedShape = uut.MakeShape(inShape, nc::physics::ToJoltVec3(transformScale));
+
+    ASSERT_EQ(JPH::EShapeType::Decorated, wrappedShape->GetType());
+    ASSERT_EQ(JPH::EShapeSubType::RotatedTranslated, wrappedShape->GetSubType());
+    const auto decoratedShape = static_cast<const JPH::RotatedTranslatedShape*>(wrappedShape.GetPtr());
+
+    const auto expectedPosition = nc::HadamardProduct(inShape.GetLocalPosition(), transformScale);
+    const auto actualPosition = nc::physics::ToVector3(decoratedShape->GetPosition());
+    EXPECT_EQ(expectedPosition, actualPosition);
+
+    const auto innerShape = decoratedShape->GetInnerShape();
+    ASSERT_EQ(JPH::EShapeType::Convex, innerShape->GetType());
+    ASSERT_EQ(JPH::EShapeSubType::Box, innerShape->GetSubType());
+    const auto box = static_cast<const JPH::BoxShape*>(innerShape);
+
+    const auto expectedScale = nc::HadamardProduct(inShape.GetLocalScale(), transformScale);
+    const auto actualScale = nc::physics::ToVector3(box->GetHalfExtent() * 2.0f);
     EXPECT_EQ(expectedScale, actualScale);
 }
 
 TEST_F(ShapeFactoryTest, MakeShape_sphere_returnsBoxShape)
 {
-    const auto expectedRadius = 0.75f;
-    const auto shape = uut.MakeShape(nc::physics::Shape::Sphere, JPH::Vec3::sReplicate(expectedRadius * 2.0f));
+    const auto inShape = nc::physics::Shape::MakeSphere(0.75, nc::Vector3::Zero());
+    const auto wrappedShape = uut.MakeShape(inShape, JPH::Vec3::sReplicate(1.0f));
 
-    ASSERT_EQ(JPH::EShapeType::Convex, shape->GetType());
-    ASSERT_EQ(JPH::EShapeSubType::Sphere, shape->GetSubType());
+    ASSERT_EQ(JPH::EShapeType::Decorated, wrappedShape->GetType());
+    ASSERT_EQ(JPH::EShapeSubType::RotatedTranslated, wrappedShape->GetSubType());
+    const auto decoratedShape = static_cast<const JPH::RotatedTranslatedShape*>(wrappedShape.GetPtr());
 
-    const auto sphere = static_cast<const JPH::SphereShape*>(shape.GetPtr());
-    EXPECT_FLOAT_EQ(expectedRadius, sphere->GetRadius());
+    const auto expectedPosition = inShape.GetLocalPosition();
+    const auto actualPosition = nc::physics::ToVector3(decoratedShape->GetPosition());
+    EXPECT_EQ(expectedPosition, actualPosition);
+
+    const auto innerShape = decoratedShape->GetInnerShape();
+    ASSERT_EQ(JPH::EShapeType::Convex, innerShape->GetType());
+    ASSERT_EQ(JPH::EShapeSubType::Sphere, innerShape->GetSubType());
+    const auto sphere = static_cast<const JPH::SphereShape*>(innerShape);
+
+    const auto expectedRadius = inShape.GetLocalScale().x * 0.5f;
+    const auto actualRadius = sphere->GetRadius();
+    EXPECT_FLOAT_EQ(expectedRadius, actualRadius);
+}
+
+TEST_F(ShapeFactoryTest, MakeShape_sphere_withTransformScaling_returnsBoxShape)
+{
+    const auto transformScale = nc::Vector3{2.0f, 2.0f, 2.0f};
+    const auto inShape = nc::physics::Shape::MakeSphere(0.75, nc::Vector3{1.0f, 2.0f, 3.0f});
+    const auto wrappedShape = uut.MakeShape(inShape, nc::physics::ToJoltVec3(transformScale));
+
+    ASSERT_EQ(JPH::EShapeType::Decorated, wrappedShape->GetType());
+    ASSERT_EQ(JPH::EShapeSubType::RotatedTranslated, wrappedShape->GetSubType());
+    const auto decoratedShape = static_cast<const JPH::RotatedTranslatedShape*>(wrappedShape.GetPtr());
+
+    const auto expectedPosition = nc::HadamardProduct(inShape.GetLocalPosition(), transformScale);
+    const auto actualPosition = nc::physics::ToVector3(decoratedShape->GetPosition());
+    EXPECT_EQ(expectedPosition, actualPosition);
+
+    const auto innerShape = decoratedShape->GetInnerShape();
+    ASSERT_EQ(JPH::EShapeType::Convex, innerShape->GetType());
+    ASSERT_EQ(JPH::EShapeSubType::Sphere, innerShape->GetSubType());
+    const auto sphere = static_cast<const JPH::SphereShape*>(innerShape);
+
+    const auto expectedRadius = inShape.GetLocalScale().x * transformScale.x * 0.5f;
+    const auto actualRadius = sphere->GetRadius();
+    EXPECT_FLOAT_EQ(expectedRadius, actualRadius);
+}
+
+TEST_F(ShapeFactoryTest, MakeShape_sphere_nonUniformTransformScaling_throws)
+{
+    const auto transformScale = nc::Vector3{1.0f, 2.0f, 3.0f};
+    const auto inShape = nc::physics::Shape::MakeSphere(0.5, nc::Vector3{1.0f, 1.0f, 1.0f});
+    EXPECT_THROW(uut.MakeShape(inShape, nc::physics::ToJoltVec3(transformScale)), nc::NcError);
 }


### PR DESCRIPTION
resolves #692, resolves #703, resolves #695

- Adding capsule shape
- Adding local scale + position values for shapes.
- Updating `WidgetSystem` to render wireframes based on `RigidBody` with `NC_USE_JOLT` enabled.

#707 was merged into this