### PR TITLE
use move_only_function

### DIFF
--- a/include/ncengine/ecs/Component.h
+++ b/include/ncengine/ecs/Component.h
@@ -104,23 +104,24 @@ template<PooledComponent T>
 struct ComponentHandler
 {
     /** @brief Function type for the Factory handler. */
-    using Factory_t = std::function<T(Entity entity, const std::any& userData)>;
+    using Factory_t = std::move_only_function<T(Entity entity,
+                                                const std::any& userData)>;
 
     /** @brief Function type for the serialize handler. */
-    using Serialize_t = std::function<void(std::ostream& binaryStream,
-                                           const T& component,
-                                           const SerializationContext& ctx,
-                                           const std::any& userData)>;
+    using Serialize_t = std::move_only_function<void(std::ostream& binaryStream,
+                                                     const T& component,
+                                                     const SerializationContext& ctx,
+                                                     const std::any& userData)>;
 
     /** @brief Function type for the deserialize handler. */
-    using Deserialize_t = std::function<T(std::istream& binaryStream,
-                                          const DeserializationContext& ctx,
-                                          const std::any& userData)>;
+    using Deserialize_t = std::move_only_function<T(std::istream& binaryStream,
+                                                    const DeserializationContext& ctx,
+                                                    const std::any& userData)>;
 
     /** @brief Function type for the DrawUI handler. */
-    using DrawUI_t = std::function<void(T& component,
-                                        ui::editor::EditorContext& ctx,
-                                        const std::any& userData)>;
+    using DrawUI_t = std::move_only_function<void(T& component,
+                                                  ui::editor::EditorContext& ctx,
+                                                  const std::any& userData)>;
 
     /**
      * @brief A unique identifier for the component.

--- a/include/ncengine/ecs/FrameLogic.h
+++ b/include/ncengine/ecs/FrameLogic.h
@@ -12,7 +12,7 @@
 namespace nc
 {
 /** @brief FrameLogic callable member type */
-using FrameLogicCallable_t = std::function<void(Entity self, ecs::Ecs world, float dt)>;
+using FrameLogicCallable_t = std::move_only_function<void(Entity self, ecs::Ecs world, float dt)>;
 
 /** @brief FrameLogic callable type requirements */
 template<class Func>

--- a/include/ncengine/physics/CollisionListener.h
+++ b/include/ncengine/physics/CollisionListener.h
@@ -12,30 +12,22 @@
 namespace nc
 {
 /** @brief Callback type for collision enter events. */
-using OnCollisionEnter_t = std::function<void(Entity self,
-                                              Entity other,
-                                              const HitInfo& hit,
-                                              ecs::Ecs world)>;
+using OnCollisionHitEvent_t = std::move_only_function<void(Entity self,
+                                                           Entity other,
+                                                           const HitInfo& hit,
+                                                           ecs::Ecs world)>;
 
-/** @brief Callback type for collision exit events. */
-using OnCollisionExit_t = std::function<void(Entity self,
-                                             Entity other,
-                                             ecs::Ecs world)>;
-
-/** @brief Callback type for trigger enter events. */
-using OnTriggerEnter_t = std::function<void(Entity self,
-                                            Entity other,
-                                            ecs::Ecs world)>;
-
-/** @brief Callback type for trigger exit events. */
-using OnTriggerExit_t = OnTriggerEnter_t;
+/** @brief Callback type for collision exit, trigger enter, and trigger exit events. */
+using OnCollisionEvent_t = std::move_only_function<void(Entity self,
+                                                        Entity other,
+                                                        ecs::Ecs world)>;
 
 /** @brief Component that receives collision event callbacks. */
 struct CollisionListener
 {
-    OnCollisionEnter_t onEnter = nullptr;
-    OnCollisionExit_t onExit = nullptr;
-    OnTriggerEnter_t onTriggerEnter = nullptr;
-    OnTriggerExit_t onTriggerExit = nullptr;
+    OnCollisionHitEvent_t onEnter = nullptr;
+    OnCollisionEvent_t onExit = nullptr;
+    OnCollisionEvent_t onTriggerEnter = nullptr;
+    OnCollisionEvent_t onTriggerExit = nullptr;
 };
 } // namespace nc

--- a/include/ncengine/physics/CollisionQuery.h
+++ b/include/ncengine/physics/CollisionQuery.h
@@ -62,6 +62,9 @@ class CollisionQuery
     public:
         /** @brief Construct a CollisionQuery capable of testing against bodies which pass a filter. */
         explicit CollisionQuery(const CollisionQueryFilter& filter = CollisionQueryFilter{});
+
+        CollisionQuery(CollisionQuery&&) noexcept;
+        CollisionQuery& operator=(CollisionQuery&&) noexcept;
         ~CollisionQuery() noexcept;
 
         /** @brief Query for the first \ref RigidBody "body" that a ray intersects. */

--- a/include/ncengine/serialize/SceneSerialization.h
+++ b/include/ncengine/serialize/SceneSerialization.h
@@ -49,7 +49,7 @@ struct DeserializationContext
 void SaveSceneFragment(std::ostream& stream,
                        ecs::Ecs ecs,
                        const asset::AssetMap& assets,
-                       std::function<bool(Entity)> entityFilter = nullptr);
+                       std::move_only_function<bool(Entity)> entityFilter = nullptr);
 
 /** @brief Load game state from a binary stream. */
 void LoadSceneFragment(std::istream& stream,

--- a/include/ncengine/utility/Signal.h
+++ b/include/ncengine/utility/Signal.h
@@ -72,8 +72,8 @@ class Signal
         Signal(const Signal&) = delete;
         Signal& operator=(const Signal&) = delete;
 
-        /** @brief Connect a std::function */
-        [[nodiscard]] auto Connect(std::function<void(Args...)> func, size_t priority = SignalPriority::Highest) -> Connection
+        /** @brief Connect a std::move_only_function */
+        [[nodiscard]] auto Connect(std::move_only_function<void(Args...)> func, size_t priority = SignalPriority::Highest) -> Connection
         {
             const auto pos = std::ranges::find_if(m_slots, [priority](auto&& slot)
             {
@@ -123,7 +123,7 @@ class Signal
         void Emit(Args... args)
         {
             Sync();
-            for (const auto& slot : m_slots)
+            for (auto& slot : m_slots)
             {
                 slot(args...);
             }

--- a/include/ncengine/utility/detail/SignalInternal.h
+++ b/include/ncengine/utility/detail/SignalInternal.h
@@ -83,7 +83,7 @@ template<class... Args>
 class Slot
 {
     public:
-        Slot(std::function<void(Args...)> func, ConnectionBacklink* link, size_t priority, int id)
+        Slot(std::move_only_function<void(Args...)> func, ConnectionBacklink* link, size_t priority, int id)
             : m_func{std::move(func)},
               m_state{std::make_shared<SharedConnectionState>(link, id)},
               m_priority{priority},
@@ -101,7 +101,7 @@ class Slot
             return m_priority;
         }
 
-        void operator()(Args... args) const
+        void operator()(Args... args)
         {
             m_func(args...);
         }
@@ -112,7 +112,7 @@ class Slot
         }
 
     private:
-        std::function<void(Args...)> m_func;
+        std::move_only_function<void(Args...)> m_func;
         std::shared_ptr<SharedConnectionState> m_state;
         size_t m_priority;
         int m_id;

--- a/source/engine/physics/CollisionQuery.cpp
+++ b/source/engine/physics/CollisionQuery.cpp
@@ -70,6 +70,8 @@ CollisionQuery::CollisionQuery(const CollisionQueryFilter& filter)
 {
 }
 
+CollisionQuery::CollisionQuery(CollisionQuery&&) noexcept = default;
+CollisionQuery& CollisionQuery::operator=(CollisionQuery&&) noexcept = default;
 CollisionQuery::~CollisionQuery() noexcept = default;
 
 auto CollisionQuery::CastRay(const Ray& ray) const -> RayCastResult

--- a/source/engine/serialize/EntitySerializationUtility.cpp
+++ b/source/engine/serialize/EntitySerializationUtility.cpp
@@ -4,7 +4,7 @@ namespace
 {
 void AddChildren(nc::Entity parent,
                  nc::ecs::ExplicitEcs<nc::Hierarchy> ecs,
-                 std::function<bool(nc::Entity)>& filter,
+                 std::move_only_function<bool(nc::Entity)>& filter,
                  std::vector<nc::Entity>& out)
 {
     auto included = ecs.Get<nc::Hierarchy>(parent).children |
@@ -45,7 +45,7 @@ auto ReconstructEntityInfo(nc::Entity entity,
 namespace nc
 {
 auto BuildFragmentEntityList(std::span<const Entity> in,
-                             std::function<bool(Entity)>& filter,
+                             std::move_only_function<bool(Entity)>& filter,
                              ecs::ExplicitEcs<Hierarchy> ecs) -> std::vector<Entity>
 {
     // All parents must precede their children, so we want a list of all root nodes that pass the filter.

--- a/source/engine/serialize/EntitySerializationUtility.h
+++ b/source/engine/serialize/EntitySerializationUtility.h
@@ -19,7 +19,7 @@ struct FragmentEntityInfo
 
 // Build a list of all entities to include in a scene fragment. All parents are guaranteed to precede their children.
 auto BuildFragmentEntityList(std::span<const Entity> in,
-                             std::function<bool(Entity)>& filter,
+                             std::move_only_function<bool(Entity)>& filter,
                              ecs::ExplicitEcs<Hierarchy> ecs) -> std::vector<Entity>;
 
 // Build a map of Entity to fragment id.

--- a/source/engine/serialize/SceneSerialization.cpp
+++ b/source/engine/serialize/SceneSerialization.cpp
@@ -61,7 +61,7 @@ void LoadAssets(std::istream& stream, nc::asset::NcAsset& assetModule)
 }
 
 void SaveEntities(std::ostream& stream,
-                  std::function<bool(nc::Entity)>& entityFilter,
+                  std::move_only_function<bool(nc::Entity)>& entityFilter,
                   nc::SerializationContext& ctx)
 {
     const auto entities = nc::BuildFragmentEntityList(ctx.ecs.GetAll<nc::Entity>(), entityFilter, ctx.ecs);
@@ -176,7 +176,7 @@ namespace nc
 void SaveSceneFragment(std::ostream& stream,
                        ecs::Ecs ecs,
                        const asset::AssetMap& assets,
-                       std::function<bool(Entity)> entityFilter)
+                       std::move_only_function<bool(Entity)> entityFilter)
 {
     NC_LOG_TRACE("Saving SceneFragment");
     static constexpr auto defaultEntityFilter = [](Entity){ return true; };

--- a/source/engine/ui/editor/impl/windows/dialogs/SceneDialogs.cpp
+++ b/source/engine/ui/editor/impl/windows/dialogs/SceneDialogs.cpp
@@ -12,7 +12,7 @@ namespace
 {
 auto BuildSimpleFilter(bool includePersistent)
 {
-    return std::function<bool(nc::Entity)>{[includePersistent](nc::Entity entity)
+    return std::move_only_function<bool(nc::Entity)>{[includePersistent](nc::Entity entity)
     {
         return includePersistent ? true : !entity.IsPersistent();
     }};
@@ -26,7 +26,7 @@ auto BuildLayerFilter(bool includePersistent, const std::vector<uint8_t>& includ
         layerFlags.at(included) = true;
     }
 
-    return std::function<bool(nc::Entity)>{[flags = std::move(layerFlags), includePersistent](nc::Entity entity)
+    return std::move_only_function<bool(nc::Entity)>{[flags = std::move(layerFlags), includePersistent](nc::Entity entity)
     {
         return (!includePersistent && entity.IsPersistent()) ? false : flags.at(entity.Layer());
     }};
@@ -184,7 +184,7 @@ void SaveSceneDialog::OnSave()
     }
 }
 
-auto SaveSceneDialog::SelectFilter() -> std::function<bool(Entity)>
+auto SaveSceneDialog::SelectFilter() -> std::move_only_function<bool(Entity)>
 {
     return m_layerInclusionType == LayerInclusionAll
         ? BuildSimpleFilter(m_includePersistent)

--- a/source/engine/ui/editor/impl/windows/dialogs/SceneDialogs.h
+++ b/source/engine/ui/editor/impl/windows/dialogs/SceneDialogs.h
@@ -60,7 +60,7 @@ class SaveSceneDialog : public ModalDialog
         void EnableAllLayers();
         void DisableAllLayers();
         void OnSave();
-        auto SelectFilter() -> std::function<bool(Entity)>;
+        auto SelectFilter() -> std::move_only_function<bool(Entity)>;
 };
 
 class LoadSceneDialog : public ModalDialog


### PR DESCRIPTION
Switching some `std::function`s to `std::move_only_function`s. Almost a drop in replacement, but new version correctly respects const, which required a tiny tweak to `Signal`/`Slot`.

This is most important in `FrameLogic` and `CollisionListener`, where it allows capturing move-only types, like `CollisionQuery` (also this was accidentally made non-copyable, non-movable; fixed here).  