### PR TITLE
ConstraintFactory + ConstraintManager

### DIFF
--- a/cmake/FetchDependencies.cmake
+++ b/cmake/FetchDependencies.cmake
@@ -88,6 +88,7 @@ FetchContent_Declare(optick
 )
 
 # Jolt
+set(CPP_EXCEPTIONS_ENABLED ON CACHE BOOL "" FORCE)
 FetchContent_Declare(JoltPhysics
                      GIT_REPOSITORY https://github.com/jrouwe/JoltPhysics
                      GIT_TAG        v5.1.0

--- a/include/ncengine/physics/Constraints.h
+++ b/include/ncengine/physics/Constraints.h
@@ -55,7 +55,7 @@ struct OrientationClamp
     float dampingFrequency = 10.0f;
 };
 
-/** @brief The space a Constraint is applied in. */
+/** @brief The relative space of a constraint. */
 enum class ConstraintSpace : uint8_t
 {
     World,
@@ -65,22 +65,22 @@ enum class ConstraintSpace : uint8_t
 /** @brief Initialization information for a constraint that attaches two bodies with no degrees of freedom. */
 struct FixedConstraintInfo
 {
-    Vector3 point1 = Vector3::Zero();
-    Vector3 axisX1 = Vector3::Right();
-    Vector3 axisY1 = Vector3::Up();
-    Vector3 point2 = Vector3::Zero();
-    Vector3 axisX2 = Vector3::Right();
-    Vector3 axisY2 = Vector3::Up();
-    bool autoDetect = false;
-    ConstraintSpace space = ConstraintSpace::World;
+    Vector3 point1 = Vector3::Zero();               /// first body reference position
+    Vector3 axisX1 = Vector3::Right();              /// first body reference right axis
+    Vector3 axisY1 = Vector3::Up();                 /// first body reference up axis
+    Vector3 point2 = Vector3::Zero();               /// second body reference frame
+    Vector3 axisX2 = Vector3::Right();              /// second body reference right axis
+    Vector3 axisY2 = Vector3::Up();                 /// second body reference up axis
+    bool detectFromPositions = false;               /// auto calculate settings from body positions (requires ConstraintSpace::World)
+    ConstraintSpace space = ConstraintSpace::World; /// space other settings are relative to
 };
 
 /** @brief Initialization information for a constraint that attaches two bodies at a point. */
 struct PointConstraintInfo
 {
-    Vector3 point1 = Vector3::Zero();
-    Vector3 point2 = Vector3::Zero();
-    ConstraintSpace space = ConstraintSpace::World;
+    Vector3 point1 = Vector3::Zero();               /// first body constraint position
+    Vector3 point2 = Vector3::Zero();               /// second body constraint position
+    ConstraintSpace space = ConstraintSpace::World; /// space other settings are relative to
 };
 
 /** @brief Generalized constraint initialization information. */

--- a/include/ncengine/physics/Constraints.h
+++ b/include/ncengine/physics/Constraints.h
@@ -4,7 +4,9 @@
  */
 #pragma once
 
-#include "ncmath/Vector.h"
+#include "ncengine/ecs/Entity.h"
+
+#include <variant>
 
 namespace nc::physics
 {
@@ -51,5 +53,47 @@ struct OrientationClamp
     Vector3 targetOrientation = Vector3::Up();
     float dampingRatio = 0.1f;
     float dampingFrequency = 10.0f;
+};
+
+/** @brief The space a Constraint is applied in. */
+enum class ConstraintSpace : uint8_t
+{
+    World,
+    Local
+};
+
+/** @brief Initialization information for a constraint that attaches two bodies with no degrees of freedom. */
+struct FixedConstraintInfo
+{
+    Vector3 point1 = Vector3::Zero();
+    Vector3 axisX1 = Vector3::Right();
+    Vector3 axisY1 = Vector3::Up();
+    Vector3 point2 = Vector3::Zero();
+    Vector3 axisX2 = Vector3::Right();
+    Vector3 axisY2 = Vector3::Up();
+    bool autoDetect = false;
+    ConstraintSpace space = ConstraintSpace::World;
+};
+
+/** @brief Initialization information for a constraint that attaches two bodies at a point. */
+struct PointConstraintInfo
+{
+    Vector3 point1 = Vector3::Zero();
+    Vector3 point2 = Vector3::Zero();
+    ConstraintSpace space = ConstraintSpace::World;
+};
+
+/** @brief Generalized constraint initialization information. */
+using ConstraintInfo = std::variant<FixedConstraintInfo, PointConstraintInfo>;
+
+/** @brief Unique value identifying internal Constraint state. */
+using ConstraintId = uint32_t;
+
+/** @brief Information regarding an existing Constraint. */
+struct ConstraintView
+{
+    ConstraintInfo info;
+    Entity referencedEntity = Entity::Null();
+    ConstraintId id = UINT32_MAX;
 };
 } // namespace nc::physics

--- a/include/ncengine/physics/RigidBody.h
+++ b/include/ncengine/physics/RigidBody.h
@@ -6,6 +6,7 @@
 
 #include "ncengine/ecs/Component.h"
 #include "ncengine/ecs/Transform.h"
+#include "ncengine/physics/Constraints.h"
 #include "ncengine/physics/Shape.h"
 #include "ncengine/utility/MatrixUtilities.h"
 

--- a/include/ncengine/utility/Signal.h
+++ b/include/ncengine/utility/Signal.h
@@ -54,8 +54,8 @@ class Connection
 /** @brief Priority values for controlling call order from a Signal. */
 struct SignalPriority
 {
-    static constexpr size_t Highest = 0ull;
-    static constexpr size_t Lowest = std::numeric_limits<size_t>::max();
+    static constexpr size_t Lowest = 0ull;
+    static constexpr size_t Highest = std::numeric_limits<size_t>::max();
 };
 
 /** @brief An event source supporting multiple Connections. */

--- a/sample/source/scenes/PhysicsTest.cpp
+++ b/sample/source/scenes/PhysicsTest.cpp
@@ -123,9 +123,9 @@ struct FollowCamera : public graphics::Camera
 #ifdef NC_USE_JOLT
 class VehicleController : public FreeComponent
 {
-    static constexpr auto force = 150.0f;
-    static constexpr auto torqueForce = 150.0f;
-    static constexpr auto jumpForce = 400.0f;
+    static constexpr auto force = 250.0f;
+    static constexpr auto torqueForce = 250.0f;
+    static constexpr auto jumpForce = 5000.0f;
     static constexpr auto jumpCooldownTime = 0.3f;
 
     public:
@@ -389,10 +389,38 @@ auto BuildVehicle(ecs::Ecs world, physics::NcPhysics* ncPhysics) -> Entity
     world.Emplace<physics::PhysicsBody>(segment2, segment2Transform, segment2Collider, physics::PhysicsProperties{.mass = 1.0f});
     world.Emplace<physics::PhysicsBody>(segment3, segment3Transform, segment3Collider, physics::PhysicsProperties{.mass = 0.2f});
 
-    world.Emplace<physics::RigidBody>(head, physics::Shape::MakeBox());
-    world.Emplace<physics::RigidBody>(segment1, physics::Shape::MakeBox());
-    world.Emplace<physics::RigidBody>(segment2, physics::Shape::MakeBox());
-    world.Emplace<physics::RigidBody>(segment3, physics::Shape::MakeBox());
+    auto& bodyHead = world.Emplace<physics::RigidBody>(head, physics::Shape::MakeBox(), physics::RigidBodyInfo{.friction = 0.8f});
+    auto& bodyNode1 = world.Emplace<physics::RigidBody>(segment1, physics::Shape::MakeBox());
+    auto& bodyNode2 = world.Emplace<physics::RigidBody>(segment2, physics::Shape::MakeBox());
+    auto& bodyNode3 = world.Emplace<physics::RigidBody>(segment3, physics::Shape::MakeBox());
+
+    bodyHead.AddConstraint(
+        physics::PointConstraintInfo{
+            .point1 = Vector3{0.0f, -0.1f, -0.6f},
+            .point2 = Vector3{0.0f, 0.0f, 0.5f},
+            .space = physics::ConstraintSpace::Local
+        },
+        bodyNode1
+    );
+
+    bodyNode1.AddConstraint(
+        physics::PointConstraintInfo{
+            .point1 = Vector3{0.0f, -0.1f, -0.5f},
+            .point2 = Vector3{0.0f, 0.0f, 0.4f},
+            .space = physics::ConstraintSpace::Local
+        },
+        bodyNode2
+    );
+
+    bodyNode2.AddConstraint(
+        physics::PointConstraintInfo{
+            .point1 = Vector3{0.0f, -0.1f, -0.4f},
+            .point2 = Vector3{0.0f, 0.0f, 0.3f},
+            .space = physics::ConstraintSpace::Local
+        },
+        bodyNode3
+    );
+
     world.Emplace<physics::CollisionListener>(
         head,
         [](Entity, Entity other, const physics::HitInfo&, ecs::Ecs){
@@ -527,6 +555,30 @@ void BuildBridge(ecs::Ecs world, physics::NcPhysics* ncPhysics)
     world.Emplace<physics::PhysicsBody>(platform1, platform1Transform, platform1Collider, physics::PhysicsProperties{.mass = 0.0f, .isKinematic = true});
     world.Emplace<physics::PhysicsBody>(platform2, platform2Transform, platform2Collider, physics::PhysicsProperties{.mass = 0.0f, .isKinematic = true});
 
+    world.Emplace<physics::RigidBody>(
+        platform1,
+        nc::physics::Shape::MakeBox(),
+        nc::physics::RigidBodyInfo{
+            .type = physics::BodyType::Static
+        }
+    );
+
+    world.Emplace<physics::RigidBody>(
+        platform2,
+        nc::physics::Shape::MakeBox(),
+        nc::physics::RigidBodyInfo{
+            .type = physics::BodyType::Static
+        }
+    );
+
+    world.Emplace<physics::RigidBody>(
+        ramp1,
+        nc::physics::Shape::MakeBox(),
+        nc::physics::RigidBodyInfo{
+            .type = physics::BodyType::Static
+        }
+    );
+
     // Bridge
     const auto bridgeParent = world.Emplace<Entity>({.tag = "Suspension Bridge"});
     auto makePlank = [&world, bridgeParent](const Vector3& pos, const Vector3& scale)
@@ -601,6 +653,12 @@ void BuildSteps(ecs::Ecs world)
         world.Emplace<physics::PhysicsBody>(step, transform, collider);
         world.Emplace<physics::PositionClamp>(step, position, 0.1f, 2.0f);
         world.Emplace<physics::VelocityRestriction>(step, Vector3::Up(), Vector3::Zero());
+
+        world.Emplace<physics::RigidBody>(step)
+            .AddConstraint(physics::PointConstraintInfo{
+                .point1 = position,
+                .point2 = position
+            });
     };
 
     buildStep(Vector3{-29.1f, 2.0f, 40.0f}, Vector3{10.0f, 1.0f, 10.0f});
@@ -811,6 +869,7 @@ void PhysicsTest::Load(ecs::Ecs world, ModuleProvider modules)
     world.GetPool<Transform>().Reserve(140);
     world.GetPool<graphics::ToonRenderer>().Reserve(140);
     world.GetPool<physics::PhysicsBody>().Reserve(140);
+    world.GetPool<physics::RigidBody>().Reserve(140);
     world.GetPool<physics::Collider>().Reserve(140);
 
     // Vehicle

--- a/source/engine/engine/ComponentFactories.cpp
+++ b/source/engine/engine/ComponentFactories.cpp
@@ -14,6 +14,7 @@
 #include "ncengine/physics/Constraints.h"
 #include "ncengine/physics/PhysicsBody.h"
 #include "ncengine/physics/PhysicsMaterial.h"
+#include "ncengine/physics/RigidBody.h"
 
 namespace nc
 {
@@ -107,5 +108,10 @@ auto CreatePositionClamp(Entity, const std::any&) -> physics::PositionClamp
 auto CreateVelocityRestriction(Entity, const std::any&) -> physics::VelocityRestriction
 {
     return physics::VelocityRestriction{};
+}
+
+auto CreateRigidBody(Entity entity, const std::any&) -> physics::RigidBody
+{
+    return physics::RigidBody{entity};
 }
 } // namespace nc

--- a/source/engine/engine/ComponentFactories.h
+++ b/source/engine/engine/ComponentFactories.h
@@ -23,4 +23,5 @@ auto CreatePhysicsBody(Entity entity, const std::any& userData) -> physics::Phys
 auto CreatePhysicsMaterial(Entity entity, const std::any&) -> physics::PhysicsMaterial;
 auto CreatePositionClamp(Entity entity, const std::any&) -> physics::PositionClamp;
 auto CreateVelocityRestriction(Entity entity, const std::any&) -> physics::VelocityRestriction;
+auto CreateRigidBody(Entity entity, const std::any&) -> physics::RigidBody;
 } // namespace nc

--- a/source/engine/engine/registration/PhysicsTypes.cpp
+++ b/source/engine/engine/registration/PhysicsTypes.cpp
@@ -94,7 +94,8 @@ void RegisterPhysicsTypes(ecs::ComponentRegistry& registry, size_t maxEntities)
         maxEntities,
         RigidBodyId,
         "RigidBody",
-        ui::editor::RigidBodyUIWidget
+        ui::editor::RigidBodyUIWidget,
+        CreateRigidBody
     );
 
     Register<physics::CollisionListener>(

--- a/source/engine/physics/dynamics/Constraint.h
+++ b/source/engine/physics/dynamics/Constraint.h
@@ -80,10 +80,4 @@ struct PositionConstraint
     float depth;
     CollisionEventType eventType;
 };
-
-struct Constraints
-{
-    std::vector<ContactConstraint> contact;
-    std::vector<PositionConstraint> position;
-};
 } // namespace nc::physics

--- a/source/engine/physics2/CMakeLists.txt
+++ b/source/engine/physics2/CMakeLists.txt
@@ -1,5 +1,6 @@
 target_sources(${NC_ENGINE_LIB}
     PRIVATE
+        Constraints.cpp
         EventDispatch.cpp
         NcPhysicsImpl2.cpp
         PhysicsUtility.cpp

--- a/source/engine/physics2/Constraints.cpp
+++ b/source/engine/physics2/Constraints.cpp
@@ -1,0 +1,32 @@
+#include "ncengine/physics/Constraints.h"
+#include "ncengine/physics/RigidBody.h"
+#include "jolt/ConstraintManager.h"
+
+#include "Jolt/Jolt.h"
+#include "Jolt/Physics/Body/Body.h"
+
+namespace nc::physics
+{
+void Constraint::Enable(bool enabled)
+{
+    s_manager->EnableConstraint(*this, enabled);
+}
+
+void Constraint::NotifyUpdateInfo()
+{
+    s_manager->UpdateConstraint(*this);
+}
+
+void Constraint::SetConstraintTarget(RigidBody* otherBody)
+{
+    auto referencedEntity = Entity::Null();
+    auto referencedBody = &JPH::Body::sFixedToWorld;
+    if (otherBody)
+    {
+        referencedEntity = otherBody->GetEntity();
+        referencedBody = static_cast<JPH::Body*>(otherBody->GetHandle());
+    }
+
+    s_manager->UpdateConstraintTarget(*this, referencedEntity, referencedBody);
+}
+} // namespace nc::physics

--- a/source/engine/physics2/NcPhysicsImpl2.h
+++ b/source/engine/physics2/NcPhysicsImpl2.h
@@ -1,6 +1,9 @@
 #pragma once
 
 #include "jolt/JoltApi.h"
+#include "jolt/BodyManager.h"
+#include "jolt/ConstraintManager.h"
+#include "jolt/ShapeFactory.h"
 
 #include "ncengine/ecs/Ecs.h"
 #include "ncengine/physics/NcPhysics.h"
@@ -31,6 +34,7 @@ class NcPhysicsImpl2 final : public NcPhysics
 
         void Run();
         void OnBuildTaskGraph(task::UpdateTasks& update, task::RenderTasks&) override;
+        void OnBeforeSceneLoad() override;
         void Clear() noexcept override;
 
         void AddJoint(Entity , Entity, const Vector3&, const Vector3&, float = 0.2f, float = 0.0f) override {}
@@ -43,7 +47,9 @@ class NcPhysicsImpl2 final : public NcPhysics
     private:
         ecs::Ecs m_ecs;
         JoltApi m_jolt;
-        Connection<RigidBody&> m_onAddRigidBodyConnection;
+        ShapeFactory m_shapeFactory;
+        ConstraintManager m_constraintManager;
+        BodyManager m_bodyManager;
 
         void OnAddRigidBody(RigidBody& body);
         void SyncTransforms();

--- a/source/engine/physics2/RigidBody.cpp
+++ b/source/engine/physics2/RigidBody.cpp
@@ -174,12 +174,12 @@ void RigidBody::AddAngularImpulse(const Vector3& impulse)
 
 auto RigidBody::AddConstraint(const ConstraintInfo& createInfo, const RigidBody& other) -> Constraint&
 {
-    return s_ctx->constraintManager.AddConstraint(createInfo, m_self, ToBody(m_handle), other.m_self, ToBody(other.m_handle));
+    return s_ctx->constraintManager.AddConstraint(createInfo, m_self, *ToBody(m_handle), other.m_self, *ToBody(other.m_handle));
 }
 
 auto RigidBody::AddConstraint(const ConstraintInfo& createInfo) -> Constraint&
 {
-    return s_ctx->constraintManager.AddConstraint(createInfo, m_self, ToBody(m_handle), Entity::Null(), &JPH::Body::sFixedToWorld);
+    return s_ctx->constraintManager.AddConstraint(createInfo, m_self, *ToBody(m_handle));
 }
 
 void RigidBody::RemoveConstraint(ConstraintId constraintId)

--- a/source/engine/physics2/RigidBody.cpp
+++ b/source/engine/physics2/RigidBody.cpp
@@ -22,16 +22,6 @@ auto ToActivationMode(bool wake) -> JPH::EActivation
 
 namespace nc::physics
 {
-RigidBody::~RigidBody() noexcept
-{
-    if (IsInitialized())
-    {
-        const auto& id = ToBody(m_handle)->GetID();
-        m_ctx->interface.RemoveBody(id);
-        m_ctx->interface.DestroyBody(id);
-    }
-}
-
 void RigidBody::SetBodyType(BodyType type, bool wake)
 {
     if (m_self.IsStatic())
@@ -40,7 +30,7 @@ void RigidBody::SetBodyType(BodyType type, bool wake)
     }
 
     m_info.type = type;
-    m_ctx->interface.SetMotionType(ToBody(m_handle)->GetID(), ToMotionType(type), ToActivationMode(wake));
+    s_ctx->interface.SetMotionType(ToBody(m_handle)->GetID(), ToMotionType(type), ToActivationMode(wake));
 }
 
 auto RigidBody::IsAwake() const -> bool
@@ -53,11 +43,11 @@ void RigidBody::SetAwakeState(bool wake)
     const auto id = ToBody(m_handle)->GetID();
     if (wake)
     {
-        m_ctx->interface.ActivateBody(id);
+        s_ctx->interface.ActivateBody(id);
     }
     else
     {
-        m_ctx->interface.DeactivateBody(id);
+        s_ctx->interface.DeactivateBody(id);
     }
 }
 
@@ -68,8 +58,8 @@ void RigidBody::SetShape(const Shape& shape, const Vector3& transformScale, bool
         ? ToJoltVec3(NormalizeScaleForShape(m_shape.GetType(), transformScale, transformScale))
         : JPH::Vec3::sReplicate(1.0f);
 
-    const auto newShape = m_ctx->shapeFactory.MakeShape(m_shape, allowedScaling);
-    m_ctx->interface.SetShape(ToBody(m_handle)->GetID(), newShape, true, ToActivationMode(wake));
+    const auto newShape = s_ctx->shapeFactory.MakeShape(m_shape, allowedScaling);
+    s_ctx->interface.SetShape(ToBody(m_handle)->GetID(), newShape, true, ToActivationMode(wake));
 }
 
 void RigidBody::SetFriction(float friction)
@@ -99,7 +89,7 @@ void RigidBody::SetAngularDamping(float damping)
 void RigidBody::SetGravityMultiplier(float factor)
 {
     m_info.gravityMultiplier = Clamp(factor, 0.0f, RigidBodyInfo::maxGravityMultiplier);
-    m_ctx->interface.SetGravityFactor(ToBody(m_handle)->GetID(), m_info.gravityMultiplier);
+    s_ctx->interface.SetGravityFactor(ToBody(m_handle)->GetID(), m_info.gravityMultiplier);
 }
 
 void RigidBody::ScalesWithTransform(bool value)
@@ -111,7 +101,7 @@ void RigidBody::ScalesWithTransform(bool value)
 
 void RigidBody::UseContinuousDetection(bool value)
 {
-    m_ctx->interface.SetMotionQuality(ToBody(m_handle)->GetID(), ToMotionQuality(value));
+    s_ctx->interface.SetMotionQuality(ToBody(m_handle)->GetID(), ToMotionQuality(value));
     m_info.flags = value
         ? m_info.flags | RigidBodyFlags::ContinuousDetection
         : m_info.flags & ~RigidBodyFlags::ContinuousDetection;
@@ -124,12 +114,12 @@ auto RigidBody::GetLinearVelocity() const -> Vector3
 
 void RigidBody::SetLinearVelocity(const Vector3& velocity)
 {
-    m_ctx->interface.SetLinearVelocity(ToBody(m_handle)->GetID(), ToJoltVec3(velocity));
+    s_ctx->interface.SetLinearVelocity(ToBody(m_handle)->GetID(), ToJoltVec3(velocity));
 }
 
 void RigidBody::AddLinearVelocity(const Vector3& velocity)
 {
-    m_ctx->interface.AddLinearVelocity(ToBody(m_handle)->GetID(), ToJoltVec3(velocity));
+    s_ctx->interface.AddLinearVelocity(ToBody(m_handle)->GetID(), ToJoltVec3(velocity));
 }
 
 auto RigidBody::GetAngularVelocity() const -> Vector3
@@ -139,47 +129,67 @@ auto RigidBody::GetAngularVelocity() const -> Vector3
 
 void RigidBody::SetAngularVelocity(const Vector3& velocity)
 {
-    m_ctx->interface.SetAngularVelocity(ToBody(m_handle)->GetID(), ToJoltVec3(velocity));
+    s_ctx->interface.SetAngularVelocity(ToBody(m_handle)->GetID(), ToJoltVec3(velocity));
 }
 
 void RigidBody::SetVelocities(const Vector3& linearVelocity, const Vector3& angularVelocity)
 {
-    m_ctx->interface.SetLinearAndAngularVelocity(ToBody(m_handle)->GetID(), ToJoltVec3(linearVelocity), ToJoltVec3(angularVelocity));
+    s_ctx->interface.SetLinearAndAngularVelocity(ToBody(m_handle)->GetID(), ToJoltVec3(linearVelocity), ToJoltVec3(angularVelocity));
 }
 
 void RigidBody::AddVelocities(const Vector3& linearVelocity, const Vector3& angularVelocity)
 {
-    m_ctx->interface.AddLinearAndAngularVelocity(ToBody(m_handle)->GetID(), ToJoltVec3(linearVelocity), ToJoltVec3(angularVelocity));
+    s_ctx->interface.AddLinearAndAngularVelocity(ToBody(m_handle)->GetID(), ToJoltVec3(linearVelocity), ToJoltVec3(angularVelocity));
 }
 
 void RigidBody::AddForce(const Vector3& force)
 {
-    m_ctx->interface.AddForce(ToBody(m_handle)->GetID(), ToJoltVec3(force));
+    s_ctx->interface.AddForce(ToBody(m_handle)->GetID(), ToJoltVec3(force));
 }
 
 void RigidBody::AddForceAt(const Vector3& force, const Vector3& point)
 {
-    m_ctx->interface.AddForce(ToBody(m_handle)->GetID(), ToJoltVec3(force), ToJoltVec3(point));
+    s_ctx->interface.AddForce(ToBody(m_handle)->GetID(), ToJoltVec3(force), ToJoltVec3(point));
 }
 
 void RigidBody::AddTorque(const Vector3& torque)
 {
-    m_ctx->interface.AddTorque(ToBody(m_handle)->GetID(), ToJoltVec3(torque));
+    s_ctx->interface.AddTorque(ToBody(m_handle)->GetID(), ToJoltVec3(torque));
 }
 
 void RigidBody::AddImpulse(const Vector3& impulse)
 {
-    m_ctx->interface.AddImpulse(ToBody(m_handle)->GetID(), ToJoltVec3(impulse));
+    s_ctx->interface.AddImpulse(ToBody(m_handle)->GetID(), ToJoltVec3(impulse));
 }
 
 void RigidBody::AddImpulseAt(const Vector3& impulse, const Vector3& point)
 {
-    m_ctx->interface.AddImpulse(ToBody(m_handle)->GetID(), ToJoltVec3(impulse), ToJoltVec3(point));
+    s_ctx->interface.AddImpulse(ToBody(m_handle)->GetID(), ToJoltVec3(impulse), ToJoltVec3(point));
 }
 
 void RigidBody::AddAngularImpulse(const Vector3& impulse)
 {
-    m_ctx->interface.AddAngularImpulse(ToBody(m_handle)->GetID(), ToJoltVec3(impulse));
+    s_ctx->interface.AddAngularImpulse(ToBody(m_handle)->GetID(), ToJoltVec3(impulse));
+}
+
+auto RigidBody::AddConstraint(const ConstraintInfo& createInfo, const RigidBody& other) -> Constraint&
+{
+    return s_ctx->constraintManager.AddConstraint(createInfo, m_self, ToBody(m_handle), other.m_self, ToBody(other.m_handle));
+}
+
+auto RigidBody::AddConstraint(const ConstraintInfo& createInfo) -> Constraint&
+{
+    return s_ctx->constraintManager.AddConstraint(createInfo, m_self, ToBody(m_handle), Entity::Null(), &JPH::Body::sFixedToWorld);
+}
+
+void RigidBody::RemoveConstraint(ConstraintId constraintId)
+{
+    s_ctx->constraintManager.RemoveConstraint(constraintId);
+}
+
+auto RigidBody::GetConstraints() -> std::span<Constraint>
+{
+    return s_ctx->constraintManager.GetConstraints(m_self);
 }
 
 void RigidBody::SetSimulatedBodyPosition(Transform& transform,
@@ -187,7 +197,7 @@ void RigidBody::SetSimulatedBodyPosition(Transform& transform,
                                          bool wake)
 {
     transform.SetPosition(position);
-    m_ctx->interface.SetPosition(ToBody(m_handle)->GetID(), ToJoltVec3(position), ToActivationMode(wake));
+    s_ctx->interface.SetPosition(ToBody(m_handle)->GetID(), ToJoltVec3(position), ToActivationMode(wake));
 }
 
 void RigidBody::SetSimulatedBodyRotation(Transform& transform,
@@ -195,7 +205,7 @@ void RigidBody::SetSimulatedBodyRotation(Transform& transform,
                                          bool wake)
 {
     transform.SetRotation(rotation);
-    m_ctx->interface.SetRotation(ToBody(m_handle)->GetID(), ToJoltQuaternion(rotation), ToActivationMode(wake));
+    s_ctx->interface.SetRotation(ToBody(m_handle)->GetID(), ToJoltQuaternion(rotation), ToActivationMode(wake));
 }
 
 auto RigidBody::SetSimulatedBodyScale(Transform& transform,
@@ -206,17 +216,11 @@ auto RigidBody::SetSimulatedBodyScale(Transform& transform,
     if (ScalesWithTransform())
     {
         appliedScale = NormalizeScaleForShape(m_shape.GetType(), transform.Scale(), scale);
-        const auto newShape = m_ctx->shapeFactory.MakeShape(m_shape, ToJoltVec3(appliedScale));
-        m_ctx->interface.SetShape(ToBody(m_handle)->GetID(), newShape, true, ToActivationMode(wake));
+        const auto newShape = s_ctx->shapeFactory.MakeShape(m_shape, ToJoltVec3(appliedScale));
+        s_ctx->interface.SetShape(ToBody(m_handle)->GetID(), newShape, true, ToActivationMode(wake));
     }
 
     transform.SetScale(appliedScale);
     return appliedScale;
-}
-
-void RigidBody::SetContext(BodyHandle handle, ComponentContext* ctx)
-{
-    m_handle = handle;
-    m_ctx = ctx;
 }
 } // namespace nc::physics

--- a/source/engine/physics2/Shape.cpp
+++ b/source/engine/physics2/Shape.cpp
@@ -21,16 +21,23 @@ void FixSphereScale(const nc::Vector3& current, nc::Vector3& desired)
         desired = nc::Vector3::Splat(desired.x);
     else if (!nc::FloatEqual(current.y, desired.y))
         desired = nc::Vector3::Splat(desired.y);
-    else
+    else if (!nc::FloatEqual(current.z, desired.z))
         desired = nc::Vector3::Splat(desired.z);
+
+    const auto avg = (desired.x + desired.y + desired.z) / 3.0f;
+    desired = nc::Vector3::Splat(avg);
 }
 
 void FixCapsuleScale(const nc::Vector3& current, nc::Vector3& desired)
 {
     if (!nc::FloatEqual(current.x, desired.x))
         desired.z = desired.x;
-    else
+    else if (!nc::FloatEqual(current.z, desired.z))
         desired.x = desired.z;
+
+    const auto avg = (desired.x + desired.z) / 2.0f;
+    desired.x = avg;
+    desired.z = avg;
 }
 } // anonymous namespace
 

--- a/source/engine/physics2/jolt/BodyFactory.cpp
+++ b/source/engine/physics2/jolt/BodyFactory.cpp
@@ -1,0 +1,58 @@
+#include "BodyFactory.h"
+#include "Conversion.h"
+#include "ShapeFactory.h"
+#include "ncengine/physics/RigidBody.h"
+
+#include "Jolt/Jolt.h"
+#include "Jolt/Physics/Body/BodyCreationSettings.h"
+#include "Jolt/Physics/Body/BodyInterface.h"
+
+namespace nc::physics
+{
+BodyFactory::BodyFactory(JPH::BodyInterface& bodyInterface,
+                         ShapeFactory& shapeFactory)
+    : m_interface{&bodyInterface},
+      m_shapeFactory{&shapeFactory}
+{
+}
+
+auto BodyFactory::MakeBody(const RigidBody& rigidBody, DirectX::FXMMATRIX transform) -> BodyResult
+{
+    const auto [initScale, initRotation, initPosition] = DecomposeMatrix(transform);
+    const auto& shape = rigidBody.GetShape();
+    const auto bodyType = rigidBody.GetBodyType();
+    auto allowedScaling = Vector3::One();
+    auto wasScaleAdjusted = false;
+    if (rigidBody.ScalesWithTransform())
+    {
+        const auto currentScale = nc::ToVector3(initScale);
+        allowedScaling = NormalizeScaleForShape(shape.GetType(), currentScale, currentScale);
+        if (allowedScaling != currentScale)
+        {
+            wasScaleAdjusted = true;
+        }
+    }
+
+    auto bodySettings = JPH::BodyCreationSettings{
+        m_shapeFactory->MakeShape(shape, ToJoltVec3(allowedScaling)),
+        ToJoltVec3(initPosition),
+        ToJoltQuaternion(initRotation),
+        ToMotionType(bodyType),
+        ToObjectLayer(bodyType)
+    };
+
+    bodySettings.mUserData = Entity::Hash{}(rigidBody.GetEntity());
+    bodySettings.mMotionQuality = ToMotionQuality(rigidBody.UseContinuousDetection());
+    bodySettings.mFriction = rigidBody.GetFriction();
+    bodySettings.mRestitution = rigidBody.GetRestitution();
+    bodySettings.mLinearDamping = rigidBody.GetLinearDamping();
+    bodySettings.mAngularDamping = rigidBody.GetAngularDamping();
+    bodySettings.mGravityFactor = rigidBody.GetGravityMultiplier();
+
+    return BodyResult{
+        m_interface->CreateBody(bodySettings),
+        allowedScaling,
+        wasScaleAdjusted
+    };
+}
+} // namespace nc::physics

--- a/source/engine/physics2/jolt/BodyFactory.h
+++ b/source/engine/physics2/jolt/BodyFactory.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "ncengine/utility/MatrixUtilities.h"
+
+namespace JPH
+{
+class Body;
+class BodyInterface;
+} // namespace JPH
+
+namespace nc::physics
+{
+class ShapeFactory;
+class RigidBody;
+
+struct BodyResult
+{
+    JPH::Body* body = nullptr;
+    Vector3 adjustedScale = Vector3::One();
+    bool wasScaleAdjusted = false;
+};
+
+class BodyFactory
+{
+    public:
+        explicit BodyFactory(JPH::BodyInterface& bodyInterface,
+                             ShapeFactory& shapeFactory);
+
+        auto MakeBody(const RigidBody& rigidBody,
+                      DirectX::FXMMATRIX transform) -> BodyResult;
+
+    private:
+        JPH::BodyInterface* m_interface;
+        ShapeFactory* m_shapeFactory;
+};
+} // namespace nc::physics

--- a/source/engine/physics2/jolt/BodyManager.cpp
+++ b/source/engine/physics2/jolt/BodyManager.cpp
@@ -1,0 +1,89 @@
+#include "BodyManager.h"
+#include "Conversion.h"
+#include "ComponentContext.h"
+#include "ConstraintManager.h"
+#include "ncengine/physics/RigidBody.h"
+#include "ncengine/utility/Signal.h"
+
+#include "Jolt/Physics/PhysicsSystem.h"
+
+namespace nc::physics
+{
+struct BodyManager::Connections
+{
+    static auto Connect(BodyManager* manager, ecs::ComponentPool<RigidBody>& pool)
+    {
+        return std::make_unique<Connections>(
+            pool.OnAdd().Connect(manager, &BodyManager::AddBody),
+            pool.OnRemove().Connect(manager, &BodyManager::RemoveBody)
+        );
+    }
+
+    Connection<RigidBody&> addRigidBodyConnection;
+    Connection<Entity> removeRigidBodyConnection;
+};
+
+BodyManager::BodyManager(ecs::ComponentPool<Transform>& transformPool,
+                         ecs::ComponentPool<RigidBody>& rigidBodyPool,
+                         uint32_t maxEntities,
+                         JPH::PhysicsSystem& physicsSystem,
+                         ShapeFactory& shapeFactory,
+                         ConstraintManager& constraintManager)
+    : m_transformPool{&transformPool},
+      m_bodies{std::min(BodyMapSizeHint, maxEntities), maxEntities},
+      m_bodyFactory{physicsSystem.GetBodyInterfaceNoLock(), shapeFactory},
+      m_constraintManager{&constraintManager},
+      m_ctx{std::make_unique<ComponentContext>(
+          physicsSystem.GetBodyInterfaceNoLock(),
+          shapeFactory,
+          constraintManager
+      )},
+      m_connections{Connections::Connect(this, rigidBodyPool)}
+{
+    RigidBody::SetContext(m_ctx.get());
+}
+
+BodyManager::~BodyManager() noexcept = default;
+
+void BodyManager::AddBody(RigidBody& added)
+{
+    auto& transform = m_transformPool->Get(added.GetEntity());
+    auto [handle, adjustedScale, wasScaleAdjusted] = m_bodyFactory.MakeBody(added, transform.TransformationMatrix());
+    if (wasScaleAdjusted)
+    {
+        transform.SetScale(adjustedScale);
+    }
+
+    m_ctx->interface.AddBody(handle->GetID(), JPH::EActivation::Activate);
+    added.SetHandle(handle);
+    m_bodies.emplace(added.GetEntity().Index(), handle->GetID());
+}
+
+void BodyManager::RemoveBody(Entity toRemove)
+{
+    if (m_deferCleanup)
+    {
+        return;
+    }
+
+    const auto bodyId = m_bodies.at(toRemove.Index());
+    m_bodies.erase(toRemove.Index());
+    m_constraintManager->RemoveConstraints(toRemove);
+    m_ctx->interface.RemoveBody(bodyId);
+    m_ctx->interface.DestroyBody(bodyId);
+}
+
+void BodyManager::Clear()
+{
+    const auto ids = m_bodies.values();
+    const auto size = static_cast<int>(ids.size());
+    if (size == 0)
+    {
+        return; // Jolt asserts size != 0 instead of just returning...
+    }
+
+    m_ctx->interface.RemoveBodies(ids.data(), size);
+    m_ctx->interface.DestroyBodies(ids.data(), size);
+    m_bodies.clear();
+}
+} // namespace nc::physics

--- a/source/engine/physics2/jolt/BodyManager.h
+++ b/source/engine/physics2/jolt/BodyManager.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include "BodyFactory.h"
+#include "ncengine/ecs/Ecs.h"
+#include "ncengine/ecs/Transform.h"
+#include "ncengine/physics/RigidBody.h"
+#include "ncengine/utility/SparseMap.h"
+
+#include "Jolt/Jolt.h"
+#include "Jolt/Physics/Body/BodyID.h"
+
+#include <memory>
+#include <span>
+
+namespace JPH
+{
+class PhysicsSystem;
+} // namespace JPH
+
+namespace nc::physics
+{
+struct ComponentContext;
+class ConstraintManager;
+class ShapeFactory;
+
+class BodyManager : public StableAddress
+{
+    public:
+        static constexpr auto BodyMapSizeHint = 1000u;
+
+        BodyManager(ecs::ComponentPool<Transform>& transformPool,
+                    ecs::ComponentPool<RigidBody>& rigidBodyPool,
+                    uint32_t maxEntities,
+                    JPH::PhysicsSystem& physicsSystem,
+                    ShapeFactory& shapeFactory,
+                    ConstraintManager& constraintManager);
+
+        ~BodyManager() noexcept;
+
+        void AddBody(RigidBody& added);
+        void RemoveBody(Entity entity);
+        void Clear();
+        void DeferCleanup(bool value)
+        {
+            m_deferCleanup = value;
+        }
+
+    private:
+        struct Connections;
+
+        ecs::ComponentPool<Transform>* m_transformPool;
+        sparse_map<JPH::BodyID> m_bodies;
+        BodyFactory m_bodyFactory;
+        ConstraintManager* m_constraintManager;
+        std::unique_ptr<ComponentContext> m_ctx;
+        std::unique_ptr<Connections> m_connections;
+        bool m_deferCleanup = false;
+};
+} // namespace nc::physics

--- a/source/engine/physics2/jolt/CMakeLists.txt
+++ b/source/engine/physics2/jolt/CMakeLists.txt
@@ -1,6 +1,8 @@
 target_sources(${NC_ENGINE_LIB}
     PRIVATE
         ContactListener.cpp
+        ConstraintFactory.cpp
+        ConstraintManager.cpp
         JobSystem.cpp
         JoltApi.cpp
 )

--- a/source/engine/physics2/jolt/CMakeLists.txt
+++ b/source/engine/physics2/jolt/CMakeLists.txt
@@ -1,5 +1,7 @@
 target_sources(${NC_ENGINE_LIB}
     PRIVATE
+        BodyFactory.cpp
+        BodyManager.cpp
         ContactListener.cpp
         ConstraintFactory.cpp
         ConstraintManager.cpp

--- a/source/engine/physics2/jolt/ComponentContext.h
+++ b/source/engine/physics2/jolt/ComponentContext.h
@@ -1,7 +1,9 @@
 #pragma once
 
+#include "ConstraintManager.h"
 #include "ShapeFactory.h"
 
+#include "Jolt/Jolt.h"
 #include "Jolt/Physics/Body/BodyInterface.h"
 
 namespace nc::physics
@@ -10,5 +12,6 @@ struct ComponentContext
 {
     JPH::BodyInterface& interface;
     ShapeFactory& shapeFactory;
+    ConstraintManager& constraintManager;
 };
 } // namespace nc::physics

--- a/source/engine/physics2/jolt/ConstraintFactory.cpp
+++ b/source/engine/physics2/jolt/ConstraintFactory.cpp
@@ -1,0 +1,62 @@
+#include "ConstraintFactory.h"
+#include "Conversion.h"
+
+#include "Jolt/Jolt.h"
+#include "Jolt/Physics/Constraints/FixedConstraint.h"
+#include "Jolt/Physics/Constraints/PointConstraint.h"
+#include "Jolt/Physics/PhysicsSystem.h"
+
+namespace
+{
+using namespace nc::physics;
+
+auto MakeConstraint(const FixedConstraintInfo& info,
+                    JPH::Body& first,
+                    JPH::Body& second) -> JPH::Constraint*
+{
+    auto settings = JPH::FixedConstraintSettings{};
+    settings.mSpace = ToConstraintSpace(info.space);
+    if (info.autoDetect)
+    {
+        settings.mAutoDetectPoint = true;
+    }
+    else
+    {
+        settings.mPoint1 = ToJoltVec3(info.point1);
+        settings.mAxisX1 = ToJoltVec3(info.axisX1);
+        settings.mAxisY1 = ToJoltVec3(info.axisY1);
+        settings.mPoint2 = ToJoltVec3(info.point2);
+        settings.mAxisX2 = ToJoltVec3(info.axisX2);
+        settings.mAxisY2 = ToJoltVec3(info.axisY2);
+    }
+
+    return settings.Create(first, second);
+}
+
+auto MakeConstraint(const PointConstraintInfo& info,
+                    JPH::Body& first,
+                    JPH::Body& second) -> JPH::Constraint*
+{
+    auto settings = JPH::PointConstraintSettings{};
+    settings.mSpace = ToConstraintSpace(info.space);
+    settings.mPoint1 = ToJoltVec3(info.point1);
+    settings.mPoint2 = ToJoltVec3(info.point2);
+    return settings.Create(first, second);
+}
+} // anonymous namespace
+
+namespace nc::physics
+{
+auto ConstraintFactory::MakeConstraint(const ConstraintInfo& createInfo,
+                                       JPH::Body& first,
+                                       JPH::Body& second) -> JPH::Constraint*
+{
+    return std::visit(
+        [&first, &second](auto&& unpacked)
+        {
+            return ::MakeConstraint(unpacked, first, second);
+        },
+        createInfo
+    );
+}
+} // namespace nc::physics

--- a/source/engine/physics2/jolt/ConstraintFactory.cpp
+++ b/source/engine/physics2/jolt/ConstraintFactory.cpp
@@ -16,8 +16,9 @@ auto MakeConstraint(const FixedConstraintInfo& info,
 {
     auto settings = JPH::FixedConstraintSettings{};
     settings.mSpace = ToConstraintSpace(info.space);
-    if (info.autoDetect)
+    if (info.detectFromPositions)
     {
+        NC_ASSERT(info.space == ConstraintSpace::World, "FixedConstraintInfo::detectFromPositions requires ConstraintSpace::World");
         settings.mAutoDetectPoint = true;
     }
     else

--- a/source/engine/physics2/jolt/ConstraintFactory.h
+++ b/source/engine/physics2/jolt/ConstraintFactory.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "ncengine/physics/Constraints.h"
+
+namespace JPH
+{
+class Body;
+class Constraint;
+class PhysicsSystem;
+} // namespace JPH
+
+namespace nc::physics
+{
+class ConstraintFactory
+{
+    public:
+        explicit ConstraintFactory(JPH::PhysicsSystem& physicsSystem)
+            : m_physicsSystem{&physicsSystem}
+        {
+        }
+
+        auto MakeConstraint(const ConstraintInfo& createInfo,
+                            JPH::Body& first,
+                            JPH::Body& second) -> JPH::Constraint*;
+
+    private:
+        JPH::PhysicsSystem* m_physicsSystem;
+};
+} // namespace nc::physics

--- a/source/engine/physics2/jolt/ConstraintManager.cpp
+++ b/source/engine/physics2/jolt/ConstraintManager.cpp
@@ -1,0 +1,147 @@
+#include "ConstraintManager.h"
+
+#include "Jolt/Jolt.h"
+#include "Jolt/Physics/PhysicsSystem.h"
+
+namespace
+{
+void UntrackConstraint(nc::physics::EntityConstraints& state, nc::physics::ConstraintId constraintId, bool isOwner)
+{
+    auto idPos = std::ranges::find(state.ids, constraintId);
+    NC_ASSERT(idPos != state.ids.cend(), "ConstraintId not found");
+    *idPos = state.ids.back();
+    state.ids.pop_back();
+    if (!isOwner)
+    {
+        return;
+    }
+
+    auto infoPos = std::ranges::find(state.views, constraintId, &nc::physics::ConstraintView::id);
+    NC_ASSERT(infoPos != state.views.cend(), "ConstraintView not found");
+    state.views.erase(infoPos);
+}
+} // anonymous namespace
+
+namespace nc::physics
+{
+auto ConstraintManager::AddConstraint(const ConstraintInfo& createInfo,
+                                      Entity owner,
+                                      JPH::Body* ownerBody,
+                                      Entity referenced,
+                                      JPH::Body* referencedBody) -> ConstraintId
+{
+    auto handle = m_factory.MakeConstraint(createInfo, *ownerBody, *referencedBody);
+    m_physicsSystem->AddConstraint(handle);
+
+    const auto ownerId = owner.Index();
+    const auto referencedId = referenced.Index();
+    const auto index = [&]()
+    {
+        if (m_freeIndices.empty())
+        {
+            const auto index = static_cast<uint32_t>(m_handles.size());
+            m_handles.push_back(handle);
+            m_pairs.emplace_back(ownerId, referencedId);
+            return index;
+        }
+
+        const auto index = m_freeIndices.back();
+        m_freeIndices.pop_back();
+        m_handles[index] = handle;
+        m_pairs[index] = ConstraintPair{ownerId, referencedId};
+        return index;
+    }();
+
+    auto& ownerState = m_entityState.contains(ownerId)
+        ? m_entityState.at(ownerId)
+        : m_entityState.emplace(ownerId, EntityConstraints{});
+
+    ownerState.ids.emplace_back(index);
+    ownerState.views.emplace_back(createInfo, referenced, index);
+
+    if (referenced.Valid())
+    {
+        auto& referencedState = m_entityState.contains(referencedId)
+            ? m_entityState.at(referencedId)
+            : m_entityState.emplace(referencedId, EntityConstraints{});
+
+        referencedState.ids.emplace_back(index);
+    }
+
+    return index;
+}
+
+void ConstraintManager::RemoveConstraint(ConstraintId constraintId)
+{
+    const auto handle = std::exchange(m_handles.at(constraintId), nullptr);
+    NC_ASSERT(handle, "Bad ConstraintId");
+    m_physicsSystem->RemoveConstraint(handle);
+    const auto [owner, referenced] = std::exchange(m_pairs.at(constraintId), ConstraintPair{});
+    m_freeIndices.push_back(constraintId);
+    UntrackConstraint(m_entityState.at(owner), constraintId, true);
+    if (referenced != Entity::NullIndex)
+    {
+        UntrackConstraint(m_entityState.at(referenced), constraintId, false);
+    }
+}
+
+void ConstraintManager::RemoveConstraints(Entity toRemove)
+{
+    const auto toRemoveId = toRemove.Index();
+    if (!m_entityState.contains(toRemoveId))
+    {
+        return;
+    }
+
+    auto& toRemoveInfo = m_entityState.at(toRemoveId);
+    for (auto constraintId : toRemoveInfo.ids)
+    {
+        const auto handle = std::exchange(m_handles[constraintId], nullptr);
+        m_physicsSystem->RemoveConstraint(handle);
+        m_freeIndices.push_back(constraintId);
+        const auto [ownerId, referencedId] = std::exchange(m_pairs[constraintId], ConstraintPair{});
+        const auto [otherId, otherIsOwner] = [toRemoveId, ownerId, referencedId]()
+        {
+            return toRemoveId == ownerId
+                ? std::pair{referencedId, false}
+                : std::pair{ownerId, true};
+        }();
+
+
+        if (otherId != Entity::NullIndex)
+        {
+            auto& otherInfo = m_entityState.at(otherId);
+            UntrackConstraint(otherInfo, constraintId, otherIsOwner);
+        }
+    }
+
+    m_entityState.erase(toRemoveId);
+}
+
+auto ConstraintManager::GetConstraints(Entity owner) const -> std::span<const ConstraintView>
+{
+    auto id = owner.Index();
+    if (m_entityState.contains(id))
+    {
+        return m_entityState.at(id).views;
+    }
+
+    return std::span<const ConstraintView>{};
+}
+
+void ConstraintManager::Clear()
+{
+
+    // todo: do better?
+    std::erase(m_handles, nullptr);
+
+    m_physicsSystem->RemoveConstraints(m_handles.data(), static_cast<int>(m_handles.size()));
+    m_handles.clear();
+    m_handles.shrink_to_fit();
+    m_pairs.clear();
+    m_pairs.shrink_to_fit();
+    m_freeIndices.clear();
+    m_freeIndices.shrink_to_fit();
+    m_entityState.clear();
+}
+} // namespace nc::physics

--- a/source/engine/physics2/jolt/ConstraintManager.cpp
+++ b/source/engine/physics2/jolt/ConstraintManager.cpp
@@ -39,17 +39,17 @@ auto ConstraintManager::AddConstraint(const ConstraintInfo& createInfo,
     {
         if (m_freeIndices.empty())
         {
-            const auto index = static_cast<uint32_t>(m_handles.size());
+            const auto i = static_cast<uint32_t>(m_handles.size());
             m_handles.push_back(handle);
             m_pairs.emplace_back(ownerId, referencedId);
-            return index;
+            return i;
         }
 
-        const auto index = m_freeIndices.back();
+        const auto i = m_freeIndices.back();
         m_freeIndices.pop_back();
-        m_handles[index] = handle;
-        m_pairs[index] = ConstraintPair{ownerId, referencedId};
-        return index;
+        m_handles[i] = handle;
+        m_pairs[i] = ConstraintPair{ownerId, referencedId};
+        return i;
     }();
 
     auto& ownerState = m_entityState.contains(ownerId)

--- a/source/engine/physics2/jolt/ConstraintManager.cpp
+++ b/source/engine/physics2/jolt/ConstraintManager.cpp
@@ -131,11 +131,11 @@ auto ConstraintManager::GetConstraints(Entity owner) const -> std::span<const Co
 
 void ConstraintManager::Clear()
 {
+    const auto constraintsBeg = m_handles.begin();
+    const auto constraintsEnd = std::remove(constraintsBeg, m_handles.end(), nullptr);
+    const auto constraintCount = std::distance(constraintsBeg, constraintsEnd);
+    m_physicsSystem->RemoveConstraints(m_handles.data(), static_cast<int>(constraintCount));
 
-    // todo: do better?
-    std::erase(m_handles, nullptr);
-
-    m_physicsSystem->RemoveConstraints(m_handles.data(), static_cast<int>(m_handles.size()));
     m_handles.clear();
     m_handles.shrink_to_fit();
     m_pairs.clear();

--- a/source/engine/physics2/jolt/ConstraintManager.h
+++ b/source/engine/physics2/jolt/ConstraintManager.h
@@ -33,10 +33,12 @@ struct EntityConstraints
 class ConstraintManager
 {
     public:
-        explicit ConstraintManager(JPH::PhysicsSystem& physicsSystem)
+        static constexpr auto ConstraintMapSizeHint = 1000u;
+
+        explicit ConstraintManager(JPH::PhysicsSystem& physicsSystem, uint32_t maxEntities)
             : m_physicsSystem{&physicsSystem},
               m_factory{physicsSystem},
-              m_entityState{1000u, 1000u} // todo: figure out
+              m_entityState{ConstraintMapSizeHint, maxEntities}
         {
         }
 

--- a/source/engine/physics2/jolt/ConstraintManager.h
+++ b/source/engine/physics2/jolt/ConstraintManager.h
@@ -19,8 +19,8 @@ namespace nc::physics
 // Pair of entity indices associated with a constraint
 struct ConstraintPair
 {
-    uint32_t ownerId = UINT32_MAX; // Index of the Entity the constraint was added to
-    uint32_t targetId = UINT32_MAX; // Index of the other Entity targeted by the constraint (may be NullIndex if fixed to world)
+    uint32_t ownerId = Entity::NullIndex; // Index of the Entity the constraint was added to
+    uint32_t targetId = Entity::NullIndex; // Index of the other Entity targeted by the constraint (may be NullIndex if fixed to world)
 };
 
 // Per-Entity constraint information
@@ -52,9 +52,13 @@ class ConstraintManager
 
         auto AddConstraint(const ConstraintInfo& createInfo,
                            Entity owner,
-                           JPH::Body* ownerBody,
+                           JPH::Body& ownerBody,
                            Entity target,
-                           JPH::Body* targetBody) -> Constraint&;
+                           JPH::Body& targetBody) -> Constraint&;
+
+        auto AddConstraint(const ConstraintInfo& createInfo,
+                           Entity owner,
+                           JPH::Body& ownerBody) -> Constraint&;
 
         void EnableConstraint(Constraint& constraint, bool enabled);
         void UpdateConstraint(Constraint& constraint);

--- a/source/engine/physics2/jolt/ConstraintManager.h
+++ b/source/engine/physics2/jolt/ConstraintManager.h
@@ -45,7 +45,7 @@ class ConstraintManager
         explicit ConstraintManager(JPH::PhysicsSystem& physicsSystem, uint32_t maxEntities)
             : m_physicsSystem{&physicsSystem},
               m_factory{physicsSystem},
-              m_entityState{ConstraintMapSizeHint, maxEntities}
+              m_entityState{std::min(ConstraintMapSizeHint, maxEntities), maxEntities}
         {
             Constraint::s_manager = this;
         }

--- a/source/engine/physics2/jolt/Conversion.h
+++ b/source/engine/physics2/jolt/Conversion.h
@@ -85,4 +85,14 @@ inline auto ToObjectLayer(BodyType bodyType) -> JPH::ObjectLayer
         default: std::unreachable();
     }
 }
+
+inline auto ToConstraintSpace(ConstraintSpace space) -> JPH::EConstraintSpace
+{
+    switch (space)
+    {
+        case ConstraintSpace::World: return JPH::EConstraintSpace::WorldSpace;
+        case ConstraintSpace::Local: return JPH::EConstraintSpace::LocalToBodyCOM;
+        default: std::unreachable();
+    }
+}
 } // namespace nc::physics

--- a/source/engine/physics2/jolt/JoltApi.cpp
+++ b/source/engine/physics2/jolt/JoltApi.cpp
@@ -78,6 +78,5 @@ JoltApi::JoltApi(const config::MemorySettings& memorySettings,
 
     physicsSystem.SetPhysicsSettings(ToJoltSettings(physicsSettings));
     physicsSystem.SetContactListener(&contactListener);
-    ctx = std::make_unique<ComponentContext>(physicsSystem.GetBodyInterfaceNoLock(), shapeFactory);
 }
 } // namespace nc::physics

--- a/source/engine/physics2/jolt/JoltApi.h
+++ b/source/engine/physics2/jolt/JoltApi.h
@@ -1,11 +1,9 @@
 #pragma once
 
 #include "Allocator.h"
-#include "ComponentContext.h"
 #include "ContactListener.h"
 #include "JobSystem.h"
 #include "Layers.h"
-#include "ShapeFactory.h"
 #include "ncengine/type/StableAddress.h"
 
 #include "Jolt/Jolt.h"
@@ -48,10 +46,8 @@ struct JoltApi : public StableAddress
     ObjectVsBroadPhaseLayerFilter objectVsBroadphaseFilter;
     ObjectLayerPairFilter objectLayerPairFilter;
     JPH::PhysicsSystem physicsSystem;
-    ShapeFactory shapeFactory;
     ContactListener contactListener;
     std::unique_ptr<JPH::JobSystem> jobSystem;
-    std::unique_ptr<ComponentContext> ctx;
 
     private:
         JoltApi(const config::MemorySettings& memorySettings,

--- a/test/physics2/CMakeLists.txt
+++ b/test/physics2/CMakeLists.txt
@@ -53,7 +53,9 @@ add_executable(RigidBody_unit_tests
     ${NC_SOURCE_DIR}/ecs/Transform.cpp
     ${NC_SOURCE_DIR}/physics2/RigidBody.cpp
     ${NC_SOURCE_DIR}/physics2/Shape.cpp
-    ${NC_SOURCE_DIR}/physics2/jolt/ContactListener.cpp
+    ${NC_SOURCE_DIR}/physics2/jolt/BodyFactory.cpp
+    ${NC_SOURCE_DIR}/physics2/jolt/ConstraintFactory.cpp
+    ${NC_SOURCE_DIR}/physics2/jolt/ConstraintManager.cpp
     ${NC_SOURCE_DIR}/physics2/jolt/JoltApi.cpp
 )
 

--- a/test/physics2/RigidBody_unit_tests.cpp
+++ b/test/physics2/RigidBody_unit_tests.cpp
@@ -1,8 +1,10 @@
-#include "gtest/gtest.h"
-#include "jolt/JobSystem_stub.inl"
-#include "ncengine/config/Config.h"
+#include "jolt/JoltApiFixture.inl"
 #include "ncengine/physics/RigidBody.h"
-#include "physics2/jolt/JoltApi.h"
+
+#include "physics2/jolt/BodyManager.h"
+#include "physics2/jolt/ComponentContext.h"
+#include "physics2/jolt/ConstraintManager.h"
+#include "physics2/jolt/ShapeFactory.h"
 
 #include "Jolt/Physics/Body/BodyCreationSettings.h"
 
@@ -10,59 +12,79 @@
 
 namespace nc::physics
 {
-class NcPhysicsImpl2
+struct BodyManager::Connections {};
+
+BodyManager::BodyManager(ecs::ComponentPool<Transform>& transformPool,
+                         ecs::ComponentPool<RigidBody>&,
+                         uint32_t maxEntities,
+                         JPH::PhysicsSystem& physicsSystem,
+                         ShapeFactory& shapeFactory,
+                         ConstraintManager& constraintManager)
+    : m_transformPool{&transformPool},
+      m_bodies{maxEntities, maxEntities},
+      m_bodyFactory{physicsSystem.GetBodyInterfaceNoLock(), shapeFactory},
+      m_ctx{std::make_unique<ComponentContext>(
+        physicsSystem.GetBodyInterfaceNoLock(),
+        shapeFactory,
+        constraintManager
+      )}
 {
-    public:
-        void MockRegisterBody(RigidBody& body, JPH::Body* apiBody, ComponentContext& ctx)
-        {
-            body.SetContext(static_cast<BodyHandle>(apiBody), &ctx);
-        }
-};
+    nc::physics::RigidBody::SetContext(m_ctx.get());
+}
+
+void BodyManager::AddBody(RigidBody& added)
+{
+    const auto matrix = DirectX::XMMatrixIdentity();
+    auto [handle, _1, _2] = m_bodyFactory.MakeBody(added, matrix);
+    m_ctx->interface.AddBody(handle->GetID(), JPH::EActivation::Activate);
+    added.SetHandle(handle);
+    m_bodies.emplace(added.GetEntity().Index(), handle->GetID());
+}
+
+void BodyManager::RemoveBody(Entity toRemove)
+{
+    const auto bodyId = m_bodies.at(toRemove.Index());
+    m_bodies.erase(toRemove.Index());
+    m_ctx->interface.RemoveBody(bodyId);
+    m_ctx->interface.DestroyBody(bodyId);
+}
+
+BodyManager::~BodyManager() noexcept = default;
 } // namespace nc::physics
 
-class RigidBodyTest : public ::testing::Test
+class RigidBodyTest : public JoltApiFixture
 {
     protected:
         RigidBodyTest()
-            : joltApi{nc::physics::JoltApi::Initialize(
-                  nc::config::MemorySettings{},
-                  nc::config::PhysicsSettings{
-                    .tempAllocatorSize = 1024 * 1024 * 4,
-                    .maxBodyPairs = 8,
-                    .maxContacts = 4
-                  },
-                  nc::task::AsyncDispatcher{}
-              )}
+            : transformPool{10, nc::ComponentHandler<nc::Transform>{}},
+              rigidBodyPool{10ull, nc::ComponentHandler<nc::physics::RigidBody>{}},
+              constraintManager{joltApi.physicsSystem, 10},
+              bodyManager{
+                  transformPool,
+                  rigidBodyPool,
+                  10,
+                  joltApi.physicsSystem,
+                  shapeFactory,
+                  constraintManager
+              }
         {
         }
 
     public:
-        nc::physics::JoltApi joltApi;
-        nc::physics::NcPhysicsImpl2 ncPhysics;
+        nc::ecs::ComponentPool<nc::Transform> transformPool;
+        nc::ecs::ComponentPool<nc::physics::RigidBody> rigidBodyPool;
+        nc::physics::ShapeFactory shapeFactory;
+        nc::physics::ConstraintManager constraintManager;
+        nc::physics::BodyManager bodyManager;
         std::vector<JPH::Body*> bodies;
 
         auto CreateRigidBody(nc::Entity entity,
                              const nc::physics::Shape& shape,
-                             const nc::physics::RigidBodyInfo& info,
-                             const JPH::Vec3& position = JPH::Vec3::sZero(),
-                             const JPH::Vec3& scale = JPH::Vec3::sReplicate(1.0f))
+                             const nc::physics::RigidBodyInfo& info)
         {
             auto body = nc::physics::RigidBody{entity, shape, info};
-            auto settings = JPH::BodyCreationSettings{
-                joltApi.shapeFactory.MakeShape(shape, scale),
-                position,
-                JPH::Quat::sIdentity(),
-                nc::physics::ToMotionType(info.type),
-                nc::physics::ToObjectLayer(info.type)
-            };
-
-            settings.mUserData = nc::Entity::Hash{}(entity);
-            settings.mMotionQuality = nc::physics::ToMotionQuality(body.UseContinuousDetection());
-            auto& interface = joltApi.physicsSystem.GetBodyInterfaceNoLock();
-            auto apiBody = interface.CreateBody(settings);
-            interface.AddBody(apiBody->GetID(), JPH::EActivation::Activate);
-            ncPhysics.MockRegisterBody(body, apiBody, *joltApi.ctx);
-            bodies.push_back(apiBody);
+            bodyManager.AddBody(body);
+            bodies.push_back(reinterpret_cast<JPH::Body*>(body.GetHandle()));
             return body;
         }
 };
@@ -109,6 +131,17 @@ TEST_F(RigidBodyTest, MoveOperations_transferRegistrationData)
     EXPECT_TRUE(first.IsInitialized());
     EXPECT_FALSE(second.GetEntity().Valid());
     EXPECT_FALSE(second.IsInitialized());
+
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wself-move"
+#endif
+    first = std::move(first);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
+    EXPECT_TRUE(first.GetEntity().Valid());
+    EXPECT_TRUE(first.IsInitialized());
 }
 
 TEST_F(RigidBodyTest, SimulationPropertyFunctions_updateInternalState)

--- a/test/physics2/Shape_unit_tests.cpp
+++ b/test/physics2/Shape_unit_tests.cpp
@@ -56,6 +56,15 @@ TEST(ShapeTest, NormalizeScaleForShape_sphere_nonUniformScaling_fixesScale)
     EXPECT_EQ(expectedUniformFromZ, actualUniformFromZ);
 }
 
+TEST(ShapeTest, NormalizeScaleForShape_sphere_nonUniformScaling_sameCurrentAndDesiredScale_averagesScale)
+{
+    constexpr auto shape = nc::physics::ShapeType::Sphere;
+    const auto nonUniformScale = nc::Vector3{1.0, 2.0f, 3.0f};
+    const auto actualScale = nc::physics::NormalizeScaleForShape(shape, nonUniformScale, nonUniformScale);
+    const auto expectedScale = nc::Vector3::Splat(2.0f);
+    EXPECT_EQ(expectedScale, actualScale);
+}
+
 TEST(ShapeTest, NormalizeScaleForShape_sphere_zeroScale_fixesScale)
 {
     constexpr auto shape = nc::physics::ShapeType::Sphere;
@@ -83,7 +92,7 @@ TEST(ShapeTest, NormalizeScaleForShape_capsule_uniformXZScaling_doesNotModify)
     EXPECT_EQ(expectedScale, actualScale);
 }
 
-TEST(ShapeTest, NormalizeScaleForShape_sphere_nonUniformXZScaling_fixesScale)
+TEST(ShapeTest, NormalizeScaleForShape_capsule_nonUniformXZScaling_fixesScale)
 {
     constexpr auto shape = nc::physics::ShapeType::Capsule;
     const auto initialScale = nc::Vector3{1.0f, 2.0f, 1.0f};
@@ -95,6 +104,15 @@ TEST(ShapeTest, NormalizeScaleForShape_sphere_nonUniformXZScaling_fixesScale)
     const auto actualUniformFromZ = nc::physics::NormalizeScaleForShape(shape, initialScale, attemptScaleZ);
     EXPECT_EQ(expectedUniformFromX, actualUniformFromX);
     EXPECT_EQ(expectedUniformFromZ, actualUniformFromZ);
+}
+
+TEST(ShapeTest, NormalizeScaleForShape_capsule_nonUniformScaling_sameCurrentAndDesiredScale_averagesScale)
+{
+    constexpr auto shape = nc::physics::ShapeType::Capsule;
+    const auto nonUniformScale = nc::Vector3{2.0, 2.0f, 3.0f};
+    const auto actualScale = nc::physics::NormalizeScaleForShape(shape, nonUniformScale, nonUniformScale);
+    const auto expectedScale = nc::Vector3{2.5f, 2.0f, 2.5f};
+    EXPECT_EQ(expectedScale, actualScale);
 }
 
 TEST(ShapeTest, NormalizeScaleForShape_capsule_zeroScale_fixesScale)

--- a/test/physics2/jolt/BodyFactory_unit_tests.cpp
+++ b/test/physics2/jolt/BodyFactory_unit_tests.cpp
@@ -1,0 +1,78 @@
+#include "JoltApiFixture.inl"
+#include "physics2/jolt/BodyFactory.h"
+#include "physics2/jolt/ShapeFactory.h"
+#include "ncengine/physics/RigidBody.h"
+
+class BodyFactoryTest : public JoltApiFixture
+{
+    protected:
+        nc::physics::ShapeFactory shapeFactory;
+        nc::physics::BodyFactory uut;
+
+        BodyFactoryTest()
+            : uut{joltApi.physicsSystem.GetBodyInterfaceNoLock(), shapeFactory}
+        {
+        }
+
+        void DestroyBody(const JPH::Body* body)
+        {
+            auto& interface = joltApi.physicsSystem.GetBodyInterfaceNoLock();
+            const auto id = body->GetID();
+            interface.DestroyBody(id); // note: factory doesn't add body, so don't call remove
+        }
+};
+
+constexpr auto g_entity = nc::Entity{42, 0, 0};
+constexpr auto g_dynamicProperties = nc::physics::RigidBodyInfo{
+    .friction = 1.0f,
+    .restitution = 0.9f,
+    .linearDamping = 0.5f,
+    .angularDamping = 0.4f,
+    .gravityMultiplier = 0.1f,
+    .type = nc::physics::BodyType::Dynamic,
+    .flags = nc::physics::RigidBodyFlags::ScaleWithTransform |
+             nc::physics::RigidBodyFlags::ContinuousDetection
+};
+
+TEST_F(BodyFactoryTest, MakeBody_setsBodyProperties)
+{
+    const auto box = nc::physics::Shape::MakeBox();
+    const auto& expectedProperties = g_dynamicProperties;
+    const auto rigidBody = nc::physics::RigidBody{g_entity, box, expectedProperties};
+    const auto matrix = DirectX::XMMatrixIdentity();
+
+    const auto result = uut.MakeBody(rigidBody, matrix);
+    EXPECT_FALSE(result.wasScaleAdjusted);
+    const auto actualBody = result.body;
+
+    EXPECT_EQ(nc::Vector3::Zero(), nc::physics::ToVector3(actualBody->GetPosition()));
+    EXPECT_EQ(nc::Quaternion::Identity(), nc::physics::ToQuaternion(actualBody->GetRotation()));
+    // skip detailed shape/scale checks - shape wrapping is implementation detail of ShapeFactory and subject to change; covered by ShapeFactory tests
+    EXPECT_FLOAT_EQ(1.0f, actualBody->GetShape()->GetVolume());
+
+    EXPECT_EQ(JPH::EMotionType::Dynamic, actualBody->GetMotionType());
+    EXPECT_EQ(nc::physics::ObjectLayer::Dynamic, actualBody->GetObjectLayer());
+    EXPECT_EQ(nc::Entity::Hash{}(g_entity), actualBody->GetUserData());
+    EXPECT_EQ(expectedProperties.friction, actualBody->GetFriction());
+    EXPECT_EQ(expectedProperties.restitution, actualBody->GetRestitution());
+
+    const auto& actualMotionProperties = actualBody->GetMotionProperties();
+    EXPECT_EQ(JPH::EMotionQuality::LinearCast, actualMotionProperties->GetMotionQuality());
+    EXPECT_EQ(expectedProperties.linearDamping, actualMotionProperties->GetLinearDamping());
+    EXPECT_EQ(expectedProperties.angularDamping, actualMotionProperties->GetAngularDamping());
+    EXPECT_EQ(expectedProperties.gravityMultiplier, actualMotionProperties->GetGravityFactor());
+
+    DestroyBody(actualBody);
+}
+
+TEST_F(BodyFactoryTest, MakeBody_invalidTransformScale_returnsAdjustedValue)
+{
+    const auto sphere = nc::physics::Shape::MakeSphere();
+    const auto rigidBody = nc::physics::RigidBody{g_entity, sphere, g_dynamicProperties};
+    const auto matrix = DirectX::XMMatrixScaling(1.0f, 2.0f, 3.0f);
+    const auto result = uut.MakeBody(rigidBody, matrix);
+    EXPECT_TRUE(result.wasScaleAdjusted);
+    EXPECT_EQ(nc::Vector3::Splat(2.0f), result.adjustedScale);
+
+    DestroyBody(result.body);
+}

--- a/test/physics2/jolt/BodyManager_integration_tests.cpp
+++ b/test/physics2/jolt/BodyManager_integration_tests.cpp
@@ -1,0 +1,223 @@
+#include "JoltApiFixture.inl"
+#include "physics2/jolt/BodyManager.h"
+#include "physics2/jolt/ConstraintManager.h"
+#include "physics2/jolt/ShapeFactory.h"
+
+class BodyManagerTest : public JoltApiFixture
+{
+    protected:
+        static constexpr auto maxEntities = 10u;
+        nc::ecs::ComponentPool<nc::Transform> transformPool;
+        nc::ecs::ComponentPool<nc::physics::RigidBody> rigidBodyPool;
+        nc::physics::ShapeFactory shapeFactory;
+        nc::physics::ConstraintManager constraintManager;
+        nc::physics::BodyManager uut;
+
+        BodyManagerTest()
+            : transformPool{maxEntities, nc::ComponentHandler<nc::Transform>{}},
+              rigidBodyPool{maxEntities, nc::ComponentHandler<nc::physics::RigidBody>{}},
+              constraintManager{joltApi.physicsSystem, maxEntities},
+              uut{
+                  transformPool,
+                  rigidBodyPool,
+                  maxEntities,
+                  joltApi.physicsSystem,
+                  shapeFactory,
+                  constraintManager
+              }
+        {
+        }
+
+        auto AddRigidBody(nc::Entity entity) -> nc::physics::RigidBody&
+        {
+            transformPool.Emplace(entity, nc::Vector3::Zero(), nc::Quaternion::Identity(), nc::Vector3::One());
+            return rigidBodyPool.Emplace(entity);
+        }
+
+        auto RemoveRigidBody(nc::Entity entity)
+        {
+            transformPool.Remove(entity);
+            rigidBodyPool.Remove(entity);
+        }
+
+        auto GetBodyInterface() -> JPH::BodyInterface&
+        {
+            return joltApi.physicsSystem.GetBodyInterfaceNoLock();
+        }
+
+        auto GetBodyId(const nc::physics::RigidBody& rigidBody) -> JPH::BodyID
+        {
+            if (!rigidBody.IsInitialized())
+            {
+                ADD_FAILURE() << "RigidBody not initialized";
+                return JPH::BodyID{JPH::BodyID::cInvalidBodyID};
+            }
+
+            const auto apiBody = reinterpret_cast<JPH::Body*>(rigidBody.GetHandle());
+            return apiBody->GetID();
+        }
+};
+
+constexpr auto g_entity1 = nc::Entity{1, 0, 0};
+constexpr auto g_entity2 = nc::Entity{2, 0, 0};
+constexpr auto g_entity3 = nc::Entity{3, 0, 0};
+
+TEST_F(BodyManagerTest, AddBody_addsBodyToSimulation)
+{
+    auto& body = AddRigidBody(g_entity1);
+    ASSERT_TRUE(body.IsInitialized());
+    const auto bodyId = GetBodyId(body);
+    auto& bodyInterface = GetBodyInterface();
+    EXPECT_TRUE(bodyInterface.IsAdded(bodyId));
+    EXPECT_TRUE(bodyInterface.IsActive(bodyId));
+    RemoveRigidBody(g_entity1);
+}
+
+TEST_F(BodyManagerTest, AddBody_initializesFromOnAdd)
+{
+    auto isInitializedBefore = false;
+    auto isInitializedAfter = false;
+
+    [[maybe_unused]] auto _1 = rigidBodyPool.OnAdd().Connect(
+        [&isInitializedBefore](auto& rb)
+        {
+            isInitializedBefore = rb.IsInitialized();
+        },
+        nc::SignalPriority::Highest
+    );
+
+    [[maybe_unused]] auto _2 = rigidBodyPool.OnAdd().Connect(
+        [&isInitializedAfter](auto& rb)
+        {
+            isInitializedAfter = rb.IsInitialized();
+        },
+        nc::SignalPriority::Lowest
+    );
+
+    AddRigidBody(g_entity1);
+    EXPECT_FALSE(isInitializedBefore);
+    EXPECT_TRUE(isInitializedAfter);
+    RemoveRigidBody(g_entity1);
+}
+
+TEST_F(BodyManagerTest, AddBody_doubleCall_throws)
+{
+    auto& body = AddRigidBody(g_entity1);
+    EXPECT_THROW(uut.AddBody(body), std::exception);
+    RemoveRigidBody(g_entity1);
+}
+
+TEST_F(BodyManagerTest, RemoveBody_calledFromOnRemove)
+{
+    auto isAddedBefore = false;
+    auto isAddedAfter = false;
+
+    auto& rigidBody = AddRigidBody(g_entity1);
+    const auto bodyId = GetBodyId(rigidBody);
+    auto& interface = GetBodyInterface();
+
+    [[maybe_unused]] auto _1 = rigidBodyPool.OnRemove().Connect(
+        [&isAddedBefore, &interface, bodyId](auto)
+        {
+            isAddedBefore = interface.IsAdded(bodyId);
+        },
+        nc::SignalPriority::Highest
+    );
+
+    [[maybe_unused]] auto _2 = rigidBodyPool.OnRemove().Connect(
+        [&isAddedAfter, &interface, bodyId](auto)
+        {
+            isAddedAfter = interface.IsAdded(bodyId);
+        },
+        nc::SignalPriority::Lowest
+    );
+
+    RemoveRigidBody(g_entity1);
+    EXPECT_TRUE(isAddedBefore);
+    EXPECT_FALSE(isAddedAfter);
+}
+
+TEST_F(BodyManagerTest, RemoveBody_deferredCleanupEnabled_skipsRemoval)
+{
+    auto& rigidBody = AddRigidBody(g_entity1);
+    const auto bodyId = GetBodyId(rigidBody);
+    uut.DeferCleanup(true);
+    uut.RemoveBody(g_entity1);
+    auto& bodyInterface = GetBodyInterface();
+    EXPECT_TRUE(bodyInterface.IsAdded(bodyId));
+
+    uut.DeferCleanup(false);
+    RemoveRigidBody(g_entity1);
+}
+
+TEST_F(BodyManagerTest, RemoveBody_badEntity_throws)
+{
+    EXPECT_THROW(uut.RemoveBody(g_entity1), std::exception);
+}
+
+TEST_F(BodyManagerTest, RemoveBody_doubleCall_throws)
+{
+    AddRigidBody(g_entity1);
+    RemoveRigidBody(g_entity1);
+    EXPECT_THROW(uut.RemoveBody(g_entity1), std::exception);
+}
+
+TEST_F(BodyManagerTest, Clear_empty_succeeds)
+{
+    EXPECT_NO_THROW(uut.Clear());
+}
+
+TEST_F(BodyManagerTest, Clear_hasBodies_removesBodiesFromSimulation)
+{
+    const auto id1 = GetBodyId(AddRigidBody(g_entity1));
+    const auto id2 = GetBodyId(AddRigidBody(g_entity2));
+    const auto id3 = GetBodyId(AddRigidBody(g_entity3));
+    uut.Clear();
+
+    auto& bodyInterface = GetBodyInterface();
+    EXPECT_FALSE(bodyInterface.IsAdded(id1));
+    EXPECT_FALSE(bodyInterface.IsAdded(id2));
+    EXPECT_FALSE(bodyInterface.IsAdded(id3));
+}
+
+TEST_F(BodyManagerTest, SampleWorkflow)
+{
+    auto& physicsSystem = joltApi.physicsSystem;
+    auto& bodyInterface = GetBodyInterface();
+
+    auto id1 = GetBodyId(AddRigidBody(g_entity1));
+    auto id2 = GetBodyId(AddRigidBody(g_entity2));
+    auto id3 = GetBodyId(AddRigidBody(g_entity3));
+
+    EXPECT_EQ(3u, physicsSystem.GetNumBodies());
+    EXPECT_TRUE(bodyInterface.IsAdded(id1));
+    EXPECT_TRUE(bodyInterface.IsAdded(id2));
+    EXPECT_TRUE(bodyInterface.IsAdded(id3));
+
+    RemoveRigidBody(g_entity2);
+    EXPECT_EQ(2u, physicsSystem.GetNumBodies());
+    EXPECT_FALSE(bodyInterface.IsAdded(id2));
+
+    id2 = GetBodyId(AddRigidBody(g_entity2));
+    EXPECT_EQ(3u, physicsSystem.GetNumBodies());
+    EXPECT_TRUE(bodyInterface.IsAdded(id2));
+
+    uut.Clear();
+    uut.DeferCleanup(true);
+    const auto removed = std::vector<nc::Entity>{g_entity1, g_entity2, g_entity3};
+    transformPool.CommitStagedComponents(removed);
+    rigidBodyPool.CommitStagedComponents(removed);
+    transformPool.ClearNonPersistent();
+    rigidBodyPool.ClearNonPersistent();
+
+    EXPECT_EQ(0u, physicsSystem.GetNumBodies());
+    EXPECT_FALSE(bodyInterface.IsAdded(id1));
+    EXPECT_FALSE(bodyInterface.IsAdded(id2));
+    EXPECT_FALSE(bodyInterface.IsAdded(id3));
+
+    uut.DeferCleanup(false);
+    id1 = GetBodyId(AddRigidBody(g_entity1));
+    RemoveRigidBody(g_entity1);
+    EXPECT_EQ(0u, physicsSystem.GetNumBodies());
+    EXPECT_FALSE(bodyInterface.IsAdded(id1));
+}

--- a/test/physics2/jolt/CMakeLists.txt
+++ b/test/physics2/jolt/CMakeLists.txt
@@ -1,3 +1,66 @@
+### BodyFactory Tests ###
+add_executable(BodyFactory_unit_tests
+    BodyFactory_unit_tests.cpp
+    ${NC_SOURCE_DIR}/physics2/jolt/BodyFactory.cpp
+    ${NC_SOURCE_DIR}/physics2/jolt/JoltApi.cpp
+    ${NC_SOURCE_DIR}/physics2/Shape.cpp
+)
+
+target_include_directories(BodyFactory_unit_tests
+    PRIVATE
+        ${NC_INCLUDE_DIR}
+        ${NC_SOURCE_DIR}
+)
+
+target_compile_options(BodyFactory_unit_tests
+    PUBLIC
+        ${NC_COMPILER_FLAGS}
+)
+
+target_link_libraries(BodyFactory_unit_tests
+    PRIVATE
+        NcMath
+        NcUtility
+        Jolt
+        gtest_main
+)
+
+add_test(BodyFactory_unit_tests BodyFactory_unit_tests)
+
+### BodyManager Tests ###
+add_executable(BodyManager_integration_tests
+    BodyManager_integration_tests.cpp
+    ${NC_SOURCE_DIR}/ecs/Transform.cpp
+    ${NC_SOURCE_DIR}/physics2/jolt/BodyFactory.cpp
+    ${NC_SOURCE_DIR}/physics2/jolt/BodyManager.cpp
+    ${NC_SOURCE_DIR}/physics2/jolt/ConstraintFactory.cpp
+    ${NC_SOURCE_DIR}/physics2/jolt/ConstraintManager.cpp
+    ${NC_SOURCE_DIR}/physics2/jolt/JoltApi.cpp
+    ${NC_SOURCE_DIR}/physics2/RigidBody.cpp
+    ${NC_SOURCE_DIR}/physics2/Shape.cpp
+)
+
+target_include_directories(BodyManager_integration_tests
+    PRIVATE
+        ${NC_INCLUDE_DIR}
+        ${NC_SOURCE_DIR}
+)
+
+target_compile_options(BodyManager_integration_tests
+    PUBLIC
+        ${NC_COMPILER_FLAGS}
+)
+
+target_link_libraries(BodyManager_integration_tests
+    PRIVATE
+        NcMath
+        NcUtility
+        Jolt
+        gtest_main
+)
+
+add_test(BodyManager_integration_tests BodyManager_integration_tests)
+
 ### ContactListener Tests ###
 add_executable(ContactListener_integration_tests
     ContactListener_integration_tests.cpp

--- a/test/physics2/jolt/CMakeLists.txt
+++ b/test/physics2/jolt/CMakeLists.txt
@@ -26,6 +26,63 @@ target_link_libraries(ContactListener_integration_tests
 
 add_test(ContactListener_integration_tests ContactListener_integration_tests)
 
+### ConstraintFactory Tests ###
+add_executable(ConstraintFactory_unit_tests
+    ConstraintFactory_unit_tests.cpp
+    ${NC_SOURCE_DIR}/physics2/jolt/ConstraintFactory.cpp
+    ${NC_SOURCE_DIR}/physics2/jolt/JoltApi.cpp
+)
+
+target_include_directories(ConstraintFactory_unit_tests
+    PRIVATE
+        ${NC_INCLUDE_DIR}
+        ${NC_SOURCE_DIR}
+)
+
+target_compile_options(ConstraintFactory_unit_tests
+    PUBLIC
+        ${NC_COMPILER_FLAGS}
+)
+
+target_link_libraries(ConstraintFactory_unit_tests
+    PRIVATE
+        NcMath
+        NcUtility
+        Jolt
+        gtest_main
+)
+
+add_test(ConstraintFactory_unit_tests ConstraintFactory_unit_tests)
+
+### ConstraintManager Tests ###
+add_executable(ConstraintManager_unit_tests
+    ConstraintManager_unit_tests.cpp
+    ${NC_SOURCE_DIR}/physics2/jolt/ConstraintFactory.cpp
+    ${NC_SOURCE_DIR}/physics2/jolt/ConstraintManager.cpp
+    ${NC_SOURCE_DIR}/physics2/jolt/JoltApi.cpp
+)
+
+target_include_directories(ConstraintManager_unit_tests
+    PRIVATE
+        ${NC_INCLUDE_DIR}
+        ${NC_SOURCE_DIR}
+)
+
+target_compile_options(ConstraintManager_unit_tests
+    PUBLIC
+        ${NC_COMPILER_FLAGS}
+)
+
+target_link_libraries(ConstraintManager_unit_tests
+    PRIVATE
+        NcMath
+        NcUtility
+        Jolt
+        gtest_main
+)
+
+add_test(ConstraintManager_unit_tests ConstraintManager_unit_tests)
+
 ### JoltApi Tests ###
 add_executable(JoltApi_unit_tests
     JoltApi_unit_tests.cpp
@@ -134,7 +191,6 @@ add_test(PhysicsAllocator_unit_tests PhysicsAllocator_unit_tests)
 ### ShapeFactory Tests ###
 add_executable(ShapeFactory_unit_tests
     ShapeFactory_unit_tests.cpp
-    ${NC_SOURCE_DIR}/physics2/jolt/ContactListener.cpp
     ${NC_SOURCE_DIR}/physics2/jolt/JoltApi.cpp
 )
 

--- a/test/physics2/jolt/ConstraintFactory_unit_tests.cpp
+++ b/test/physics2/jolt/ConstraintFactory_unit_tests.cpp
@@ -1,0 +1,97 @@
+#include "JoltApiFixture.inl"
+#include "physics2/jolt/ConstraintFactory.h"
+
+#include "physics2/jolt/Conversion.h"
+#include "ncutility/ScopeExit.h"
+
+#include "Jolt/Physics/Body/BodyCreationSettings.h"
+#include "Jolt/Physics/Collision/Shape/BoxShape.h"
+#include "Jolt/Physics/Constraints/FixedConstraint.h"
+
+class ConstraintFactoryTest : public JoltApiFixture
+{
+    protected:
+        nc::physics::ConstraintFactory uut;
+
+        ConstraintFactoryTest()
+            : uut{joltApi.physicsSystem}
+        {
+        }
+};
+
+TEST_F(ConstraintFactoryTest, MakeConstraint_FixedConstraint_twoBody_setsExpectedValues)
+{
+    auto body1 = CreateBody();
+    auto body2 = CreateBody();
+    SCOPE_EXIT
+    (
+        DestroyBody(body1);
+        DestroyBody(body2);
+    );
+
+    const auto inConstraint = nc::physics::FixedConstraintInfo{
+        .point1 = nc::Vector3{1.0f, 2.0f, 3.0f},
+        .axisX1 = nc::Vector3::Right(),
+        .axisY1 = nc::Vector3::Up(),
+        .point2 = nc::Vector3{4.0f, 5.0f, 6.0f},
+        .axisX2 = nc::Vector3::Front(),
+        .axisY2 = nc::Vector3::Down(),
+        .space = nc::physics::ConstraintSpace::World
+    };
+
+    const auto baseConstraint = uut.MakeConstraint(inConstraint, *body1, *body2);
+    const auto actualType = baseConstraint->GetType();
+    const auto actualSubType = baseConstraint->GetSubType();
+    ASSERT_EQ(JPH::EConstraintType::TwoBodyConstraint, actualType);
+    ASSERT_EQ(JPH::EConstraintSubType::Fixed, actualSubType);
+
+    const auto baseSettings = baseConstraint->GetConstraintSettings();
+    const auto actualSettings = static_cast<JPH::FixedConstraintSettings*>(baseSettings.GetPtr());
+
+    EXPECT_EQ(inConstraint.point1, nc::physics::ToVector3(actualSettings->mPoint1));
+    EXPECT_EQ(inConstraint.axisX1, nc::physics::ToVector3(actualSettings->mAxisX1));
+    EXPECT_EQ(inConstraint.axisY1, nc::physics::ToVector3(actualSettings->mAxisY1));
+    EXPECT_EQ(inConstraint.point2, nc::physics::ToVector3(actualSettings->mPoint2));
+    EXPECT_EQ(inConstraint.axisX2, nc::physics::ToVector3(actualSettings->mAxisX2));
+    EXPECT_EQ(inConstraint.axisY2, nc::physics::ToVector3(actualSettings->mAxisY2));
+    EXPECT_EQ(inConstraint.autoDetect, actualSettings->mAutoDetectPoint);
+    // can't test ConstraintSpace, returned settings are always local
+}
+
+TEST_F(ConstraintFactoryTest, MakeConstraint_FixedConstraint_oneBody_setsExpectedValues)
+{
+    auto body1 = CreateBody();
+    auto dummy = &JPH::Body::sFixedToWorld;
+    SCOPE_EXIT
+    (
+        DestroyBody(body1);
+    );
+
+    const auto inConstraint = nc::physics::FixedConstraintInfo{
+        .point1 = nc::Vector3{1.0f, 2.0f, 3.0f},
+        .axisX1 = nc::Vector3::Right(),
+        .axisY1 = nc::Vector3::Up(),
+        .point2 = nc::Vector3{4.0f, 5.0f, 6.0f},
+        .axisX2 = nc::Vector3::Front(),
+        .axisY2 = nc::Vector3::Down(),
+        .space = nc::physics::ConstraintSpace::Local
+    };
+
+    const auto baseConstraint = uut.MakeConstraint(inConstraint, *body1, *dummy);
+    const auto actualType = baseConstraint->GetType();
+    const auto actualSubType = baseConstraint->GetSubType();
+    ASSERT_EQ(JPH::EConstraintType::TwoBodyConstraint, actualType);
+    ASSERT_EQ(JPH::EConstraintSubType::Fixed, actualSubType);
+
+    const auto baseSettings = baseConstraint->GetConstraintSettings();
+    const auto actualSettings = static_cast<JPH::FixedConstraintSettings*>(baseSettings.GetPtr());
+
+    EXPECT_EQ(inConstraint.point1, nc::physics::ToVector3(actualSettings->mPoint1));
+    EXPECT_EQ(inConstraint.axisX1, nc::physics::ToVector3(actualSettings->mAxisX1));
+    EXPECT_EQ(inConstraint.axisY1, nc::physics::ToVector3(actualSettings->mAxisY1));
+    EXPECT_EQ(inConstraint.point2, nc::physics::ToVector3(actualSettings->mPoint2));
+    EXPECT_EQ(inConstraint.axisX2, nc::physics::ToVector3(actualSettings->mAxisX2));
+    EXPECT_EQ(inConstraint.axisY2, nc::physics::ToVector3(actualSettings->mAxisY2));
+    EXPECT_EQ(inConstraint.autoDetect, actualSettings->mAutoDetectPoint);
+    // can't test ConstraintSpace, returned settings are always local
+}

--- a/test/physics2/jolt/ConstraintFactory_unit_tests.cpp
+++ b/test/physics2/jolt/ConstraintFactory_unit_tests.cpp
@@ -4,9 +4,11 @@
 #include "physics2/jolt/Conversion.h"
 #include "ncutility/ScopeExit.h"
 
-#include "Jolt/Physics/Body/BodyCreationSettings.h"
-#include "Jolt/Physics/Collision/Shape/BoxShape.h"
 #include "Jolt/Physics/Constraints/FixedConstraint.h"
+#include "Jolt/Physics/Constraints/PointConstraint.h"
+
+// note: Jolt Constraint settings are always returned in local space. This also means the value of mSpace doesn't
+//       map to the ConstraintSpace provided in the input constraint info.
 
 class ConstraintFactoryTest : public JoltApiFixture
 {
@@ -36,6 +38,7 @@ TEST_F(ConstraintFactoryTest, MakeConstraint_FixedConstraint_twoBody_setsExpecte
         .point2 = nc::Vector3{4.0f, 5.0f, 6.0f},
         .axisX2 = nc::Vector3::Front(),
         .axisY2 = nc::Vector3::Down(),
+        .detectFromPositions = false,
         .space = nc::physics::ConstraintSpace::World
     };
 
@@ -54,8 +57,7 @@ TEST_F(ConstraintFactoryTest, MakeConstraint_FixedConstraint_twoBody_setsExpecte
     EXPECT_EQ(inConstraint.point2, nc::physics::ToVector3(actualSettings->mPoint2));
     EXPECT_EQ(inConstraint.axisX2, nc::physics::ToVector3(actualSettings->mAxisX2));
     EXPECT_EQ(inConstraint.axisY2, nc::physics::ToVector3(actualSettings->mAxisY2));
-    EXPECT_EQ(inConstraint.autoDetect, actualSettings->mAutoDetectPoint);
-    // can't test ConstraintSpace, returned settings are always local
+    // detectFromPosition is not saved to the settings
 }
 
 TEST_F(ConstraintFactoryTest, MakeConstraint_FixedConstraint_oneBody_setsExpectedValues)
@@ -74,6 +76,7 @@ TEST_F(ConstraintFactoryTest, MakeConstraint_FixedConstraint_oneBody_setsExpecte
         .point2 = nc::Vector3{4.0f, 5.0f, 6.0f},
         .axisX2 = nc::Vector3::Front(),
         .axisY2 = nc::Vector3::Down(),
+        .detectFromPositions = false,
         .space = nc::physics::ConstraintSpace::Local
     };
 
@@ -92,6 +95,118 @@ TEST_F(ConstraintFactoryTest, MakeConstraint_FixedConstraint_oneBody_setsExpecte
     EXPECT_EQ(inConstraint.point2, nc::physics::ToVector3(actualSettings->mPoint2));
     EXPECT_EQ(inConstraint.axisX2, nc::physics::ToVector3(actualSettings->mAxisX2));
     EXPECT_EQ(inConstraint.axisY2, nc::physics::ToVector3(actualSettings->mAxisY2));
-    EXPECT_EQ(inConstraint.autoDetect, actualSettings->mAutoDetectPoint);
-    // can't test ConstraintSpace, returned settings are always local
+    // detectFromPosition is not saved to the settings
+}
+
+TEST_F(ConstraintFactoryTest, MakeConstraint_FixedConstraint_detectFromPositions_setsExpectedValues)
+{
+    const auto pos1 = JPH::Vec3{1.0f, 2.0f, 3.0f};
+    const auto pos2 = JPH::Vec3{4.0f, 5.0f, 6.0f};
+
+    auto body1 = CreateBody(pos1);
+    auto body2 = CreateBody(pos2);
+    SCOPE_EXIT
+    (
+        DestroyBody(body1);
+        DestroyBody(body2);
+    );
+
+    const auto inConstraint = nc::physics::FixedConstraintInfo{
+        .detectFromPositions = true,
+        .space = nc::physics::ConstraintSpace::World
+    };
+
+    const auto baseConstraint = uut.MakeConstraint(inConstraint, *body1, *body2);
+    const auto baseSettings = baseConstraint->GetConstraintSettings();
+    const auto actualSettings = static_cast<JPH::FixedConstraintSettings*>(baseSettings.GetPtr());
+
+    // expected points are in local space
+    constexpr auto scale = 0.5f;
+    const auto expectedPoint1 = nc::physics::ToVector3((pos2 - pos1) * scale);
+    const auto expectedPoint2 = nc::physics::ToVector3((pos1 - pos2) * scale);
+    const auto expectedRight = nc::Vector3::Right();
+    const auto expectedUp = nc::Vector3::Up();
+
+    EXPECT_EQ(expectedPoint1, nc::physics::ToVector3(actualSettings->mPoint1));
+    EXPECT_EQ(expectedRight, nc::physics::ToVector3(actualSettings->mAxisX1));
+    EXPECT_EQ(expectedUp, nc::physics::ToVector3(actualSettings->mAxisY1));
+    EXPECT_EQ(expectedPoint2, nc::physics::ToVector3(actualSettings->mPoint2));
+    EXPECT_EQ(expectedRight, nc::physics::ToVector3(actualSettings->mAxisX2));
+    EXPECT_EQ(expectedUp, nc::physics::ToVector3(actualSettings->mAxisY2));
+    // detectFromPosition is not saved to the settings
+}
+
+TEST_F(ConstraintFactoryTest, MakeConstraint_FixedConstraint_detectFromPositionsWithLocalSpace_throws)
+{
+    auto body1 = CreateBody();
+    auto body2 = CreateBody();
+    SCOPE_EXIT
+    (
+        DestroyBody(body1);
+        DestroyBody(body2);
+    );
+
+    const auto inConstraint = nc::physics::FixedConstraintInfo{
+        .detectFromPositions = true,
+        .space = nc::physics::ConstraintSpace::Local
+    };
+
+    EXPECT_THROW(uut.MakeConstraint(inConstraint, *body1, *body2), std::exception);
+}
+
+TEST_F(ConstraintFactoryTest, MakeConstraint_PointConstraint_twoBody_setsExpectedValues)
+{
+    auto body1 = CreateBody();
+    auto body2 = CreateBody();
+    SCOPE_EXIT
+    (
+        DestroyBody(body1);
+        DestroyBody(body2);
+    );
+
+    const auto inConstraint = nc::physics::PointConstraintInfo{
+        .point1 = nc::Vector3{1.0f, 2.0f, 3.0f},
+        .point2 = nc::Vector3{-1.0f, -2.0f, -3.0f},
+        .space = nc::physics::ConstraintSpace::World
+    };
+
+    const auto baseConstraint = uut.MakeConstraint(inConstraint, *body1, *body2);
+    const auto actualType = baseConstraint->GetType();
+    const auto actualSubType = baseConstraint->GetSubType();
+    ASSERT_EQ(JPH::EConstraintType::TwoBodyConstraint, actualType);
+    ASSERT_EQ(JPH::EConstraintSubType::Point, actualSubType);
+
+    const auto baseSettings = baseConstraint->GetConstraintSettings();
+    const auto actualSettings = static_cast<JPH::PointConstraintSettings*>(baseSettings.GetPtr());
+
+    EXPECT_EQ(inConstraint.point1, nc::physics::ToVector3(actualSettings->mPoint1));
+    EXPECT_EQ(inConstraint.point2, nc::physics::ToVector3(actualSettings->mPoint2));
+}
+
+TEST_F(ConstraintFactoryTest, MakeConstraint_PointConstraint_oneBody_setsExpectedValues)
+{
+    auto body1 = CreateBody();
+    auto dummy = &JPH::Body::sFixedToWorld;
+    SCOPE_EXIT
+    (
+        DestroyBody(body1);
+    );
+
+    const auto inConstraint = nc::physics::PointConstraintInfo{
+        .point1 = nc::Vector3{1.0f, 2.0f, 3.0f},
+        .point2 = nc::Vector3{-1.0f, -2.0f, -3.0f},
+        .space = nc::physics::ConstraintSpace::World
+    };
+
+    const auto baseConstraint = uut.MakeConstraint(inConstraint, *body1, *dummy);
+    const auto actualType = baseConstraint->GetType();
+    const auto actualSubType = baseConstraint->GetSubType();
+    ASSERT_EQ(JPH::EConstraintType::TwoBodyConstraint, actualType);
+    ASSERT_EQ(JPH::EConstraintSubType::Point, actualSubType);
+
+    const auto baseSettings = baseConstraint->GetConstraintSettings();
+    const auto actualSettings = static_cast<JPH::PointConstraintSettings*>(baseSettings.GetPtr());
+
+    EXPECT_EQ(inConstraint.point1, nc::physics::ToVector3(actualSettings->mPoint1));
+    EXPECT_EQ(inConstraint.point2, nc::physics::ToVector3(actualSettings->mPoint2));
 }

--- a/test/physics2/jolt/ConstraintManager_unit_tests.cpp
+++ b/test/physics2/jolt/ConstraintManager_unit_tests.cpp
@@ -7,7 +7,7 @@ class ConstraintManagerTest : public JoltApiFixture
         nc::physics::ConstraintManager uut;
 
         ConstraintManagerTest()
-            : uut{joltApi.physicsSystem}
+            : uut{joltApi.physicsSystem, 100u}
         {
         }
 };

--- a/test/physics2/jolt/ConstraintManager_unit_tests.cpp
+++ b/test/physics2/jolt/ConstraintManager_unit_tests.cpp
@@ -1,6 +1,8 @@
 #include "JoltApiFixture.inl"
 #include "physics2/jolt/ConstraintManager.h"
 
+#include "Jolt/Physics/Constraints/PointConstraint.h"
+
 class ConstraintManagerTest : public JoltApiFixture
 {
     protected:
@@ -16,7 +18,7 @@ constexpr auto g_entity1 = nc::Entity{0, 0, 0};
 constexpr auto g_entity2 = nc::Entity{42, 0, 0};
 constexpr auto g_entity3 = nc::Entity{21, 0, 0};
 
-TEST_F(ConstraintManagerTest, AddGetRemove_twoBody_succeeds)
+TEST_F(ConstraintManagerTest, AddConstraint_twoBody_succeeds)
 {
     const auto expectedInfo = nc::physics::PointConstraintInfo{
         .point1 = nc::Vector3{1.0f, 2.0f, 3.0f},
@@ -26,31 +28,19 @@ TEST_F(ConstraintManagerTest, AddGetRemove_twoBody_succeeds)
 
     auto body1 = CreateBody();
     auto body2 = CreateBody();
-    const auto actualId = uut.AddConstraint(expectedInfo, g_entity1, body1, g_entity2, body2);
+    const auto& actualConstraint = uut.AddConstraint(expectedInfo, g_entity1, body1, g_entity2, body2);
 
-    const auto entity1Views = uut.GetConstraints(g_entity1);
-    const auto entity2Views = uut.GetConstraints(g_entity2);
-    ASSERT_EQ(1ull, entity1Views.size());
-    ASSERT_EQ(0ull, entity2Views.size());
-
-    const auto& actualView = entity1Views[0];
-    EXPECT_EQ(g_entity2, actualView.referencedEntity);
-    EXPECT_EQ(actualId, actualView.id);
-
-    const auto& actualInfo = std::get<nc::physics::PointConstraintInfo>(actualView.info);
+    EXPECT_EQ(g_entity2, actualConstraint.GetConstraintTarget());
+    auto& actualInfo = std::get<nc::physics::PointConstraintInfo>(actualConstraint.GetInfo());
     EXPECT_EQ(expectedInfo.point1, actualInfo.point1);
     EXPECT_EQ(expectedInfo.point2, actualInfo.point2);
     EXPECT_EQ(expectedInfo.space, actualInfo.space);
-
-    EXPECT_NO_THROW(uut.RemoveConstraint(actualId));
-
-    EXPECT_EQ(0ull, uut.GetConstraints(g_entity1).size());
 
     DestroyBody(body1);
     DestroyBody(body2);
 }
 
-TEST_F(ConstraintManagerTest, AddGetRemove_oneBody_succeeds)
+TEST_F(ConstraintManagerTest, AddConstraint_oneBody_succeeds)
 {
     const auto expectedInfo = nc::physics::PointConstraintInfo{
         .point1 = nc::Vector3{1.0f, 2.0f, 3.0f},
@@ -60,47 +50,259 @@ TEST_F(ConstraintManagerTest, AddGetRemove_oneBody_succeeds)
 
     auto body = CreateBody();
     auto dummyBody = &JPH::Body::sFixedToWorld;
-    const auto actualId = uut.AddConstraint(expectedInfo, g_entity1, body, nc::Entity::Null(), dummyBody);
+    const auto& actualConstraint = uut.AddConstraint(expectedInfo, g_entity1, body, nc::Entity::Null(), dummyBody);
 
-    const auto views = uut.GetConstraints(g_entity1);
-    ASSERT_EQ(1ull, views.size());
+    const auto constraints = uut.GetConstraints(g_entity1);
+    ASSERT_EQ(1ull, constraints.size());
 
-    const auto& actualView = views[0];
-    EXPECT_EQ(nc::Entity::Null(), actualView.referencedEntity);
-    EXPECT_EQ(actualId, actualView.id);
-
-    const auto& actualInfo = std::get<nc::physics::PointConstraintInfo>(actualView.info);
+    EXPECT_EQ(nc::Entity::Null(), actualConstraint.GetConstraintTarget());
+    const auto& actualInfo = std::get<nc::physics::PointConstraintInfo>(actualConstraint.GetInfo());
     EXPECT_EQ(expectedInfo.point1, actualInfo.point1);
     EXPECT_EQ(expectedInfo.point2, actualInfo.point2);
     EXPECT_EQ(expectedInfo.space, actualInfo.space);
 
-    EXPECT_NO_THROW(uut.RemoveConstraint(actualId));
-
-    EXPECT_EQ(0ull, uut.GetConstraints(g_entity1).size());
-
     DestroyBody(body);
 }
 
-TEST_F(ConstraintManagerTest, AddGetRemove_multipleConstraintsBetweenBodies_succeeds)
+TEST_F(ConstraintManagerTest, AddConstraint_multipleConstraintsBetweenBodies_succeeds)
 {
     const auto expectedInfo = nc::physics::PointConstraintInfo{};
     auto body1 = CreateBody();
     auto body2 = CreateBody();
-    const auto body1Id1 = uut.AddConstraint(expectedInfo, g_entity1, body1, g_entity2, body2);
-    const auto body1Id2 = uut.AddConstraint(expectedInfo, g_entity1, body1, g_entity2, body2);
-    const auto body2Id1 = uut.AddConstraint(expectedInfo, g_entity2, body2, g_entity1, body1);
-    const auto body2Id2 = uut.AddConstraint(expectedInfo, g_entity2, body2, g_entity1, body1);
 
-    ASSERT_EQ(2ull, uut.GetConstraints(g_entity1).size());
-    ASSERT_EQ(2ull, uut.GetConstraints(g_entity2).size());
+    const auto& c1 = uut.AddConstraint(expectedInfo, g_entity1, body1, g_entity2, body2);
+    EXPECT_EQ(g_entity2, c1.GetConstraintTarget());
 
-    uut.RemoveConstraint(body2Id2);
-    uut.RemoveConstraint(body2Id1);
-    uut.RemoveConstraint(body1Id2);
-    uut.RemoveConstraint(body1Id1);
+    const auto& c2 = uut.AddConstraint(expectedInfo, g_entity1, body1, g_entity2, body2);
+    EXPECT_EQ(g_entity2, c2.GetConstraintTarget());
 
-    ASSERT_EQ(0ull, uut.GetConstraints(g_entity1).size());
-    ASSERT_EQ(0ull, uut.GetConstraints(g_entity2).size());
+    const auto& c3 = uut.AddConstraint(expectedInfo, g_entity2, body2, g_entity1, body1);
+    EXPECT_EQ(g_entity1, c3.GetConstraintTarget());
+
+    const auto& c4 = uut.AddConstraint(expectedInfo, g_entity2, body2, g_entity1, body1);
+    EXPECT_EQ(g_entity1, c4.GetConstraintTarget());
+
+    EXPECT_EQ(2ull, uut.GetConstraints(g_entity1).size());
+    EXPECT_EQ(2ull, uut.GetConstraints(g_entity2).size());
+
+    DestroyBody(body1);
+    DestroyBody(body2);
+}
+
+TEST_F(ConstraintManagerTest, EnableConstraint_updatesState)
+{
+    const auto expectedInfo = nc::physics::PointConstraintInfo{};
+    auto body1 = CreateBody();
+    auto body2 = CreateBody();
+    auto& constraint = uut.AddConstraint(expectedInfo, g_entity1, body1, g_entity2, body2);
+    const auto handle = uut.GetConstraintHandle(constraint.GetId());
+    EXPECT_TRUE(constraint.IsEnabled());
+    EXPECT_TRUE(handle->GetEnabled());
+
+    uut.EnableConstraint(constraint, false);
+    EXPECT_FALSE(constraint.IsEnabled());
+    EXPECT_FALSE(handle->GetEnabled());
+
+    uut.EnableConstraint(constraint, true);
+    EXPECT_TRUE(constraint.IsEnabled());
+    EXPECT_TRUE(handle->GetEnabled());
+
+    DestroyBody(body1);
+    DestroyBody(body2);
+}
+
+TEST_F(ConstraintManagerTest, EnableConstraint_staleConstraint_throws)
+{
+    const auto expectedInfo = nc::physics::PointConstraintInfo{};
+    auto body1 = CreateBody();
+    auto body2 = CreateBody();
+    auto constraint = uut.AddConstraint(expectedInfo, g_entity1, body1, g_entity2, body2);
+    uut.RemoveConstraint(constraint.GetId());
+    EXPECT_THROW(uut.EnableConstraint(constraint, true), std::exception);
+
+    DestroyBody(body1);
+    DestroyBody(body2);
+}
+
+TEST_F(ConstraintManagerTest, UpdateConstraint_sameType_updateSettings)
+{
+    const auto initialInfo = nc::physics::PointConstraintInfo{};
+    const auto expectedInfo = nc::physics::PointConstraintInfo{
+        .point1 = nc::Vector3{3.0f, 3.0f, 3.0f},
+        .point2 = nc::Vector3{4.0f, 4.0f, 4.0f}
+    };
+
+    auto body1 = CreateBody();
+    auto body2 = CreateBody();
+    auto& constraint = uut.AddConstraint(initialInfo, g_entity1, body1, g_entity2, body2);
+
+    constraint.GetInfo() = expectedInfo;
+    uut.UpdateConstraint(constraint);
+    auto handle = uut.GetConstraintHandle(constraint.GetId());
+    ASSERT_EQ(JPH::EConstraintSubType::Point, handle->GetSubType());
+    auto pointConstraintHandle = static_cast<JPH::PointConstraint*>(handle);
+
+    EXPECT_EQ(expectedInfo.point1, nc::physics::ToVector3(pointConstraintHandle->GetLocalSpacePoint1()));
+    EXPECT_EQ(expectedInfo.point2, nc::physics::ToVector3(pointConstraintHandle->GetLocalSpacePoint2()));
+
+    DestroyBody(body1);
+    DestroyBody(body2);
+}
+
+TEST_F(ConstraintManagerTest, UpdateConstraint_newType_buildsNewType)
+{
+    const auto initialInfo = nc::physics::PointConstraintInfo{};
+    const auto expectedInfo = nc::physics::FixedConstraintInfo{};
+
+    auto body1 = CreateBody();
+    auto body2 = CreateBody();
+    auto& constraint = uut.AddConstraint(initialInfo, g_entity1, body1, g_entity2, body2);
+
+    constraint.GetInfo() = expectedInfo;
+    uut.UpdateConstraint(constraint);
+    auto handle = uut.GetConstraintHandle(constraint.GetId());
+    EXPECT_EQ(JPH::EConstraintSubType::Fixed, handle->GetSubType());
+
+    DestroyBody(body1);
+    DestroyBody(body2);
+}
+
+TEST_F(ConstraintManagerTest, UpdateConstraint_disabled_preservesDisabledState)
+{
+    const auto initialInfo = nc::physics::FixedConstraintInfo{};
+    const auto updatedInfo = nc::physics::PointConstraintInfo{};
+    auto body1 = CreateBody();
+    auto body2 = CreateBody();
+    auto& constraint = uut.AddConstraint(initialInfo, g_entity1, body1, g_entity2, body2);
+    const auto handle = uut.GetConstraintHandle(constraint.GetId());
+
+    uut.EnableConstraint(constraint, false);
+    constraint.GetInfo() = updatedInfo;
+    uut.UpdateConstraint(constraint);
+    EXPECT_FALSE(constraint.IsEnabled());
+    EXPECT_FALSE(handle->GetEnabled());
+
+    uut.UpdateConstraintTarget(constraint, nc::Entity::Null(), &JPH::Body::sFixedToWorld);
+    EXPECT_FALSE(constraint.IsEnabled());
+    EXPECT_FALSE(handle->GetEnabled());
+}
+
+TEST_F(ConstraintManagerTest, UpdateConstraintTarget_attachedToOtherBody_attachToNewBody_updatesMapping)
+{
+    const auto info = nc::physics::FixedConstraintInfo{};
+    auto body1 = CreateBody();
+    auto body2 = CreateBody();
+    auto body3 = CreateBody();
+    auto& constraint = uut.AddConstraint(info, g_entity1, body1, g_entity2, body2);
+
+    uut.UpdateConstraintTarget(constraint, g_entity3, body3);
+    EXPECT_EQ(constraint.GetConstraintTarget(), g_entity3);
+    EXPECT_EQ(1u, uut.GetConstraints(g_entity1).size());
+    EXPECT_EQ(0u, uut.GetConstraints(g_entity2).size());
+    EXPECT_EQ(0u, uut.GetConstraints(g_entity3).size());
+
+    DestroyBody(body2);
+    EXPECT_NO_THROW(uut.RemoveConstraints(g_entity2));
+    EXPECT_EQ(1u, uut.GetConstraints(g_entity1).size());
+
+    DestroyBody(body3);
+    EXPECT_NO_THROW(uut.RemoveConstraints(g_entity3));
+    EXPECT_EQ(0u, uut.GetConstraints(g_entity1).size());
+
+    DestroyBody(body1);
+}
+
+TEST_F(ConstraintManagerTest, UpdateConstraintTarget_attachedToOtherBody_attachToWorld_updatesMapping)
+{
+    const auto info = nc::physics::FixedConstraintInfo{};
+    auto body1 = CreateBody();
+    auto body2 = CreateBody();
+    auto& constraint = uut.AddConstraint(info, g_entity1, body1, g_entity2, body2);
+
+    uut.UpdateConstraintTarget(constraint, nc::Entity::Null(), &JPH::Body::sFixedToWorld);
+    EXPECT_FALSE(constraint.GetConstraintTarget().Valid());
+    EXPECT_EQ(1u, uut.GetConstraints(g_entity1).size());
+    EXPECT_EQ(0u, uut.GetConstraints(g_entity2).size());
+
+    DestroyBody(body2);
+    EXPECT_NO_THROW(uut.RemoveConstraints(g_entity2));
+    EXPECT_EQ(1u, uut.GetConstraints(g_entity1).size());
+
+    DestroyBody(body1);
+    EXPECT_NO_THROW(uut.RemoveConstraints(g_entity1));
+    EXPECT_EQ(0u, uut.GetConstraints(g_entity1).size());
+}
+
+TEST_F(ConstraintManagerTest, UpdateConstraintTarget_attachedToWorld_attachToBody_updatesMapping)
+{
+    const auto info = nc::physics::FixedConstraintInfo{};
+    auto body1 = CreateBody();
+    auto body2 = CreateBody();
+    auto& constraint = uut.AddConstraint(info, g_entity1, body1, nc::Entity::Null(), &JPH::Body::sFixedToWorld);
+
+    uut.UpdateConstraintTarget(constraint, g_entity2, body2);
+    EXPECT_EQ(constraint.GetConstraintTarget(), g_entity2);
+    EXPECT_EQ(1u, uut.GetConstraints(g_entity1).size());
+    EXPECT_EQ(0u, uut.GetConstraints(g_entity2).size());
+
+    DestroyBody(body2);
+    EXPECT_NO_THROW(uut.RemoveConstraints(g_entity2));
+    EXPECT_EQ(0u, uut.GetConstraints(g_entity1).size());
+
+    DestroyBody(body1);
+    EXPECT_NO_THROW(uut.RemoveConstraints(g_entity1));
+}
+
+TEST_F(ConstraintManagerTest, UpdateConstraintTarget_attachToSelf_throws)
+{
+    const auto info = nc::physics::FixedConstraintInfo{};
+    auto body1 = CreateBody();
+    auto body2 = CreateBody();
+    auto& constraint = uut.AddConstraint(info, g_entity1, body1, g_entity2, body2);
+
+    EXPECT_THROW(uut.UpdateConstraintTarget(constraint, g_entity1, body1), std::exception);
+}
+
+TEST_F(ConstraintManagerTest, RemoveConstraint_twoBody_removesState)
+{
+    const auto info = nc::physics::PointConstraintInfo{};
+    auto body1 = CreateBody();
+    auto body2 = CreateBody();
+    const auto id = uut.AddConstraint(info, g_entity1, body1, g_entity2, body2).GetId();
+
+    EXPECT_NO_THROW(uut.RemoveConstraint(id));
+    EXPECT_TRUE(uut.GetConstraints(g_entity1).empty());
+
+    DestroyBody(body1);
+    DestroyBody(body2);
+}
+
+TEST_F(ConstraintManagerTest, RemoveConstraint_oneBody_removesState)
+{
+    const auto info = nc::physics::PointConstraintInfo{};
+    auto body = CreateBody();
+    const auto id = uut.AddConstraint(info, g_entity1, body, nc::Entity::Null(), &JPH::Body::sFixedToWorld).GetId();
+
+    EXPECT_NO_THROW(uut.RemoveConstraint(id));
+    EXPECT_TRUE(uut.GetConstraints(g_entity1).empty());
+
+    DestroyBody(body);
+}
+
+TEST_F(ConstraintManagerTest, RemoveConstraint_multipleConstraintsBetweenBodies_preservesOthers)
+{
+    const auto info = nc::physics::PointConstraintInfo{};
+    auto body1 = CreateBody();
+    auto body2 = CreateBody();
+    const auto toKeepId1 = uut.AddConstraint(info, g_entity1, body1, g_entity2, body2).GetId();
+    const auto toRemoveId = uut.AddConstraint(info, g_entity1, body1, g_entity2, body2).GetId();
+    const auto toKeepId2 = uut.AddConstraint(info, g_entity1, body1, g_entity2, body2).GetId();
+
+    uut.RemoveConstraint(toRemoveId);
+    auto remaining = uut.GetConstraints(g_entity1);
+    ASSERT_EQ(2u, remaining.size());
+    EXPECT_EQ(toKeepId1, remaining[0].GetId()); // want to preserve order for the editor
+    EXPECT_EQ(toKeepId2, remaining[1].GetId());
 
     DestroyBody(body1);
     DestroyBody(body2);
@@ -111,12 +313,12 @@ TEST_F(ConstraintManagerTest, RemoveConstraint_recyclesId)
     const auto expectedInfo = nc::physics::PointConstraintInfo{};
     auto body1 = CreateBody();
     auto body2 = CreateBody();
-    const auto toBeDeletedId = uut.AddConstraint(expectedInfo, g_entity1, body1, g_entity2, body2);
+    const auto& toBeDeletedId = uut.AddConstraint(expectedInfo, g_entity1, body1, g_entity2, body2).GetId();
     uut.AddConstraint(expectedInfo, g_entity1, body1, g_entity2, body2);
     uut.AddConstraint(expectedInfo, g_entity1, body1, g_entity2, body2);
 
     uut.RemoveConstraint(toBeDeletedId);
-    const auto recycledId = uut.AddConstraint(expectedInfo, g_entity1, body1, g_entity2, body2);
+    const auto recycledId = uut.AddConstraint(expectedInfo, g_entity1, body1, g_entity2, body2).GetId();
     EXPECT_EQ(toBeDeletedId, recycledId);
 
     uut.Clear();
@@ -134,7 +336,8 @@ TEST_F(ConstraintManagerTest, RemoveConstraint_doubleDelete_throws)
     const auto expectedInfo = nc::physics::PointConstraintInfo{};
     auto body1 = CreateBody();
     auto body2 = CreateBody();
-    const auto toBeDeletedId = uut.AddConstraint(expectedInfo, g_entity1, body1, g_entity2, body2);
+    const auto toBeDeleted = uut.AddConstraint(expectedInfo, g_entity1, body1, g_entity2, body2);
+    const auto toBeDeletedId = toBeDeleted.GetId();
     uut.RemoveConstraint(toBeDeletedId);
     EXPECT_THROW(uut.RemoveConstraint(toBeDeletedId), std::exception);
 }
@@ -186,12 +389,12 @@ TEST_F(ConstraintManagerTest, Clear_withNullptrsInList_succeeds)
     auto body1 = CreateBody();
     auto body2 = CreateBody();
     uut.AddConstraint(expectedInfo, g_entity1, body1, g_entity2, body2);
-    auto id2 = uut.AddConstraint(expectedInfo, g_entity1, body1, g_entity2, body2);
-    auto id3 = uut.AddConstraint(expectedInfo, g_entity2, body2, g_entity1, body1);
+    auto constraint2 = uut.AddConstraint(expectedInfo, g_entity1, body1, g_entity2, body2);
+    auto constraint3 = uut.AddConstraint(expectedInfo, g_entity2, body2, g_entity1, body1);
     uut.AddConstraint(expectedInfo, g_entity2, body2, g_entity1, body1);
 
-    uut.RemoveConstraint(id2);
-    uut.RemoveConstraint(id3);
+    uut.RemoveConstraint(constraint2.GetId());
+    uut.RemoveConstraint(constraint3.GetId());
     EXPECT_NO_THROW(uut.Clear());
     EXPECT_EQ(0ull, uut.GetConstraints(g_entity1).size());
     EXPECT_EQ(0ull, uut.GetConstraints(g_entity2).size());

--- a/test/physics2/jolt/ConstraintManager_unit_tests.cpp
+++ b/test/physics2/jolt/ConstraintManager_unit_tests.cpp
@@ -1,0 +1,201 @@
+#include "JoltApiFixture.inl"
+#include "physics2/jolt/ConstraintManager.h"
+
+class ConstraintManagerTest : public JoltApiFixture
+{
+    protected:
+        nc::physics::ConstraintManager uut;
+
+        ConstraintManagerTest()
+            : uut{joltApi.physicsSystem}
+        {
+        }
+};
+
+constexpr auto g_entity1 = nc::Entity{0, 0, 0};
+constexpr auto g_entity2 = nc::Entity{42, 0, 0};
+constexpr auto g_entity3 = nc::Entity{21, 0, 0};
+
+TEST_F(ConstraintManagerTest, AddGetRemove_twoBody_succeeds)
+{
+    const auto expectedInfo = nc::physics::PointConstraintInfo{
+        .point1 = nc::Vector3{1.0f, 2.0f, 3.0f},
+        .point2 = nc::Vector3{4.0f, 5.0f, 6.0f},
+        .space = nc::physics::ConstraintSpace::World
+    };
+
+    auto body1 = CreateBody();
+    auto body2 = CreateBody();
+    const auto actualId = uut.AddConstraint(expectedInfo, g_entity1, body1, g_entity2, body2);
+
+    const auto entity1Views = uut.GetConstraints(g_entity1);
+    const auto entity2Views = uut.GetConstraints(g_entity2);
+    ASSERT_EQ(1ull, entity1Views.size());
+    ASSERT_EQ(0ull, entity2Views.size());
+
+    const auto& actualView = entity1Views[0];
+    EXPECT_EQ(g_entity2, actualView.referencedEntity);
+    EXPECT_EQ(actualId, actualView.id);
+
+    const auto& actualInfo = std::get<nc::physics::PointConstraintInfo>(actualView.info);
+    EXPECT_EQ(expectedInfo.point1, actualInfo.point1);
+    EXPECT_EQ(expectedInfo.point2, actualInfo.point2);
+    EXPECT_EQ(expectedInfo.space, actualInfo.space);
+
+    EXPECT_NO_THROW(uut.RemoveConstraint(actualId));
+
+    EXPECT_EQ(0ull, uut.GetConstraints(g_entity1).size());
+
+    DestroyBody(body1);
+    DestroyBody(body2);
+}
+
+TEST_F(ConstraintManagerTest, AddGetRemove_oneBody_succeeds)
+{
+    const auto expectedInfo = nc::physics::PointConstraintInfo{
+        .point1 = nc::Vector3{1.0f, 2.0f, 3.0f},
+        .point2 = nc::Vector3{4.0f, 5.0f, 6.0f},
+        .space = nc::physics::ConstraintSpace::World
+    };
+
+    auto body = CreateBody();
+    auto dummyBody = &JPH::Body::sFixedToWorld;
+    const auto actualId = uut.AddConstraint(expectedInfo, g_entity1, body, nc::Entity::Null(), dummyBody);
+
+    const auto views = uut.GetConstraints(g_entity1);
+    ASSERT_EQ(1ull, views.size());
+
+    const auto& actualView = views[0];
+    EXPECT_EQ(nc::Entity::Null(), actualView.referencedEntity);
+    EXPECT_EQ(actualId, actualView.id);
+
+    const auto& actualInfo = std::get<nc::physics::PointConstraintInfo>(actualView.info);
+    EXPECT_EQ(expectedInfo.point1, actualInfo.point1);
+    EXPECT_EQ(expectedInfo.point2, actualInfo.point2);
+    EXPECT_EQ(expectedInfo.space, actualInfo.space);
+
+    EXPECT_NO_THROW(uut.RemoveConstraint(actualId));
+
+    EXPECT_EQ(0ull, uut.GetConstraints(g_entity1).size());
+
+    DestroyBody(body);
+}
+
+TEST_F(ConstraintManagerTest, AddGetRemove_multipleConstraintsBetweenBodies_succeeds)
+{
+    const auto expectedInfo = nc::physics::PointConstraintInfo{};
+    auto body1 = CreateBody();
+    auto body2 = CreateBody();
+    const auto body1Id1 = uut.AddConstraint(expectedInfo, g_entity1, body1, g_entity2, body2);
+    const auto body1Id2 = uut.AddConstraint(expectedInfo, g_entity1, body1, g_entity2, body2);
+    const auto body2Id1 = uut.AddConstraint(expectedInfo, g_entity2, body2, g_entity1, body1);
+    const auto body2Id2 = uut.AddConstraint(expectedInfo, g_entity2, body2, g_entity1, body1);
+
+    ASSERT_EQ(2ull, uut.GetConstraints(g_entity1).size());
+    ASSERT_EQ(2ull, uut.GetConstraints(g_entity2).size());
+
+    uut.RemoveConstraint(body2Id2);
+    uut.RemoveConstraint(body2Id1);
+    uut.RemoveConstraint(body1Id2);
+    uut.RemoveConstraint(body1Id1);
+
+    ASSERT_EQ(0ull, uut.GetConstraints(g_entity1).size());
+    ASSERT_EQ(0ull, uut.GetConstraints(g_entity2).size());
+
+    DestroyBody(body1);
+    DestroyBody(body2);
+}
+
+TEST_F(ConstraintManagerTest, RemoveConstraint_recyclesId)
+{
+    const auto expectedInfo = nc::physics::PointConstraintInfo{};
+    auto body1 = CreateBody();
+    auto body2 = CreateBody();
+    const auto toBeDeletedId = uut.AddConstraint(expectedInfo, g_entity1, body1, g_entity2, body2);
+    uut.AddConstraint(expectedInfo, g_entity1, body1, g_entity2, body2);
+    uut.AddConstraint(expectedInfo, g_entity1, body1, g_entity2, body2);
+
+    uut.RemoveConstraint(toBeDeletedId);
+    const auto recycledId = uut.AddConstraint(expectedInfo, g_entity1, body1, g_entity2, body2);
+    EXPECT_EQ(toBeDeletedId, recycledId);
+
+    uut.Clear();
+    DestroyBody(body1);
+    DestroyBody(body2);
+}
+
+TEST_F(ConstraintManagerTest, RemoveConstraint_badId_throws)
+{
+    EXPECT_THROW(uut.RemoveConstraint(100), std::exception);
+}
+
+TEST_F(ConstraintManagerTest, RemoveConstraint_doubleDelete_throws)
+{
+    const auto expectedInfo = nc::physics::PointConstraintInfo{};
+    auto body1 = CreateBody();
+    auto body2 = CreateBody();
+    const auto toBeDeletedId = uut.AddConstraint(expectedInfo, g_entity1, body1, g_entity2, body2);
+    uut.RemoveConstraint(toBeDeletedId);
+    EXPECT_THROW(uut.RemoveConstraint(toBeDeletedId), std::exception);
+}
+
+TEST_F(ConstraintManagerTest, RemoveConstraints_noConstraints_succeeds)
+{
+    EXPECT_NO_THROW(uut.RemoveConstraints(g_entity1));
+}
+
+TEST_F(ConstraintManagerTest, RemoveConstraints_removesFromSelfAndOthers)
+{
+    const auto expectedInfo = nc::physics::PointConstraintInfo{};
+    auto body1 = CreateBody();
+    auto body2 = CreateBody();
+    auto body3 = CreateBody();
+    uut.AddConstraint(expectedInfo, g_entity1, body1, g_entity2, body2);
+    uut.AddConstraint(expectedInfo, g_entity1, body1, g_entity2, body2);
+    uut.AddConstraint(expectedInfo, g_entity2, body2, g_entity1, body1);
+    uut.AddConstraint(expectedInfo, g_entity2, body2, g_entity1, body1);
+    uut.AddConstraint(expectedInfo, g_entity2, body2, g_entity3, body3);
+    uut.AddConstraint(expectedInfo, g_entity3, body3, g_entity1, body1);
+
+    ASSERT_EQ(2ull, uut.GetConstraints(g_entity1).size());
+    ASSERT_EQ(3ull, uut.GetConstraints(g_entity2).size());
+    ASSERT_EQ(1ull, uut.GetConstraints(g_entity3).size());
+
+    uut.RemoveConstraints(g_entity1);
+    ASSERT_EQ(0ull, uut.GetConstraints(g_entity1).size());
+    ASSERT_EQ(1ull, uut.GetConstraints(g_entity2).size());
+    ASSERT_EQ(0ull, uut.GetConstraints(g_entity3).size());
+
+    uut.RemoveConstraints(g_entity2);
+    ASSERT_EQ(0ull, uut.GetConstraints(g_entity2).size());
+    ASSERT_EQ(0ull, uut.GetConstraints(g_entity3).size());
+
+    DestroyBody(body1);
+    DestroyBody(body2);
+    DestroyBody(body3);
+}
+
+TEST_F(ConstraintManagerTest, Clear_triviallySucceeds)
+{
+    EXPECT_NO_THROW(uut.Clear());
+}
+
+TEST_F(ConstraintManagerTest, Clear_withNullptrsInList_succeeds)
+{
+    const auto expectedInfo = nc::physics::PointConstraintInfo{};
+    auto body1 = CreateBody();
+    auto body2 = CreateBody();
+    uut.AddConstraint(expectedInfo, g_entity1, body1, g_entity2, body2);
+    auto id2 = uut.AddConstraint(expectedInfo, g_entity1, body1, g_entity2, body2);
+    auto id3 = uut.AddConstraint(expectedInfo, g_entity2, body2, g_entity1, body1);
+    uut.AddConstraint(expectedInfo, g_entity2, body2, g_entity1, body1);
+
+    uut.RemoveConstraint(id2);
+    uut.RemoveConstraint(id3);
+    EXPECT_NO_THROW(uut.Clear());
+    EXPECT_EQ(0ull, uut.GetConstraints(g_entity1).size());
+    EXPECT_EQ(0ull, uut.GetConstraints(g_entity2).size());
+
+    DestroyBody(body1);
+    DestroyBody(body2);
+}

--- a/test/physics2/jolt/ConstraintManager_unit_tests.cpp
+++ b/test/physics2/jolt/ConstraintManager_unit_tests.cpp
@@ -1,4 +1,5 @@
 #include "JoltApiFixture.inl"
+#include "physics2/jolt/Conversion.h"
 #include "physics2/jolt/ConstraintManager.h"
 
 #include "Jolt/Physics/Constraints/PointConstraint.h"

--- a/test/physics2/jolt/ContactListener_integration_tests.cpp
+++ b/test/physics2/jolt/ContactListener_integration_tests.cpp
@@ -1,10 +1,13 @@
 #include "gtest/gtest.h"
 #include "JobSystem_stub.inl"
 #include "physics2/jolt/ContactListener.h"
+#include "physics2/jolt/Conversion.h"
 #include "physics2/jolt/JoltApi.h"
 #include "ncengine/config/Config.h"
+#include "ncengine/physics/RigidBody.h"
 
 #include "Jolt/Physics/Body/BodyCreationSettings.h"
+#include "Jolt/Physics/Collision/Shape/BoxShape.h"
 
 #include <ranges>
 

--- a/test/physics2/jolt/ContactListener_stub.inl
+++ b/test/physics2/jolt/ContactListener_stub.inl
@@ -1,0 +1,19 @@
+#include "physics2/jolt/ContactListener.h"
+
+namespace nc::physics
+{
+void ContactListener::OnContactAdded(const JPH::Body&,
+                                     const JPH::Body&,
+                                     const JPH::ContactManifold&,
+                                     JPH::ContactSettings&)
+{
+}
+
+void ContactListener::OnContactRemoved(const JPH::SubShapeIDPair&)
+{
+}
+
+void ContactListener::CommitPendingChanges()
+{
+}
+} // namespace nc::physics

--- a/test/physics2/jolt/JoltApiFixture.inl
+++ b/test/physics2/jolt/JoltApiFixture.inl
@@ -1,0 +1,54 @@
+#include "gtest/gtest.h"
+#include "ContactListener_stub.inl"
+#include "JobSystem_stub.inl"
+#include "ncengine/config/Config.h"
+#include "physics2/jolt/JoltApi.h"
+
+#include "Jolt/Physics/Body/BodyCreationSettings.h"
+#include "Jolt/Physics/Collision/Shape/BoxShape.h"
+
+class JoltApiFixture : public ::testing::Test
+{
+    protected:
+        nc::physics::JoltApi joltApi;
+
+        JoltApiFixture(uint32_t tempAllocatorSize = 1024 * 1024 * 4,
+                       uint32_t maxBodyPairs = 8,
+                       uint32_t maxContacts = 4)
+            : joltApi{nc::physics::JoltApi::Initialize(
+                  nc::config::MemorySettings{},
+                  nc::config::PhysicsSettings{
+                    .tempAllocatorSize = tempAllocatorSize,
+                    .maxBodyPairs = maxBodyPairs,
+                    .maxContacts = maxContacts
+                  },
+                  nc::task::AsyncDispatcher{}
+              )}
+        {
+        }
+
+        auto CreateBody(const JPH::Vec3& position = JPH::Vec3::sZero(),
+                        const JPH::Quat& rotation = JPH::Quat::sIdentity()) -> JPH::Body*
+        {
+            auto bodySettings = JPH::BodyCreationSettings{
+                new JPH::BoxShape(JPH::Vec3::sReplicate(0.5f)),
+                position,
+                rotation,
+                JPH::EMotionType::Dynamic,
+                JPH::ObjectLayer{0}
+            };
+
+            auto& interface = joltApi.physicsSystem.GetBodyInterfaceNoLock();
+            auto body = interface.CreateBody(bodySettings);
+            interface.AddBody(body->GetID(), JPH::EActivation::Activate);
+            return body;
+        }
+
+        void DestroyBody(const JPH::Body* body)
+        {
+            auto& interface = joltApi.physicsSystem.GetBodyInterfaceNoLock();
+            const auto id = body->GetID();
+            interface.RemoveBody(id);
+            interface.DestroyBody(id);
+        }
+};

--- a/test/physics2/jolt/JoltConversion_unit_tests.cpp
+++ b/test/physics2/jolt/JoltConversion_unit_tests.cpp
@@ -62,3 +62,9 @@ TEST(JoltConversionTest, ToMotionType_convertsBodyType)
     EXPECT_EQ(JPH::EMotionType::Static, ToMotionType(nc::physics::BodyType::Static));
     EXPECT_EQ(JPH::EMotionType::Kinematic, ToMotionType(nc::physics::BodyType::Kinematic));
 }
+
+TEST(JoltConversionTest, ToConstraintSpace_convertsSpace)
+{
+    EXPECT_EQ(JPH::EConstraintSpace::WorldSpace, ToConstraintSpace(nc::physics::ConstraintSpace::World));
+    EXPECT_EQ(JPH::EConstraintSpace::LocalToBodyCOM, ToConstraintSpace(nc::physics::ConstraintSpace::Local));
+}

--- a/test/physics2/jolt/ShapeFactory_unit_tests.cpp
+++ b/test/physics2/jolt/ShapeFactory_unit_tests.cpp
@@ -1,28 +1,8 @@
-#include "gtest/gtest.h"
-#include "JobSystem_stub.inl"
+#include "JoltApiFixture.inl"
 #include "physics2/jolt/ShapeFactory.h"
-#include "physics2/jolt/JoltApi.h"
-#include "ncengine/config/Config.h"
 
-class ShapeFactoryTest : public ::testing::Test
+class ShapeFactoryTest : public JoltApiFixture
 {
-    private:
-        nc::physics::JoltApi m_jolt;
-
-    protected:
-        ShapeFactoryTest()
-            : m_jolt{nc::physics::JoltApi::Initialize(
-                  nc::config::MemorySettings{},
-                  nc::config::PhysicsSettings{
-                    .tempAllocatorSize = 1024 * 1024 * 4,
-                    .maxBodyPairs = 8,
-                    .maxContacts = 4
-                  },
-                  nc::task::AsyncDispatcher{}
-              )}
-        {
-        }
-
     public:
         nc::physics::ShapeFactory uut;
 };


### PR DESCRIPTION
resolves #696 

Full change set for constraints was getting outrageously large. This is a just a few of the pieces needed:
- Adding a few constraint-related types to API
- Adding `ConstraintFactory` to build `Jolt::Constraint`s from our `ConstraintInfo` types.
- Adding `ConstraintManager` to track constraints and maintain a mapping between constraints and body pairs.
- Updating `NormalizeScaleForShape()` to compute an average scale if the current and desired scales are equal. (same behavior if scales are different - if we resize in editor, scale based on which axis was scaled)
- Adding `JoltApiFixture` helper for tests. Physics tests are generally using the same base setup, so it cuts down a bit on repetition.