### PR TITLE
Collision Events

### DIFF
--- a/include/ncengine/ecs/Entity.h
+++ b/include/ncengine/ecs/Entity.h
@@ -40,6 +40,14 @@ class Entity
         {
         }
 
+        static constexpr auto FromHash(uint64_t hash) noexcept -> Entity
+        {
+            const auto index = static_cast<Entity::index_type>((hash >> 16) & 0xFFFFFFFF);
+            const auto layer = static_cast<Entity::layer_type>((hash >> 8) & 0xFF);
+            const auto flags = static_cast<Entity::flags_type>(hash & 0xFF);
+            return Entity{index, layer, flags};
+        }
+
         static constexpr auto Null() noexcept { return Entity{}; }
         constexpr auto Valid() const noexcept { return m_index != NullIndex; }
         constexpr auto Index() const noexcept { return m_index; }
@@ -58,9 +66,9 @@ class Entity
         {
             constexpr auto operator()(const Entity& entity) const noexcept
             {
-                return static_cast<size_t>(entity.Index()) << 16
-                     | static_cast<size_t>(entity.Layer()) << 8
-                     | static_cast<size_t>(entity.Flags());
+                return static_cast<uint64_t>(entity.Index()) << 16
+                     | static_cast<uint64_t>(entity.Layer()) << 8
+                     | static_cast<uint64_t>(entity.Flags());
             }
         };
 

--- a/include/ncengine/physics/EventListeners.h
+++ b/include/ncengine/physics/EventListeners.h
@@ -1,0 +1,31 @@
+/**
+ * @file EventListener.h
+ * @copyright Jaremie Romer and McCallister Romer 2024
+ */
+#pragma once
+
+#include "HitInfo.h"
+#include "ncengine/ecs/EcsFwd.h"
+
+#include <functional>
+
+namespace nc::physics
+{
+/** @brief Callback type for collision enter events. */
+using OnCollisionEnter_t = std::function<void(Entity self,
+                                              Entity other,
+                                              const HitInfo& hit,
+                                              ecs::Ecs world)>;
+
+/** @brief Callback type for collision exit events. */
+using OnCollisionExit_t = std::function<void(Entity self,
+                                             Entity other,
+                                             ecs::Ecs world)>;
+
+/** @brief Component that receives collision event callbacks. */
+struct CollisionListener
+{
+    OnCollisionEnter_t onEnter = nullptr;
+    OnCollisionExit_t onExit = nullptr;
+};
+} // namespace nc::physics

--- a/include/ncengine/physics/EventListeners.h
+++ b/include/ncengine/physics/EventListeners.h
@@ -4,8 +4,8 @@
  */
 #pragma once
 
-#include "HitInfo.h"
 #include "ncengine/ecs/EcsFwd.h"
+#include "ncengine/physics/HitInfo.h"
 
 #include <functional>
 

--- a/include/ncengine/physics/HitInfo.h
+++ b/include/ncengine/physics/HitInfo.h
@@ -1,0 +1,48 @@
+/**
+ * @file HitInfo.h
+ * @copyright Jaremie Romer and McCallister Romer 2024
+ */
+#pragma once
+
+#include "ncengine/ecs/Entity.h"
+
+#include <array>
+#include <span>
+
+namespace nc::physics
+{
+/** @brief A list of contact points on a RigidBody. */
+class Contacts
+{
+    public:
+        explicit Contacts(const std::array<Vector3, 4>& points, size_t numPoints = 4)
+            : m_points{points},
+              m_numPoints{static_cast<uint32_t>(numPoints)}
+        {
+        }
+
+        auto GetPoints() const -> std::span<const Vector3>
+        {
+            return std::span<const Vector3>{m_points.begin(), m_numPoints};
+        }
+
+        auto GetCount() const -> uint32_t
+        {
+            return m_numPoints;
+        }
+
+    private:
+        std::array<Vector3, 4> m_points;
+        uint32_t m_numPoints;
+};
+
+/** @brief Collision event information. */
+struct HitInfo
+{
+    Vector3 offset = Vector3::Zero();
+    Vector3 normal = Vector3::Zero();
+    float depth = 0.0f;
+    Contacts contactsOnFirst;
+    Contacts contactsOnSecond;
+};
+} // namespace nc::physics

--- a/include/ncengine/type/EngineId.h
+++ b/include/ncengine/type/EngineId.h
@@ -40,6 +40,7 @@ constexpr size_t PositionClampId = 21ull;
 constexpr size_t SpotLightId = 22ull;
 constexpr size_t OrientationClampId = 23ull;
 constexpr size_t RigidBodyId = 24ull;
+constexpr size_t CollisionListenerId = 25ull;
 /** @} */
 
 /** @{ */

--- a/sample/source/scenes/PhysicsTest.cpp
+++ b/sample/source/scenes/PhysicsTest.cpp
@@ -1,4 +1,5 @@
 #include "PhysicsTest.h"
+#include "shared/GameLog.h"
 #include "shared/GameLogic.h"
 #include "shared/Prefabs.h"
 #include "shared/spawner/Spawner.h"
@@ -9,6 +10,7 @@
 #include "ncengine/graphics/SceneNavigationCamera.h"
 #include "ncengine/input/Input.h"
 #include "ncengine/physics/Constraints.h"
+#include "ncengine/physics/EventListeners.h"
 #include "ncengine/physics/NcPhysics.h"
 #include "ncengine/physics/PhysicsMaterial.h"
 #include "ncengine/physics/RigidBody.h"
@@ -340,7 +342,7 @@ class VehicleController : public FreeComponent
 auto BuildVehicle(ecs::Ecs world, physics::NcPhysics* ncPhysics) -> Entity
 {
     const auto head = world.Emplace<Entity>({
-        .scale = Vector3::Splat(2.0f),
+        .scale = Vector3::Splat(1.0f),
         .tag = "Worm Head"
     });
 
@@ -391,6 +393,15 @@ auto BuildVehicle(ecs::Ecs world, physics::NcPhysics* ncPhysics) -> Entity
     world.Emplace<physics::RigidBody>(segment1, physics::Shape::MakeBox());
     world.Emplace<physics::RigidBody>(segment2, physics::Shape::MakeBox());
     world.Emplace<physics::RigidBody>(segment3, physics::Shape::MakeBox());
+    world.Emplace<physics::CollisionListener>(
+        head,
+        [](Entity, Entity other, const physics::HitInfo&, ecs::Ecs){
+            GameLog::Log(fmt::format("Player collision enter with {}", other.Index()));
+        },
+        [](Entity, Entity other, ecs::Ecs){
+            GameLog::Log(fmt::format("Player collsion exit with {}", other.Index()));
+        }
+    );
 
     world.Emplace<physics::VelocityRestriction>(head);
     world.Emplace<physics::VelocityRestriction>(segment1);

--- a/source/engine/engine/registration/PhysicsTypes.cpp
+++ b/source/engine/engine/registration/PhysicsTypes.cpp
@@ -2,6 +2,7 @@
 #include "ncengine/physics/Collider.h"
 #include "ncengine/physics/ConcaveCollider.h"
 #include "ncengine/physics/Constraints.h"
+#include "ncengine/physics/EventListeners.h"
 #include "ncengine/physics/PhysicsBody.h"
 #include "ncengine/physics/PhysicsMaterial.h"
 #include "ncengine/physics/RigidBody.h"
@@ -93,6 +94,13 @@ void RegisterPhysicsTypes(ecs::ComponentRegistry& registry, size_t maxEntities)
         maxEntities,
         RigidBodyId,
         "RigidBody"
+    );
+
+    Register<physics::CollisionListener>(
+        registry,
+        maxEntities,
+        CollisionListenerId,
+        "CollisionListener"
     );
 }
 } // namespace nc

--- a/source/engine/physics2/CMakeLists.txt
+++ b/source/engine/physics2/CMakeLists.txt
@@ -1,5 +1,6 @@
 target_sources(${NC_ENGINE_LIB}
     PRIVATE
+        EventDispatch.cpp
         NcPhysicsImpl2.cpp
         RigidBody.cpp
         Shape.cpp

--- a/source/engine/physics2/EventDispatch.cpp
+++ b/source/engine/physics2/EventDispatch.cpp
@@ -1,0 +1,60 @@
+#include "EventDispatch.h"
+#include "jolt/ContactListener.h"
+
+#include "ncengine/ecs/Ecs.h"
+#include "ncengine/physics/EventListeners.h"
+
+namespace
+{
+void CheckDispatchOnEnter(nc::Entity target,
+                          nc::Entity other,
+                          const nc::physics::HitInfo& hit,
+                          nc::ecs::Ecs& world,
+                          nc::ecs::ComponentPool<nc::physics::CollisionListener>& pool)
+{
+    if (target.ReceivesCollisionEvents() && pool.Contains(target))
+    {
+        auto& listener = pool.Get(target);
+        if (listener.onEnter)
+        {
+            listener.onEnter(target, other, hit, world);
+        }
+    }
+}
+
+void CheckDispatchOnExit(nc::Entity target,
+                         nc::Entity other,
+                         nc::ecs::ComponentPool<nc::physics::CollisionListener>& pool,
+                         nc::ecs::Ecs& world)
+{
+    if (target.ReceivesCollisionEvents() && pool.Contains(target))
+    {
+        auto& listener = pool.Get(target);
+        if (listener.onExit)
+        {
+            listener.onExit(target, other, world);
+        }
+    }
+}
+} // anonymous namespace
+
+namespace nc::physics
+{
+void DispatchPhysicsEvents(ContactListener& events, ecs::Ecs world)
+{
+    auto& listenerPool = world.GetPool<CollisionListener>();
+    for (const auto& [pair, hit] : events.GetAdded())
+    {
+        CheckDispatchOnEnter(pair.first, pair.second, hit, world, listenerPool);
+        CheckDispatchOnEnter(pair.second, pair.first, hit, world, listenerPool);
+    }
+
+    for (const auto& [_, first, second] : events.GetRemoved())
+    {
+        CheckDispatchOnExit(first, second, listenerPool, world);
+        CheckDispatchOnExit(second, first, listenerPool, world);
+    }
+
+    events.CommitPendingChanges();
+}
+} // namespace nc::physics

--- a/source/engine/physics2/EventDispatch.h
+++ b/source/engine/physics2/EventDispatch.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "ncengine/ecs/EcsFwd.h"
+
+namespace nc::physics
+{
+class ContactListener;
+
+void DispatchPhysicsEvents(ContactListener& events, ecs::Ecs world);
+} // namespace nc::physics

--- a/source/engine/physics2/NcPhysicsImpl2.cpp
+++ b/source/engine/physics2/NcPhysicsImpl2.cpp
@@ -101,7 +101,7 @@ void NcPhysicsImpl2::OnAddRigidBody(RigidBody& body)
         ToObjectLayer(bodyType)
     };
 
-    bodySettings.mUserData = ToUserData(body.GetEntity());
+    bodySettings.mUserData = Entity::Hash{}(body.GetEntity());
     auto& iBody = m_jolt.physicsSystem.GetBodyInterfaceNoLock();
     auto apiBody = iBody.CreateBody(bodySettings);
     iBody.AddBody(apiBody->GetID(), JPH::EActivation::Activate);

--- a/source/engine/physics2/NcPhysicsImpl2.cpp
+++ b/source/engine/physics2/NcPhysicsImpl2.cpp
@@ -102,8 +102,7 @@ void NcPhysicsImpl2::OnAddRigidBody(RigidBody& body)
     };
 
     bodySettings.mUserData = ToUserData(body.GetEntity());
-
-    auto& iBody = m_jolt.physicsSystem.GetBodyInterface(); // @todo: 697 try non-locking interface
+    auto& iBody = m_jolt.physicsSystem.GetBodyInterfaceNoLock();
     auto apiBody = iBody.CreateBody(bodySettings);
     iBody.AddBody(apiBody->GetID(), JPH::EActivation::Activate);
     body.SetContext(apiBody, m_jolt.ctx.get());

--- a/source/engine/physics2/NcPhysicsImpl2.h
+++ b/source/engine/physics2/NcPhysicsImpl2.h
@@ -19,8 +19,6 @@ struct PhysicsSettings;
 
 namespace physics
 {
-using PhysicsEcsFilter = ecs::ExplicitEcs<Transform, RigidBody>;
-
 class NcPhysicsImpl2 final : public NcPhysics
 {
     public:
@@ -38,11 +36,12 @@ class NcPhysicsImpl2 final : public NcPhysics
         auto RaycastToClickables(LayerMask = LayerMaskAll) -> IClickable* override { return nullptr; }
 
     private:
-        PhysicsEcsFilter m_ecs;
+        ecs::Ecs m_ecs;
         JoltApi m_jolt;
         Connection<RigidBody&> m_onAddRigidBodyConnection;
 
         void OnAddRigidBody(RigidBody& body);
+        void SyncTransforms();
 };
 } // namespace physics
 } // namespace nc

--- a/source/engine/physics2/jolt/CMakeLists.txt
+++ b/source/engine/physics2/jolt/CMakeLists.txt
@@ -1,4 +1,5 @@
 target_sources(${NC_ENGINE_LIB}
     PRIVATE
+        ContactListener.cpp
         JoltApi.cpp
 )

--- a/source/engine/physics2/jolt/ContactListener.cpp
+++ b/source/engine/physics2/jolt/ContactListener.cpp
@@ -8,7 +8,17 @@
 
 namespace
 {
+auto FillPoints(std::array<nc::Vector3, 4>& points, const JPH::ContactPoints& source) -> size_t
+{
+    const auto count = source.size();
+    NC_ASSERT(count <= 4u, "Unexpected contact count");
+    for (auto i = 0u; i < count; ++i)
+    {
+        points[i] = nc::physics::ToVector3(source[i]);
+    }
 
+    return count;
+}
 } // anonymous namespace
 
 namespace nc::physics
@@ -50,20 +60,9 @@ void ContactListener::OnContactAdded(const JPH::Body& body1,
     }
 
     auto pointsOnFirst = std::array<Vector3, 4>{};
-    const auto numPointsOnFirst = manifold.mRelativeContactPointsOn1.size();
-    NC_ASSERT(numPointsOnFirst <= 4u, "Unexpected contact count");
-    for (auto i = 0u; i < numPointsOnFirst; ++i)
-    {
-        pointsOnFirst[i] = ToVector3(manifold.mRelativeContactPointsOn1[i]);
-    }
-
     auto pointsOnSecond = std::array<Vector3, 4>{};
-    const auto numPointsOnSecond = manifold.mRelativeContactPointsOn2.size();
-    NC_ASSERT(numPointsOnFirst <= 4u, "Unexpected contact count");
-    for (auto i = 0u; i < numPointsOnFirst; ++i)
-    {
-        pointsOnSecond[i] = ToVector3(manifold.mRelativeContactPointsOn2[i]);
-    }
+    const auto numPointsOnFirst = FillPoints(pointsOnFirst, manifold.mRelativeContactPointsOn1);
+    const auto numPointsOnSecond = FillPoints(pointsOnSecond, manifold.mRelativeContactPointsOn2);
 
     {
         auto lock = std::lock_guard{m_addedMutex};

--- a/source/engine/physics2/jolt/ContactListener.cpp
+++ b/source/engine/physics2/jolt/ContactListener.cpp
@@ -48,8 +48,8 @@ void ContactListener::OnContactAdded(const JPH::Body& body1,
 
     const auto pair = OverlappingPair{
         hash,
-        ToEntity(body1.GetUserData()),
-        ToEntity(body2.GetUserData())
+        Entity::FromHash(body1.GetUserData()),
+        Entity::FromHash(body2.GetUserData())
     };
 
     const auto firstReceivesEvents = pair.first.ReceivesCollisionEvents() && !pair.first.IsStatic();

--- a/source/engine/physics2/jolt/ContactListener.cpp
+++ b/source/engine/physics2/jolt/ContactListener.cpp
@@ -1,0 +1,130 @@
+#include "ContactListener.h"
+#include "Conversion.h"
+
+#include "Jolt/Physics/PhysicsSystem.h"
+#include "ncutility/NcError.h"
+
+#include <ranges>
+
+namespace
+{
+
+} // anonymous namespace
+
+namespace nc::physics
+{
+// note: This is called from multiple threads with all bodies locked.
+void ContactListener::OnContactAdded(const JPH::Body& body1,
+                                     const JPH::Body& body2,
+                                     const JPH::ContactManifold& manifold,
+                                     JPH::ContactSettings&)
+{
+    if (m_physicsSystem->WereBodiesInContact(body1.GetID(), body2.GetID()))
+    {
+        return; // not the first contact between bodies
+    }
+
+    const auto hash = JPH::SubShapeIDPair{
+        body1.GetID(),
+        manifold.mSubShapeID1,
+        body2.GetID(),
+        manifold.mSubShapeID2
+    }.GetHash();
+
+    if (m_pairs.contains(hash))
+    {
+        return; // ignore wake up events
+    }
+
+    const auto pair = OverlappingPair{
+        hash,
+        ToEntity(body1.GetUserData()),
+        ToEntity(body2.GetUserData())
+    };
+
+    const auto firstReceivesEvents = pair.first.ReceivesCollisionEvents() && !pair.first.IsStatic();
+    const auto secondReceivesEvents = pair.second.ReceivesCollisionEvents() && !pair.second.IsStatic();
+    if (!(firstReceivesEvents || secondReceivesEvents))
+    {
+        return; // our api doesn't allow this event to be dispatched
+    }
+
+    auto pointsOnFirst = std::array<Vector3, 4>{};
+    const auto numPointsOnFirst = manifold.mRelativeContactPointsOn1.size();
+    NC_ASSERT(numPointsOnFirst <= 4u, "Unexpected contact count");
+    for (auto i = 0u; i < numPointsOnFirst; ++i)
+    {
+        pointsOnFirst[i] = ToVector3(manifold.mRelativeContactPointsOn1[i]);
+    }
+
+    auto pointsOnSecond = std::array<Vector3, 4>{};
+    const auto numPointsOnSecond = manifold.mRelativeContactPointsOn2.size();
+    NC_ASSERT(numPointsOnFirst <= 4u, "Unexpected contact count");
+    for (auto i = 0u; i < numPointsOnFirst; ++i)
+    {
+        pointsOnSecond[i] = ToVector3(manifold.mRelativeContactPointsOn2[i]);
+    }
+
+    {
+        auto lock = std::lock_guard{m_addedMutex};
+        m_added.emplace_back(
+            pair,
+            HitInfo{
+                ToVector3(manifold.mBaseOffset),
+                ToVector3(manifold.mWorldSpaceNormal),
+                manifold.mPenetrationDepth,
+                Contacts{pointsOnFirst, numPointsOnFirst},
+                Contacts{pointsOnSecond, numPointsOnSecond}
+            }
+        );
+    }
+}
+
+// note: This called from multiple threads with all bodies locked.
+void ContactListener::OnContactRemoved(const JPH::SubShapeIDPair& pairID)
+{
+    const auto id1 = pairID.GetBody1ID();
+    const auto id2 = pairID.GetBody2ID();
+    if (m_physicsSystem->WereBodiesInContact(id1, id2))
+    {
+        return; // not the last contact between bodies
+    }
+
+    auto& interface = m_physicsSystem->GetBodyInterfaceNoLock();
+    if (interface.IsAdded(id1) && interface.IsAdded(id2))
+    {
+        if (!interface.IsActive(id1) && !interface.IsActive(id2))
+        {
+            return; // ignore sleep events
+        }
+    }
+
+    const auto pos = m_pairs.find(pairID.GetHash());
+    if (pos == m_pairs.cend())
+    {
+        return;
+    }
+
+    {
+        auto lock = std::lock_guard{m_removedMutex};
+        m_removed.push_back(pos->second);
+    }
+}
+
+void ContactListener::CommitPendingChanges()
+{
+    for (const auto& overlappinPair : m_removed)
+    {
+        m_pairs.erase(overlappinPair.hash);
+    }
+
+    m_removed.clear();
+
+    for (const auto& collisionPair : m_added)
+    {
+        m_pairs.emplace(collisionPair.pair.hash, collisionPair.pair);
+    }
+
+    m_added.clear();
+}
+} // namespace nc::physics

--- a/source/engine/physics2/jolt/ContactListener.h
+++ b/source/engine/physics2/jolt/ContactListener.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include "ncengine/physics/HitInfo.h"
+
+#include "Jolt/Jolt.h"
+#include "Jolt/Physics/Collision/ContactListener.h"
+
+#include <mutex>
+#include <span>
+#include <unordered_map>
+#include <vector>
+
+namespace JPH
+{
+class PhysicsSystem;
+} // namespace JPH
+
+namespace nc::physics
+{
+struct OverlappingPair
+{
+    uint64_t hash;
+    Entity first;
+    Entity second;
+};
+
+struct CollisionPair
+{
+    OverlappingPair pair;
+    HitInfo hit;
+};
+
+class ContactListener final : public JPH::ContactListener
+{
+    public:
+        explicit ContactListener(JPH::PhysicsSystem& physicsSystem)
+            : m_physicsSystem{&physicsSystem}
+        {
+        }
+
+        void OnContactAdded(const JPH::Body& body1,
+                            const JPH::Body& body2,
+                            const JPH::ContactManifold& manifold,
+                            JPH::ContactSettings& settings) override;
+
+        void OnContactRemoved(const JPH::SubShapeIDPair& pair) override;
+
+        auto GetAdded() const -> std::span<const CollisionPair> { return m_added; }
+        auto GetRemoved() const -> std::span<const OverlappingPair> { return m_removed; }
+        void CommitPendingChanges();
+
+    private:
+        JPH::PhysicsSystem* m_physicsSystem;
+        std::unordered_map<size_t, OverlappingPair> m_pairs;
+
+        std::vector<CollisionPair> m_added;
+        std::mutex m_addedMutex;
+
+        std::vector<OverlappingPair> m_removed;
+        std::mutex m_removedMutex;
+};
+} // namespace nc::physics

--- a/source/engine/physics2/jolt/Conversion.h
+++ b/source/engine/physics2/jolt/Conversion.h
@@ -5,6 +5,9 @@
 
 #include "DirectXMath.h"
 
+
+#include <type_traits>
+
 namespace nc::physics
 {
 inline auto ToJoltVec3(const nc::Vector3& in) -> JPH::Vec3
@@ -76,19 +79,5 @@ inline auto ToObjectLayer(BodyType bodyType) -> JPH::ObjectLayer
         case BodyType::Static:    return ObjectLayer::Static;
         default: std::unreachable();
     }
-}
-
-inline auto ToUserData(Entity entity) -> uint64_t
-{
-    auto out = uint64_t{};
-    std::memcpy(&out, &entity, sizeof(Entity));
-    return out;
-}
-
-inline auto ToEntity(uint64_t bodyUserData) -> Entity
-{
-    auto out = Entity{};
-    std::memcpy(&out, &bodyUserData, sizeof(Entity));
-    return out;
 }
 } // namespace nc::physics

--- a/source/engine/physics2/jolt/Conversion.h
+++ b/source/engine/physics2/jolt/Conversion.h
@@ -77,4 +77,18 @@ inline auto ToObjectLayer(BodyType bodyType) -> JPH::ObjectLayer
         default: std::unreachable();
     }
 }
+
+inline auto ToUserData(Entity entity) -> uint64_t
+{
+    auto out = uint64_t{};
+    std::memcpy(&out, &entity, sizeof(Entity));
+    return out;
+}
+
+inline auto ToEntity(uint64_t bodyUserData) -> Entity
+{
+    auto out = Entity{};
+    std::memcpy(&out, &bodyUserData, sizeof(Entity));
+    return out;
+}
 } // namespace nc::physics

--- a/source/engine/physics2/jolt/JoltApi.cpp
+++ b/source/engine/physics2/jolt/JoltApi.cpp
@@ -29,6 +29,7 @@ JoltApi::~JoltApi() noexcept
 }
 
 JoltApi::JoltApi()
+    : contactListener{physicsSystem}
 {
     physicsSystem.Init(
         maxBodies,
@@ -40,6 +41,7 @@ JoltApi::JoltApi()
         objectLayerPairFilter
     );
 
+    physicsSystem.SetContactListener(&contactListener);
     ctx = std::make_unique<ComponentContext>(physicsSystem.GetBodyInterface(), shapeFactory);
 }
 } // namespace nc::physics

--- a/source/engine/physics2/jolt/JoltApi.cpp
+++ b/source/engine/physics2/jolt/JoltApi.cpp
@@ -42,6 +42,6 @@ JoltApi::JoltApi()
     );
 
     physicsSystem.SetContactListener(&contactListener);
-    ctx = std::make_unique<ComponentContext>(physicsSystem.GetBodyInterface(), shapeFactory);
+    ctx = std::make_unique<ComponentContext>(physicsSystem.GetBodyInterfaceNoLock(), shapeFactory);
 }
 } // namespace nc::physics

--- a/source/engine/physics2/jolt/JoltApi.h
+++ b/source/engine/physics2/jolt/JoltApi.h
@@ -2,6 +2,7 @@
 
 #include "Allocator.h"
 #include "ComponentContext.h"
+#include "ContactListener.h"
 #include "Layers.h"
 #include "ShapeFactory.h"
 #include "ncengine/type/StableAddress.h"
@@ -46,6 +47,7 @@ struct JoltApi : public StableAddress
     ObjectLayerPairFilter objectLayerPairFilter;
     JPH::PhysicsSystem physicsSystem;
     ShapeFactory shapeFactory;
+    ContactListener contactListener;
     std::unique_ptr<ComponentContext> ctx;
 
     private:

--- a/test/ecs/Entity_unit_tests.cpp
+++ b/test/ecs/Entity_unit_tests.cpp
@@ -127,3 +127,19 @@ TEST(Entity_unit_tests, Hash_AllValues_ReturnsExpectedHash)
     constexpr auto expected = size_t{0x00000123456789AB}; // top 4 bytes empty | index | layer | flags
     EXPECT_EQ(expected, actual);
 }
+
+TEST(Entity_unit_tests, FromHash_NoFlags_ReconstructsEntity)
+{
+    constexpr auto expectedEntity = Entity{42u, 0u, 0u};
+    constexpr auto hash = Entity::Hash{}(expectedEntity);
+    constexpr auto actualEntity = Entity::FromHash(hash);
+    EXPECT_EQ(expectedEntity, actualEntity);
+}
+
+TEST(Entity_unit_tests, FromHash_AllValues_ReconstructsEntity)
+{
+    constexpr auto expectedEntity = Entity{128u, 7u, nc::Entity::Flags::Static | nc::Entity::Flags::NoSerialize};
+    constexpr auto hash = Entity::Hash{}(expectedEntity);
+    constexpr auto actualEntity = Entity::FromHash(hash);
+    EXPECT_EQ(expectedEntity, actualEntity);
+}

--- a/test/physics2/CMakeLists.txt
+++ b/test/physics2/CMakeLists.txt
@@ -1,4 +1,28 @@
 ### Shape Tests ###
+add_executable(Contacts_unit_tests
+    Contacts_unit_tests.cpp
+)
+
+target_include_directories(Contacts_unit_tests
+    PRIVATE
+        ${NC_INCLUDE_DIR}
+)
+
+target_compile_options(Contacts_unit_tests
+    PUBLIC
+        ${NC_COMPILER_FLAGS}
+)
+
+target_link_libraries(Contacts_unit_tests
+    PRIVATE
+        NcMath
+        NcUtility
+        gtest_main
+)
+
+add_test(Contacts_unit_tests Contacts_unit_tests)
+
+### Shape Tests ###
 add_executable(Shape_unit_tests
     Shape_unit_tests.cpp
     ${NC_SOURCE_DIR}/physics2/Shape.cpp

--- a/test/physics2/Contacts_unit_tests.cpp
+++ b/test/physics2/Contacts_unit_tests.cpp
@@ -1,0 +1,51 @@
+#include "gtest/gtest.h"
+#include "ncengine/physics/HitInfo.h"
+
+#include <algorithm>
+
+TEST(ContactsTest, InitializeWithMaxSize_hasExpectedPoints)
+{
+    constexpr auto expectedPoints = std::array{
+        nc::Vector3{1.0f, 2.0f, 3.0f},
+        nc::Vector3{4.0f, 5.0f, 6.0f},
+        nc::Vector3{7.0f, 8.0f, 9.0f},
+        nc::Vector3{10.0f, 11.0f, 12.0f}
+    };
+
+    const auto uut = nc::physics::Contacts{expectedPoints, 4};
+    const auto actualPoints = uut.GetPoints();
+    EXPECT_EQ(4, actualPoints.size());
+    EXPECT_EQ(4, uut.GetCount());
+    EXPECT_TRUE(std::ranges::equal(expectedPoints, actualPoints));
+}
+
+TEST(ContactsTest, InitializeWithPartialSize_hasExpectedPoints)
+{
+    constexpr auto expectedPoints = std::array{
+        nc::Vector3{1.0f, 2.0f, 3.0f},
+        nc::Vector3{4.0f, 5.0f, 6.0f},
+        nc::Vector3{0.0f, 0.0f, 0.0f},
+        nc::Vector3{0.0f, 0.0f, 0.0f}
+    };
+
+    const auto uut = nc::physics::Contacts{expectedPoints, 2};
+    const auto actualPoints = uut.GetPoints();
+    EXPECT_EQ(2, actualPoints.size());
+    EXPECT_EQ(2, uut.GetCount());
+
+    EXPECT_TRUE(std::ranges::equal(
+        expectedPoints.begin(),
+        expectedPoints.begin() + 2,
+        actualPoints.begin(),
+        actualPoints.end()
+    ));
+}
+
+TEST(ContactsTest, InitializeWithPartialSize_hasNoPoints)
+{
+    constexpr auto expectedPoints = std::array<nc::Vector3, 4>{};
+    const auto uut = nc::physics::Contacts{expectedPoints, 0};
+    const auto actualPoints = uut.GetPoints();
+    EXPECT_EQ(0, actualPoints.size());
+    EXPECT_EQ(0, uut.GetCount());
+}

--- a/test/physics2/jolt/CMakeLists.txt
+++ b/test/physics2/jolt/CMakeLists.txt
@@ -1,7 +1,36 @@
+### ContactListener Tests ###
+add_executable(ContactListener_integration_tests
+    ContactListener_integration_tests.cpp
+    ${NC_SOURCE_DIR}/physics2/jolt/JoltApi.cpp
+    ${NC_SOURCE_DIR}/physics2/jolt/ContactListener.cpp
+)
+
+target_include_directories(ContactListener_integration_tests
+    PRIVATE
+        ${NC_INCLUDE_DIR}
+        ${NC_SOURCE_DIR}
+)
+
+target_compile_options(ContactListener_integration_tests
+    PUBLIC
+        ${NC_COMPILER_FLAGS}
+)
+
+target_link_libraries(ContactListener_integration_tests
+    PRIVATE
+        NcMath
+        NcUtility
+        Jolt
+        gtest_main
+)
+
+add_test(ContactListener_integration_tests ContactListener_integration_tests)
+
 ### JoltApi Tests ###
 add_executable(JoltApi_unit_tests
     JoltApi_unit_tests.cpp
     ${NC_SOURCE_DIR}/physics2/jolt/JoltApi.cpp
+    ${NC_SOURCE_DIR}/physics2/jolt/ContactListener.cpp
 )
 
 target_include_directories(JoltApi_unit_tests
@@ -131,9 +160,10 @@ target_link_libraries(PhysicsAllocator_unit_tests
 
 add_test(PhysicsAllocator_unit_tests PhysicsAllocator_unit_tests)
 
-### ShapeFactor Tests ###
+### ShapeFactory Tests ###
 add_executable(ShapeFactory_unit_tests
     ShapeFactory_unit_tests.cpp
+    ${NC_SOURCE_DIR}/physics2/jolt/ContactListener.cpp
     ${NC_SOURCE_DIR}/physics2/jolt/JoltApi.cpp
 )
 

--- a/test/physics2/jolt/ContactListener_integration_tests.cpp
+++ b/test/physics2/jolt/ContactListener_integration_tests.cpp
@@ -42,7 +42,7 @@ class ContactListenerTest : public ::testing::Test
                 nc::physics::ToObjectLayer(type)
             };
 
-            settings.mUserData = nc::physics::ToUserData(entity);
+            settings.mUserData = nc::Entity::Hash{}(entity);
             auto& interface = joltApi.physicsSystem.GetBodyInterfaceNoLock();
             auto body = interface.CreateBody(settings);
             interface.AddBody(body->GetID(), JPH::EActivation::Activate);

--- a/test/physics2/jolt/ContactListener_integration_tests.cpp
+++ b/test/physics2/jolt/ContactListener_integration_tests.cpp
@@ -1,0 +1,230 @@
+#include "gtest/gtest.h"
+#include "physics2/jolt/ContactListener.h"
+#include "physics2/jolt/JoltApi.h"
+
+#include "Jolt/Physics/Body/BodyCreationSettings.h"
+
+#include <ranges>
+
+class ContactListenerTest : public ::testing::Test
+{
+    protected:
+        ContactListenerTest()
+            : joltApi{nc::physics::JoltApi::Initialize()},
+              uut{joltApi.contactListener}
+        {
+        }
+
+    public:
+        nc::physics::JoltApi joltApi;
+        nc::physics::ContactListener& uut;
+        std::vector<nc::physics::CollisionPair> lastOnEnter;
+        std::vector<nc::physics::OverlappingPair> lastOnExit;
+
+        void Step()
+        {
+            joltApi.physicsSystem.Update(1.0f / 60.0f, 1, &joltApi.tempAllocator, &joltApi.jobSystem);
+            lastOnEnter = std::ranges::to<std::vector>(uut.GetAdded());
+            lastOnExit = std::ranges::to<std::vector>(uut.GetRemoved());
+            uut.CommitPendingChanges();
+        }
+
+        auto CreateBody(nc::Entity entity,
+                        nc::physics::BodyType type,
+                        const JPH::Vec3& position,
+                        const JPH::Vec3& halfExtents) -> JPH::Body*
+        {
+            auto settings = JPH::BodyCreationSettings{
+                new JPH::BoxShape{halfExtents},
+                position,
+                JPH::Quat::sIdentity(),
+                nc::physics::ToMotionType(type),
+                nc::physics::ToObjectLayer(type)
+            };
+
+            settings.mUserData = nc::physics::ToUserData(entity);
+            auto& interface = joltApi.physicsSystem.GetBodyInterfaceNoLock();
+            auto body = interface.CreateBody(settings);
+            interface.AddBody(body->GetID(), JPH::EActivation::Activate);
+            return body;
+        }
+
+        void DestroyBody(JPH::BodyID id)
+        {
+            auto& interface = joltApi.physicsSystem.GetBodyInterfaceNoLock();
+            interface.RemoveBody(id);
+            interface.DestroyBody(id);
+        }
+};
+
+TEST_F(ContactListenerTest, EmptyFrame_succeeds)
+{
+    Step();
+    EXPECT_EQ(0u, lastOnEnter.size());
+    EXPECT_EQ(0u, lastOnExit.size());
+}
+
+TEST_F(ContactListenerTest, InteractingObjects_generatesExpectedEvents)
+{
+    auto& interface = joltApi.physicsSystem.GetBodyInterfaceNoLock();
+
+    const auto entity1 = nc::Entity{42, 0, 0};
+    const auto entity2 = nc::Entity{100, 0, 0};
+    auto body1 = CreateBody(
+        entity1,
+        nc::physics::BodyType::Static,
+        JPH::Vec3::sReplicate(0.0f),
+        JPH::Vec3{5.0f, 0.5f, 5.0f}
+    );
+
+    auto body2 = CreateBody(
+        entity2,
+        nc::physics::BodyType::Dynamic,
+        JPH::Vec3{0.0f, 1.0f, 0.0f},
+        JPH::Vec3::sReplicate(0.5f)
+    );
+
+    // expect enter event on start
+    Step();
+    EXPECT_EQ(1u, lastOnEnter.size());
+    EXPECT_EQ(0u, lastOnExit.size());
+    const auto& enter = lastOnEnter.at(0);
+    EXPECT_TRUE(
+        (entity1 == enter.pair.first && entity2 == enter.pair.second) ||
+        (entity1 == enter.pair.second && entity2 == enter.pair.first)
+    );
+
+    // still colliding, but no events
+    Step();
+    EXPECT_EQ(0u, lastOnEnter.size());
+    EXPECT_EQ(0u, lastOnExit.size());
+
+    // expect no events on sleep
+    interface.DeactivateBody(body2->GetID());
+    Step();
+    EXPECT_EQ(0u, lastOnEnter.size());
+    EXPECT_EQ(0u, lastOnExit.size());
+
+    // expect no events on wake
+    interface.ActivateBody(body2->GetID());
+    Step();
+    EXPECT_EQ(0u, lastOnEnter.size());
+    EXPECT_EQ(0u, lastOnExit.size());
+
+    // expect exit event when moved apart
+    interface.SetPosition(body2->GetID(), JPH::Vec3{0.0f, 2.0f, 0.0f}, JPH::EActivation::Activate);
+    Step();
+    EXPECT_EQ(0u, lastOnEnter.size());
+    EXPECT_EQ(1u, lastOnExit.size());
+    const auto& exit = lastOnExit.at(0);
+    EXPECT_TRUE(
+        (entity1 == exit.first && entity2 == exit.second) ||
+        (entity1 == exit.second && entity2 == exit.first)
+    );
+
+    // expect enter event to be retriggered in near future
+    auto frames = 0;
+    while (true)
+    {
+        if (++frames > 60)
+        {
+            ADD_FAILURE() << "Objects did no collide within frame limit";
+            break;
+        }
+
+        Step();
+        EXPECT_EQ(0u, lastOnExit.size());
+        if (lastOnEnter.size() > 0)
+        {
+            EXPECT_EQ(1u, lastOnEnter.size());
+            const auto& reenter = lastOnEnter.at(0);
+            EXPECT_TRUE(
+                (entity1 == reenter.pair.first && entity2 == reenter.pair.second) ||
+                (entity1 == reenter.pair.second && entity2 == reenter.pair.first)
+            );
+
+            break;
+        }
+    }
+
+    DestroyBody(body1->GetID());
+    DestroyBody(body2->GetID());
+}
+
+TEST_F(ContactListenerTest, Events_staticVsStatic_generatesNoEvents)
+{
+    const auto entity1 = nc::Entity{42, 0, nc::Entity::Flags::Static};
+    const auto entity2 = nc::Entity{100, 0, nc::Entity::Flags::Static};
+    auto body1 = CreateBody(
+        entity1,
+        nc::physics::BodyType::Static,
+        JPH::Vec3{0.0f, 0.0f, 0.0f},
+        JPH::Vec3::sReplicate(2.0f)
+    );
+
+    auto body2 = CreateBody(
+        entity2,
+        nc::physics::BodyType::Static,
+        JPH::Vec3{0.0f, 1.0f, 0.0f},
+        JPH::Vec3::sReplicate(2.0f)
+    );
+
+    Step();
+    EXPECT_EQ(0u, lastOnEnter.size());
+    EXPECT_EQ(0u, lastOnExit.size());
+
+    DestroyBody(body1->GetID());
+    DestroyBody(body2->GetID());
+}
+
+TEST_F(ContactListenerTest, Events_noCollisionEventsVsNoCollisionEvents_generatesNoEvents)
+{
+    const auto entity1 = nc::Entity{42, 0, nc::Entity::Flags::NoCollisionNotifications};
+    const auto entity2 = nc::Entity{100, 0, nc::Entity::Flags::NoCollisionNotifications};
+    auto body1 = CreateBody(
+        entity1,
+        nc::physics::BodyType::Dynamic,
+        JPH::Vec3{0.0f, 0.0f, 0.0f},
+        JPH::Vec3::sReplicate(2.0f)
+    );
+
+    auto body2 = CreateBody(
+        entity2,
+        nc::physics::BodyType::Dynamic,
+        JPH::Vec3{0.0f, 1.0f, 0.0f},
+        JPH::Vec3::sReplicate(2.0f)
+    );
+
+    Step();
+    EXPECT_EQ(0u, lastOnEnter.size());
+    EXPECT_EQ(0u, lastOnExit.size());
+
+    DestroyBody(body1->GetID());
+    DestroyBody(body2->GetID());
+}
+
+TEST_F(ContactListenerTest, Events_staticVsNoCollisionEvents_generatesNoEvents)
+{
+    const auto entity1 = nc::Entity{42, 0, nc::Entity::Flags::Static};
+    const auto entity2 = nc::Entity{100, 0, nc::Entity::Flags::NoCollisionNotifications};
+    auto body1 = CreateBody(
+        entity1,
+        nc::physics::BodyType::Static,
+        JPH::Vec3{0.0f, 0.0f, 0.0f},
+        JPH::Vec3::sReplicate(2.0f)
+    );
+
+    auto body2 = CreateBody(
+        entity2,
+        nc::physics::BodyType::Dynamic,
+        JPH::Vec3{0.0f, 1.0f, 0.0f},
+        JPH::Vec3::sReplicate(2.0f)
+    );
+
+    Step();
+    EXPECT_EQ(0u, lastOnEnter.size());
+    EXPECT_EQ(0u, lastOnExit.size());
+
+    DestroyBody(body1->GetID());
+    DestroyBody(body2->GetID());
+}

--- a/test/physics2/jolt/ContactListener_integration_tests.cpp
+++ b/test/physics2/jolt/ContactListener_integration_tests.cpp
@@ -24,8 +24,10 @@ class ContactListenerTest : public ::testing::Test
         void Step()
         {
             joltApi.physicsSystem.Update(1.0f / 60.0f, 1, &joltApi.tempAllocator, &joltApi.jobSystem);
-            lastOnEnter = std::ranges::to<std::vector>(uut.GetAdded());
-            lastOnExit = std::ranges::to<std::vector>(uut.GetRemoved());
+            lastOnEnter.clear();
+            lastOnExit.clear();
+            std::ranges::copy(uut.GetAdded(), std::back_inserter(lastOnEnter));
+            std::ranges::copy(uut.GetRemoved(), std::back_inserter(lastOnExit));
             uut.CommitPendingChanges();
         }
 

--- a/test/physics2/jolt/JoltConversion_unit_tests.cpp
+++ b/test/physics2/jolt/JoltConversion_unit_tests.cpp
@@ -63,3 +63,11 @@ TEST(JoltConversionTest, ToObjectLayer_convertsBodyType)
     EXPECT_EQ(nc::physics::ObjectLayer::Dynamic, ToObjectLayer(nc::physics::BodyType::Kinematic));
     EXPECT_EQ(nc::physics::ObjectLayer::Static, ToObjectLayer(nc::physics::BodyType::Static));
 }
+
+TEST(JoltConversionTest, EntityToUserData_roundTrip_preservesValue)
+{
+    const auto expectedEntity = nc::Entity{42, 1, 0};
+    const auto userData = nc::physics::ToUserData(expectedEntity);
+    const auto actualEntity = nc::physics::ToEntity(userData);
+    EXPECT_EQ(expectedEntity, actualEntity);
+}

--- a/test/physics2/jolt/JoltConversion_unit_tests.cpp
+++ b/test/physics2/jolt/JoltConversion_unit_tests.cpp
@@ -56,18 +56,3 @@ TEST(JoltConversionTest, ToMotionType_convertsBodyType)
     EXPECT_EQ(JPH::EMotionType::Static, ToMotionType(nc::physics::BodyType::Static));
     EXPECT_EQ(JPH::EMotionType::Kinematic, ToMotionType(nc::physics::BodyType::Kinematic));
 }
-
-TEST(JoltConversionTest, ToObjectLayer_convertsBodyType)
-{
-    EXPECT_EQ(nc::physics::ObjectLayer::Dynamic, ToObjectLayer(nc::physics::BodyType::Dynamic));
-    EXPECT_EQ(nc::physics::ObjectLayer::Dynamic, ToObjectLayer(nc::physics::BodyType::Kinematic));
-    EXPECT_EQ(nc::physics::ObjectLayer::Static, ToObjectLayer(nc::physics::BodyType::Static));
-}
-
-TEST(JoltConversionTest, EntityToUserData_roundTrip_preservesValue)
-{
-    const auto expectedEntity = nc::Entity{42, 1, 0};
-    const auto userData = nc::physics::ToUserData(expectedEntity);
-    const auto actualEntity = nc::physics::ToEntity(userData);
-    EXPECT_EQ(expectedEntity, actualEntity);
-}


### PR DESCRIPTION
resolves #695 

Adding collision enter/exit events. I added a new `CollisionListener` component for this because the signature is different than those in the existing `CollisionLogic`, and we may end up wanting separate components for collision/trigger events for internal reasons.