### PR TITLE
Logging Improvements + Rerouting Diligent Messages

### DIFF
--- a/include/ncengine/config/Config.h
+++ b/include/ncengine/config/Config.h
@@ -13,8 +13,6 @@ namespace nc::config
 struct ProjectSettings
 {
     std::string projectName = "Project Name";
-    std::string logFilePath = "NcEngine.log";
-    size_t logMaxFileSize = 1000000ull;
 };
 
 /** @brief Settings for configuring the engine run loop and executor. */

--- a/include/ncengine/utility/FileLogger.h
+++ b/include/ncengine/utility/FileLogger.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "Log.h"
+
+#include "ncengine/type/StableAddress.h"
+
+#include <mutex>
+#include <string>
+#include <vector>
+
+namespace nc
+{
+/** @brief Basic file logging implementation. Construct this on the stack in main() to reroute logging to a file. */
+class FileLogger : public StableAddress
+{
+    public:
+        static constexpr auto DefaultMaxLogSize = 1000000ull;
+        static constexpr auto DefaultMessageFlushCount = 20ull;
+
+        FileLogger(std::string_view logFilePath,
+                   size_t logMaxFileSize = DefaultMaxLogSize,
+                   size_t messageFlushCount = DefaultMessageFlushCount);
+
+        ~FileLogger() noexcept;
+
+    private:
+        static inline FileLogger* s_instance = nullptr;
+        std::mutex m_mutex;
+        std::vector<std::string> m_messages;
+        std::string m_logPath;
+        size_t m_maxSize;
+        size_t m_messageFlushCount;
+
+        static void Log(LogCategory category,
+                        std::string_view subsystem,
+                        std::string_view file,
+                        int line,
+                        std::string_view message);
+
+        void BufferMessage(std::string&& message);
+        void Flush() noexcept;
+};
+} // namespace nc

--- a/include/ncengine/utility/FileLogger.h
+++ b/include/ncengine/utility/FileLogger.h
@@ -1,3 +1,7 @@
+/**
+ * @file FileLogger.h
+ * @copyright Jaremie Romer and McCallister Romer 2024
+ */
 #pragma once
 
 #include "Log.h"

--- a/include/ncengine/utility/Log.h
+++ b/include/ncengine/utility/Log.h
@@ -1,27 +1,62 @@
 /**
  * @file Log.h
- * @copyright Jaremie Romer and McCallister Romer 2023
+ * @copyright Jaremie Romer and McCallister Romer 2024
  */
 #pragma once
 
 #include "detail/LogInternal.h"
 
-#include "fmt/format.h"
+#include <string_view>
+
+namespace nc
+{
+/** @brief Type of a log message. */
+enum class LogCategory : char
+{
+    Info    = 'I',
+    Warning = 'W',
+    Error   = 'E',
+    Verbose = 'V'
+};
+
+/** @brief Function type for receiving logging messages. */
+using LogCallback_t = void(*)(LogCategory category,
+                              std::string_view subsystem,
+                              std::string_view function,
+                              int line,
+                              std::string_view message);
+
+/** @brief Set a callback to reroute logging messages (defaults to stdout). */
+void SetLogCallback(LogCallback_t callback);
+
+/** @brief Log callback instance. */
+extern LogCallback_t LogCallback;
+} // namespace nc
 
 #if NC_LOG_LEVEL >= 1
-    #define NC_LOG_INFO(str, ...)         NC_LOG_IMPL('I', str NC_OPT_EXPAND(__VA_ARGS__));
-    #define NC_LOG_WARNING(str, ...)      NC_LOG_IMPL('W', str NC_OPT_EXPAND(__VA_ARGS__));
-    #define NC_LOG_ERROR(str, ...)        NC_LOG_IMPL('E', str NC_OPT_EXPAND(__VA_ARGS__));
-    #define NC_LOG_EXCEPTION(exception)   nc::utility::detail::Log(exception);
+    #define NC_LOG_INFO(str, ...)         nc::LogCallback(nc::LogCategory::Info,    NC_LOG_CAPTURE_DEFAULT_ARGS(str NC_OPT_EXPAND(__VA_ARGS__)));
+    #define NC_LOG_WARNING(str, ...)      nc::LogCallback(nc::LogCategory::Warning, NC_LOG_CAPTURE_DEFAULT_ARGS(str NC_OPT_EXPAND(__VA_ARGS__)));
+    #define NC_LOG_ERROR(str, ...)        nc::LogCallback(nc::LogCategory::Error,   NC_LOG_CAPTURE_DEFAULT_ARGS(str NC_OPT_EXPAND(__VA_ARGS__)));
+    #define NC_LOG_EXCEPTION(exception)   nc::detail::LogException(exception);
+
+    #define NC_LOG_INFO_EXT(subsystem, file, line, str)    nc::LogCallback(nc::LogCategory::Info, subsystem, file, line, str);
+    #define NC_LOG_WARNING_EXT(subsystem, file, line, str) nc::LogCallback(nc::LogCategory::Warning, subsystem, file, line, str);
+    #define NC_LOG_ERROR_EXT(subsystem, file, line, str)   nc::LogCallback(nc::LogCategory::Error, subsystem, file, line, str);
 #else
     #define NC_LOG_INFO(str, ...);
     #define NC_LOG_WARNING(str, ...);
     #define NC_LOG_ERROR(str, ...);
     #define NC_LOG_EXCEPTION(exception);
+
+    #define NC_LOG_INFO_EXT(subsystem, file, line, str);
+    #define NC_LOG_WARNING_EXT(subsystem, file, line, str);
+    #define NC_LOG_ERROR_EXT(subsystem, file, line, str);
 #endif
 
 #if NC_LOG_LEVEL >= 2
-    #define NC_LOG_TRACE(str, ...)        NC_LOG_IMPL('V', str NC_OPT_EXPAND(__VA_ARGS__));
+    #define NC_LOG_TRACE(str, ...)                         nc::LogCallback(nc::LogCategory::Verbose, NC_LOG_CAPTURE_DEFAULT_ARGS(str NC_OPT_EXPAND(__VA_ARGS__)));
+    #define NC_LOG_TRACE_EXT(subsystem, file, line, str)   nc::LogCallback(nc::LogCategory::Verbose, subsystem, file, line, str);
 #else
     #define NC_LOG_TRACE(str, ...);
+    #define NC_LOG_TRACE_EXT(subsystem, file, line, str);
 #endif

--- a/include/ncengine/utility/Log.h
+++ b/include/ncengine/utility/Log.h
@@ -29,19 +29,29 @@ using LogCallback_t = void(*)(LogCategory category,
 /** @brief Set a callback to reroute logging messages (defaults to stdout). */
 void SetLogCallback(LogCallback_t callback);
 
-/** @brief Log callback instance. */
+/** @cond internal */
+namespace detail
+{
 extern LogCallback_t LogCallback;
+
+void DefaultLogCallback(LogCategory category,
+                        std::string_view subsystem,
+                        std::string_view function,
+                        int line,
+                        std::string_view message);
+} // namespace detail
+/** @endcond internal */
 } // namespace nc
 
 #if NC_LOG_LEVEL >= 1
-    #define NC_LOG_INFO(str, ...)         nc::LogCallback(nc::LogCategory::Info,    NC_LOG_CAPTURE_DEFAULT_ARGS(str NC_OPT_EXPAND(__VA_ARGS__)));
-    #define NC_LOG_WARNING(str, ...)      nc::LogCallback(nc::LogCategory::Warning, NC_LOG_CAPTURE_DEFAULT_ARGS(str NC_OPT_EXPAND(__VA_ARGS__)));
-    #define NC_LOG_ERROR(str, ...)        nc::LogCallback(nc::LogCategory::Error,   NC_LOG_CAPTURE_DEFAULT_ARGS(str NC_OPT_EXPAND(__VA_ARGS__)));
+    #define NC_LOG_INFO(str, ...)         nc::detail::LogCallback(nc::LogCategory::Info,    NC_LOG_CAPTURE_DEFAULT_ARGS(str NC_OPT_EXPAND(__VA_ARGS__)));
+    #define NC_LOG_WARNING(str, ...)      nc::detail::LogCallback(nc::LogCategory::Warning, NC_LOG_CAPTURE_DEFAULT_ARGS(str NC_OPT_EXPAND(__VA_ARGS__)));
+    #define NC_LOG_ERROR(str, ...)        nc::detail::LogCallback(nc::LogCategory::Error,   NC_LOG_CAPTURE_DEFAULT_ARGS(str NC_OPT_EXPAND(__VA_ARGS__)));
     #define NC_LOG_EXCEPTION(exception)   nc::detail::LogException(exception);
 
-    #define NC_LOG_INFO_EXT(subsystem, file, line, str)    nc::LogCallback(nc::LogCategory::Info, subsystem, file, line, str);
-    #define NC_LOG_WARNING_EXT(subsystem, file, line, str) nc::LogCallback(nc::LogCategory::Warning, subsystem, file, line, str);
-    #define NC_LOG_ERROR_EXT(subsystem, file, line, str)   nc::LogCallback(nc::LogCategory::Error, subsystem, file, line, str);
+    #define NC_LOG_INFO_EXT(subsystem, file, line, str)    nc::detail::LogCallback(nc::LogCategory::Info, subsystem, file, line, str);
+    #define NC_LOG_WARNING_EXT(subsystem, file, line, str) nc::detail::LogCallback(nc::LogCategory::Warning, subsystem, file, line, str);
+    #define NC_LOG_ERROR_EXT(subsystem, file, line, str)   nc::detail::LogCallback(nc::LogCategory::Error, subsystem, file, line, str);
 #else
     #define NC_LOG_INFO(str, ...);
     #define NC_LOG_WARNING(str, ...);
@@ -54,8 +64,8 @@ extern LogCallback_t LogCallback;
 #endif
 
 #if NC_LOG_LEVEL >= 2
-    #define NC_LOG_TRACE(str, ...)                         nc::LogCallback(nc::LogCategory::Verbose, NC_LOG_CAPTURE_DEFAULT_ARGS(str NC_OPT_EXPAND(__VA_ARGS__)));
-    #define NC_LOG_TRACE_EXT(subsystem, file, line, str)   nc::LogCallback(nc::LogCategory::Verbose, subsystem, file, line, str);
+    #define NC_LOG_TRACE(str, ...)                         nc::detail::LogCallback(nc::LogCategory::Verbose, NC_LOG_CAPTURE_DEFAULT_ARGS(str NC_OPT_EXPAND(__VA_ARGS__)));
+    #define NC_LOG_TRACE_EXT(subsystem, file, line, str)   nc::detail::LogCallback(nc::LogCategory::Verbose, subsystem, file, line, str);
 #else
     #define NC_LOG_TRACE(str, ...);
     #define NC_LOG_TRACE_EXT(subsystem, file, line, str);

--- a/include/ncengine/utility/detail/LogInternal.h
+++ b/include/ncengine/utility/detail/LogInternal.h
@@ -5,6 +5,7 @@
 #include "fmt/format.h"
 
 #include <exception>
+#include <utility>
 
 namespace nc::detail
 {

--- a/sample/config.ini
+++ b/sample/config.ini
@@ -52,7 +52,7 @@ near_clip=0.5
 far_clip=400
 use_shadows=1
 antialiasing=8
-use_validation_layers=1
+use_validation_layers=0
 [audio_settings]
 audio_enabled=1
 buffer_frames=512

--- a/sample/config.ini
+++ b/sample/config.ini
@@ -1,7 +1,5 @@
 [project_settings]
 project_name=NcEngine Samples
-log_file_path=Sample.log
-log_max_file_size=1000000
 [engine_settings]
 time_step=0.01667
 max_time_step=0.1
@@ -54,7 +52,7 @@ near_clip=0.5
 far_clip=400
 use_shadows=1
 antialiasing=8
-use_validation_layers=0
+use_validation_layers=1
 [audio_settings]
 audio_enabled=1
 buffer_frames=512

--- a/source/ncengine/config/Config.cpp
+++ b/source/ncengine/config/Config.cpp
@@ -18,8 +18,6 @@ using namespace std::literals;
 
 // project
 constexpr auto ProjectNameKey = "project_name"sv;
-constexpr auto LogFilePathKey = "log_file_path"sv;
-constexpr auto LogMaxFileSizeKey = "log_max_file_size"sv;
 
 // engine
 constexpr auto TimeStepKey = "time_step"sv;
@@ -189,8 +187,6 @@ auto BuildFromConfigMap(const std::unordered_map<std::string, std::string>& kvPa
     if constexpr (std::same_as<Struct_t, nc::config::ProjectSettings>)
     {
         ParseValueIfExists(out.projectName, ProjectNameKey, kvPairs);
-        ParseValueIfExists(out.logFilePath, LogFilePathKey, kvPairs);
-        ParseValueIfExists(out.logMaxFileSize, LogMaxFileSizeKey, kvPairs);
     }
     else if constexpr (std::same_as<Struct_t, nc::config::EngineSettings>)
     {
@@ -349,8 +345,6 @@ void Write(std::ostream& stream, const Config& config, bool writeSections)
 {
     if (writeSections) stream << "[project_settings]\n";
     ::WriteKVPair(stream, ProjectNameKey, config.projectSettings.projectName);
-    ::WriteKVPair(stream, LogFilePathKey, config.projectSettings.logFilePath);
-    ::WriteKVPair(stream, LogMaxFileSizeKey, config.projectSettings.logMaxFileSize);
 
     if (writeSections) stream << "[engine_settings]\n";
     ::WriteKVPair(stream, TimeStepKey, config.engineSettings.timeStep);
@@ -418,8 +412,6 @@ void Write(std::ostream& stream, const Config& config, bool writeSections)
 bool Validate(const Config& config)
 {
     return (config.projectSettings.projectName != "") &&
-           (config.projectSettings.logFilePath != "") &&
-           (config.projectSettings.logMaxFileSize > 0) &&
            (config.engineSettings.timeStep >= 0.0f) &&
            (config.engineSettings.maxTimeStep > 0.0f) &&
            (config.assetSettings.audioClipsPath != "") &&

--- a/source/ncengine/config/default_config.ini
+++ b/source/ncengine/config/default_config.ini
@@ -1,7 +1,5 @@
 [project_settings]
 project_name=Project Name
-log_file_path=Diagnostics.log
-log_max_file_size=1000000
 [engine_settings]
 time_step=0.01667
 max_time_step=0.1

--- a/source/ncengine/engine/NcEngineImpl.cpp
+++ b/source/ncengine/engine/NcEngineImpl.cpp
@@ -60,13 +60,11 @@ namespace nc
 {
 auto InitializeNcEngine(const config::Config& config) -> std::unique_ptr<NcEngine>
 {
-    utility::detail::InitializeLog(config.projectSettings);
     NC_LOG_INFO("Creating NcEngine instance v{}", NC_PROJECT_VERSION);
     ::LogConfig(config);
     if (!config::Validate(config))
     {
         NC_LOG_ERROR("NcEngine initialization failed: invalid config");
-        utility::detail::CloseLog();
         throw NcError("NcEngine initialization failed: invalid config");
     }
 
@@ -92,7 +90,6 @@ NcEngineImpl::NcEngineImpl(const config::Config& config)
 NcEngineImpl::~NcEngineImpl() noexcept
 {
     Shutdown();
-    utility::detail::CloseLog();
 }
 
 void NcEngineImpl::Start(std::unique_ptr<Scene> initialScene)

--- a/source/ncengine/graphics2/NcGraphicsImpl2.cpp
+++ b/source/ncengine/graphics2/NcGraphicsImpl2.cpp
@@ -56,10 +56,9 @@ struct NcGraphicsStub2 : nc::graphics::NcGraphics
     void ClearEnvironment() override {}
 };
 
-auto MakeEngineCreateInfo(bool enableValidation) -> Diligent::EngineCreateInfo
+auto MakeEngineCreateInfo() -> Diligent::EngineCreateInfo
 {
     auto engineCI = Diligent::EngineCreateInfo{};
-    engineCI.EnableValidation = enableValidation;
     engineCI.Features.BindlessResources = Diligent::DEVICE_FEATURE_STATE_ENABLED;
     engineCI.Features.ShaderResourceRuntimeArrays = Diligent::DEVICE_FEATURE_STATE_ENABLED;
     return engineCI;
@@ -136,13 +135,7 @@ NcGraphicsImpl2::NcGraphicsImpl2(const config::GraphicsSettings& graphicsSetting
                                  window::NcWindow& window)
         : m_registry{registry},
           m_onResizeConnection{window.OnResize().Connect(this, &NcGraphicsImpl2::OnResize)},
-          m_engine{
-            graphicsSettings,
-            MakeEngineCreateInfo(graphicsSettings.useValidationLayers),
-            window.GetWindowHandle(),
-            GetSupportedApis(),
-            ::LogCallback
-          },
+          m_engine{graphicsSettings, MakeEngineCreateInfo(), window.GetWindowHandle(), GetSupportedApis(), ::LogCallback},
           m_shaderBindings{m_engine.GetDevice(), memorySettings.maxTextures},
           m_assetDispatch{
             m_engine.GetContext(),

--- a/source/ncengine/graphics2/NcGraphicsImpl2.cpp
+++ b/source/ncengine/graphics2/NcGraphicsImpl2.cpp
@@ -56,12 +56,36 @@ struct NcGraphicsStub2 : nc::graphics::NcGraphics
     void ClearEnvironment() override {}
 };
 
-auto MakeEngineCreateInfo() -> Diligent::EngineCreateInfo
+auto MakeEngineCreateInfo(bool enableValidation) -> Diligent::EngineCreateInfo
 {
     auto engineCI = Diligent::EngineCreateInfo{};
+    engineCI.EnableValidation = enableValidation;
     engineCI.Features.BindlessResources = Diligent::DEVICE_FEATURE_STATE_ENABLED;
     engineCI.Features.ShaderResourceRuntimeArrays = Diligent::DEVICE_FEATURE_STATE_ENABLED;
     return engineCI;
+}
+
+void LogCallback(Diligent::DEBUG_MESSAGE_SEVERITY severity,
+                 const char* msg,
+                 const char*,
+                 const char* file,
+                 int line)
+{
+    constexpr auto subsystem = "Diligent";
+    if (!file) file = "";
+    switch (severity)
+    {
+        case Diligent::DEBUG_MESSAGE_SEVERITY_INFO:
+            NC_LOG_TRACE_EXT(subsystem, file, line, msg);
+            break;
+        case Diligent::DEBUG_MESSAGE_SEVERITY_WARNING:
+            NC_LOG_WARNING_EXT(subsystem, file, line, msg);
+            break;
+        case Diligent::DEBUG_MESSAGE_SEVERITY_ERROR:
+        case Diligent::DEBUG_MESSAGE_SEVERITY_FATAL_ERROR:
+            NC_LOG_ERROR_EXT(subsystem, file, line, msg);
+            break;
+    }
 }
 } // anonymous namespace
 
@@ -112,7 +136,13 @@ NcGraphicsImpl2::NcGraphicsImpl2(const config::GraphicsSettings& graphicsSetting
                                  window::NcWindow& window)
         : m_registry{registry},
           m_onResizeConnection{window.OnResize().Connect(this, &NcGraphicsImpl2::OnResize)},
-          m_engine{graphicsSettings, MakeEngineCreateInfo(), window.GetWindowHandle(), GetSupportedApis()},
+          m_engine{
+            graphicsSettings,
+            MakeEngineCreateInfo(graphicsSettings.useValidationLayers),
+            window.GetWindowHandle(),
+            GetSupportedApis(),
+            ::LogCallback
+          },
           m_shaderBindings{m_engine.GetDevice(), memorySettings.maxTextures},
           m_assetDispatch{
             m_engine.GetContext(),

--- a/source/ncengine/utility/CMakeLists.txt
+++ b/source/ncengine/utility/CMakeLists.txt
@@ -1,4 +1,5 @@
 target_sources(${NC_ENGINE_LIB}
     PRIVATE
+        FileLogger.cpp
         Log.cpp
 )

--- a/source/ncengine/utility/FileLogger.cpp
+++ b/source/ncengine/utility/FileLogger.cpp
@@ -29,6 +29,11 @@ FileLogger::FileLogger(std::string_view logFilePath,
       m_maxSize{logMaxFileSize},
       m_messageFlushCount{messageFlushCount}
 {
+    if (!std::filesystem::exists(m_logPath))
+    {
+        std::ofstream{m_logPath};
+    }
+
     s_instance = this;
     SetLogCallback(FileLogger::Log);
     NC_LOG_INFO("Log started: {}", ::GetDateTime());

--- a/source/ncengine/utility/FileLogger.cpp
+++ b/source/ncengine/utility/FileLogger.cpp
@@ -1,0 +1,87 @@
+#include "ncengine/utility/FileLogger.h"
+
+#include "ncutility/NcError.h"
+#include "ncutility/platform/Platform.h"
+
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+
+namespace
+{
+NC_DISABLE_WARNING_PUSH
+NC_DISABLE_WARNING_MSVC(4996)
+auto GetDateTime()
+{
+    const auto timePoint = std::chrono::system_clock::now();
+    const auto time = std::chrono::system_clock::to_time_t(timePoint);
+    return std::ctime(&time);
+}
+NC_DISABLE_WARNING_POP
+} // anonymous namespace
+
+namespace nc
+{
+FileLogger::FileLogger(std::string_view logFilePath,
+                       size_t logMaxFileSize,
+                       size_t messageFlushCount)
+    : m_logPath{logFilePath},
+      m_maxSize{logMaxFileSize},
+      m_messageFlushCount{messageFlushCount}
+{
+    s_instance = this;
+    SetLogCallback(FileLogger::Log);
+    NC_LOG_INFO("Log started: {}", ::GetDateTime());
+}
+
+FileLogger::~FileLogger() noexcept
+{
+    NC_LOG_INFO("Log ended: {}", ::GetDateTime());
+    Flush();
+    s_instance = nullptr;
+}
+
+void FileLogger::Log(LogCategory category,
+                     std::string_view subsystem,
+                     std::string_view file,
+                     int line,
+                     std::string_view message)
+{
+    NC_ASSERT(s_instance, "No FileLogger constructed");
+    s_instance->BufferMessage(NC_LOG_FMT_MSG(category, subsystem, file, line, message));
+}
+
+void FileLogger::BufferMessage(std::string&& message)
+{
+    const auto lock = std::lock_guard{m_mutex};
+    m_messages.push_back(std::move(message));
+    if (m_messages.size() > m_messageFlushCount)
+    {
+        Flush();
+    }
+}
+
+void FileLogger::Flush() noexcept
+{
+    try
+    {
+        if (std::filesystem::file_size(m_logPath) > m_maxSize)
+        {
+            std::filesystem::rename(m_logPath, m_logPath + ".1");
+        }
+
+        auto file = std::ofstream{m_logPath, std::ios::app};
+        for(const auto& message : m_messages)
+        {
+            file << message;
+        }
+
+        m_messages.clear();
+    }
+    catch(const std::exception& e)
+    {
+        std::cerr << e.what() << '\n';
+    }
+}
+} // namespace nc

--- a/source/ncengine/utility/FileLogger.cpp
+++ b/source/ncengine/utility/FileLogger.cpp
@@ -1,6 +1,5 @@
 #include "ncengine/utility/FileLogger.h"
 
-#include "ncutility/NcError.h"
 #include "ncutility/platform/Platform.h"
 
 #include <chrono>
@@ -40,6 +39,12 @@ FileLogger::~FileLogger() noexcept
     NC_LOG_INFO("Log ended: {}", ::GetDateTime());
     Flush();
     s_instance = nullptr;
+
+    // Don't leave a dangling ptr behind, but verify cb hasn't already been changed.
+    if (detail::LogCallback == FileLogger::Log)
+    {
+        SetLogCallback(detail::DefaultLogCallback);
+    }
 }
 
 void FileLogger::Log(LogCategory category,
@@ -48,7 +53,6 @@ void FileLogger::Log(LogCategory category,
                      int line,
                      std::string_view message)
 {
-    NC_ASSERT(s_instance, "No FileLogger constructed");
     s_instance->BufferMessage(NC_LOG_FMT_MSG(category, subsystem, file, line, message));
 }
 

--- a/source/ncengine/utility/Log.cpp
+++ b/source/ncengine/utility/Log.cpp
@@ -3,112 +3,34 @@
 
 #include "ncutility/NcError.h"
 
-#include <chrono>
-#include <filesystem>
-#include <fstream>
 #include <iostream>
-#include <mutex>
-#include <vector>
 
 namespace
 {
-/** @todo MSVC warns simply that we're using time_t. It'd be better to avoid ctime
- *        altogether - new chrono stuff may offer a better way? */
-auto GetDateTime()
+void ConsoleLog(nc::LogCategory category,
+                std::string_view subsystem,
+                std::string_view function,
+                int line,
+                std::string_view message)
 {
-#if defined(_MSC_VER)
-#pragma warning( push )
-#pragma warning( disable : 4996 )
-#endif
-    const auto timePoint = std::chrono::system_clock::now();
-    const auto time = std::chrono::system_clock::to_time_t(timePoint);
-    return std::ctime(&time);
-#if defined(_MSC_VER)
-#pragma warning( pop )
-#endif
-}
-
-struct LogEntry
-{
-    std::string message;
-    char prefix;
-};
-
-constexpr auto MaxMessageCount = 20ull;
-auto g_mutex = std::mutex{};
-auto g_messages = std::vector<LogEntry>{};
-auto g_logPath = std::string{};
-auto g_logMaxSize = 0ull;
-
-void FlushLogToFile() noexcept
-{
-    try
-    {
-        if (std::filesystem::file_size(g_logPath) > g_logMaxSize)
-        {
-            std::filesystem::rename(g_logPath, g_logPath + ".1");
-        }
-
-        auto file = std::ofstream{g_logPath, std::ios::app};
-        for(const auto& item : g_messages)
-        {
-            file << item.prefix << ' ' << item.message << '\n';
-        }
-
-        g_messages.clear();
-    }
-    catch(const std::exception& e)
-    {
-        std::cerr << e.what() << '\n';
-    }
+    std::cout << NC_LOG_FMT_MSG(category, subsystem, function, line, message);
 }
 } // anonymous namespace
 
-namespace nc::utility::detail
+namespace nc
 {
-void InitializeLog(const config::ProjectSettings& settings)
-{
-    const auto lock = std::lock_guard{g_mutex};
-    g_logPath = settings.logFilePath;
-    g_logMaxSize = settings.logMaxFileSize;
-    auto file = std::ofstream{g_logPath, std::ios::out | std::ios::app};
-    if (!file)
-    {
-        throw NcError(fmt::format("Failed to initialize log: {}", g_logPath));
-    }
+LogCallback_t LogCallback = ::ConsoleLog;
 
-    file << "Log started: " << ::GetDateTime();
+void SetLogCallback(LogCallback_t callback)
+{
+    LogCallback = callback;
 }
 
-void CloseLog() noexcept
+namespace detail
 {
-    const auto lock = std::lock_guard{g_mutex};
-    ::FlushLogToFile();
-    /** @todo Reopening the file here is a wild choice, but attempts to queue up the
-     *        time_t as a string before the flush segfault. Fix when ctime is gone. */
-    auto file = std::ofstream{g_logPath, std::ios::app};
-    file << "Log ended: " << ::GetDateTime() << '\n';
-}
-
-void Log(char prefix, std::string_view item) noexcept
+void LogException(const std::exception& e) noexcept
 {
-    const auto lock = std::lock_guard{g_mutex};
-    g_messages.emplace_back(std::string{item}, prefix);
-    if (g_messages.size() > MaxMessageCount)
-    {
-        ::FlushLogToFile();
-    }
-}
-
-void Log(char prefix, std::string_view file, int line, std::string_view item) noexcept
-{
-    Log(prefix, fmt::format("{}:{}: {}", file, line, item));
-}
-
-void Log(const std::exception& e) noexcept
-{
-    Log('E', fmt::format("***Exception*** {}", e.what()));
-    std::cerr << e.what();
+    LogCallback(LogCategory::Error, "NcEngine", "", 0, fmt::format("***EXCEPTION***\n{}", e.what()));
 
     try
     {
@@ -116,7 +38,8 @@ void Log(const std::exception& e) noexcept
     }
     catch(const std::exception& rethrown)
     {
-        Log(rethrown);
+        LogException(rethrown);
     }
 }
-} // namespace nc::utility
+} // namespace detail
+} // namespace nc

--- a/source/ncengine/utility/Log.cpp
+++ b/source/ncengine/utility/Log.cpp
@@ -1,33 +1,27 @@
 #include "ncengine/utility/Log.h"
-#include "ncengine/config/Config.h"
-
-#include "ncutility/NcError.h"
 
 #include <iostream>
 
-namespace
-{
-void ConsoleLog(nc::LogCategory category,
-                std::string_view subsystem,
-                std::string_view function,
-                int line,
-                std::string_view message)
-{
-    std::cout << NC_LOG_FMT_MSG(category, subsystem, function, line, message);
-}
-} // anonymous namespace
-
 namespace nc
 {
-LogCallback_t LogCallback = ::ConsoleLog;
-
 void SetLogCallback(LogCallback_t callback)
 {
-    LogCallback = callback;
+    detail::LogCallback = callback;
 }
 
 namespace detail
 {
+LogCallback_t LogCallback = DefaultLogCallback;
+
+void DefaultLogCallback(nc::LogCategory category,
+                        std::string_view subsystem,
+                        std::string_view function,
+                        int line,
+                        std::string_view message)
+{
+    std::cout << NC_LOG_FMT_MSG(category, subsystem, function, line, message);
+}
+
 void LogException(const std::exception& e) noexcept
 {
     LogCallback(LogCategory::Error, "NcEngine", "", 0, fmt::format("***EXCEPTION***\n{}", e.what()));

--- a/test/ncengine/config/Config_tests.cpp
+++ b/test/ncengine/config/Config_tests.cpp
@@ -52,14 +52,12 @@ TEST(ConfigTests, Read_partialConfig_succeeds)
     auto stream = std::istringstream
     {
         "project_name=PartialCollateral\n"
-        "log_file_path=Partial.log\n"
         "max_transforms=100\n"
         "use_validation_layers=1\n"
     };
 
     const auto actual = nc::config::Read(stream);
     EXPECT_STREQ("PartialCollateral", actual.projectSettings.projectName.c_str());
-    EXPECT_STREQ("Partial.log", actual.projectSettings.logFilePath.c_str());
     EXPECT_EQ(100, actual.memorySettings.maxTransforms);
     EXPECT_TRUE(actual.graphicsSettings.useValidationLayers);
 }
@@ -104,8 +102,6 @@ TEST(ConfigTests, SaveLoad_roundTrip_preservesData)
     const auto actual = nc::config::Load(filepath);
 
     EXPECT_EQ(expected.projectSettings.projectName, actual.projectSettings.projectName);
-    EXPECT_EQ(expected.projectSettings.logFilePath, actual.projectSettings.logFilePath);
-    EXPECT_EQ(expected.projectSettings.logMaxFileSize, actual.projectSettings.logMaxFileSize);
 
     EXPECT_FLOAT_EQ(expected.engineSettings.timeStep, actual.engineSettings.timeStep);
     EXPECT_FLOAT_EQ(expected.engineSettings.maxTimeStep, actual.engineSettings.maxTimeStep);

--- a/test/ncengine/config/collateral/config.ini
+++ b/test/ncengine/config/collateral/config.ini
@@ -4,8 +4,6 @@
 
 [project_settings]
 project_name =  ConfigTests_Collateral
-log_file_path=Diagnostics.log
-log_max_file_size=1000000
 [engine_settings]
 time_step=0.01667
 max_time_step=0.1

--- a/test/ncengine/utility/CMakeLists.txt
+++ b/test/ncengine/utility/CMakeLists.txt
@@ -1,3 +1,33 @@
+### Log Tests ###
+add_executable(Log_tests
+    Log_tests.cpp
+    ${NC_SOURCE_DIR}/utility/Log.cpp
+    ${NC_SOURCE_DIR}/utility/FileLogger.cpp
+)
+
+target_include_directories(Log_tests
+    PRIVATE
+        ${NC_INCLUDE_DIR}
+)
+
+target_compile_definitions(Log_tests
+    PRIVATE
+        -DNC_LOG_LEVEL=2
+)
+
+target_compile_options(Log_tests
+    PUBLIC
+        ${NC_COMPILER_FLAGS}
+)
+
+target_link_libraries(Log_tests
+    PRIVATE
+        NcUtility
+        gtest_main
+)
+
+add_test(Log_tests Log_tests)
+
 ### Signal Tests ###
 add_executable(Signal_unit_tests
     Signal_unit_tests.cpp

--- a/test/ncengine/utility/Log_tests.cpp
+++ b/test/ncengine/utility/Log_tests.cpp
@@ -1,0 +1,178 @@
+#include "gtest/gtest.h"
+#include "ncengine/utility/Log.h"
+#include "ncengine/utility/FileLogger.h"
+
+#include "ncutility/NcError.h"
+
+#include <filesystem>
+#include <fstream>
+
+class LogTest : public testing::Test
+{
+    protected:
+        void TearDown() override
+        {
+            nc::SetLogCallback(nc::detail::DefaultLogCallback);
+        }
+};
+
+class FileLoggerTest : public testing::Test
+{
+    protected:
+        static constexpr auto MaxMessageCount = 3ull;
+        std::filesystem::path testLogPath = "";
+
+        auto MakeUut() -> nc::FileLogger
+        {
+            return nc::FileLogger{testLogPath.string(), 10000, MaxMessageCount};
+        }
+
+        void SetUp() override
+        {
+            testLogPath = std::filesystem::temp_directory_path() / "nc_test.log";
+            auto file = std::ofstream{testLogPath};
+            if (!file)
+            {
+                throw nc::NcError{"Failed to create temporary log file"};
+            }
+        }
+
+        void TearDown() override
+        {
+            if (!testLogPath.empty())
+            {
+                std::filesystem::remove(testLogPath);
+            }
+        }
+};
+
+TEST_F(LogTest, DefaultCallback_logsToStdout)
+{
+    constexpr auto subsystem = std::string_view{"Testing"};
+    constexpr auto file = std::string_view{"Log_tests.cpp"};
+    constexpr auto line = 100;
+    constexpr auto info = std::string_view{"something informative, perhaps"};
+    constexpr auto warning = std::string_view{"an undesirable"};
+    constexpr auto error = std::string_view{"even worse"};
+    constexpr auto trace = std::string_view{"chatty cathy"};
+
+    {
+        testing::internal::CaptureStdout();
+        NC_LOG_INFO_EXT(subsystem, file, line, info);
+        const auto expected = NC_LOG_FMT_MSG(nc::LogCategory::Info, subsystem, file, line, info);
+        EXPECT_EQ(expected, testing::internal::GetCapturedStdout());
+    }
+
+    {
+        testing::internal::CaptureStdout();
+        NC_LOG_WARNING_EXT(subsystem, file, line, warning);
+        const auto expected = NC_LOG_FMT_MSG(nc::LogCategory::Warning, subsystem, file, line, warning);
+        EXPECT_EQ(expected, testing::internal::GetCapturedStdout());
+    }
+
+    {
+        testing::internal::CaptureStdout();
+        NC_LOG_ERROR_EXT(subsystem, file, line, error);
+        const auto expected = NC_LOG_FMT_MSG(nc::LogCategory::Error, subsystem, file, line, error);
+        EXPECT_EQ(expected, testing::internal::GetCapturedStdout());
+    }
+
+    {
+        testing::internal::CaptureStdout();
+        NC_LOG_TRACE_EXT(subsystem, file, line, trace);
+        const auto expected = NC_LOG_FMT_MSG(nc::LogCategory::Verbose, subsystem, file, line, trace);
+        EXPECT_EQ(expected, testing::internal::GetCapturedStdout());
+    }
+}
+
+TEST_F(LogTest, SetLogCallback_registersFunction)
+{
+    static auto called = false;
+    auto callback = [](nc::LogCategory category,
+                       std::string_view subsystem,
+                       std::string_view function,
+                       int line,
+                       std::string_view message)
+    {
+        called = true;
+        EXPECT_EQ(nc::LogCategory::Info, category);
+        EXPECT_STREQ("TestSubsystem", subsystem.data());
+        EXPECT_STREQ("TestFile", function.data());
+        EXPECT_EQ(42, line);
+        EXPECT_STREQ("TestMessage", message.data());
+    };
+
+    nc::SetLogCallback(callback);
+    NC_LOG_INFO_EXT("TestSubsystem", "TestFile", 42, "TestMessage");
+    EXPECT_TRUE(called);
+}
+
+TEST_F(FileLoggerTest, Constructor_registersCallback)
+{
+    nc::SetLogCallback(nullptr);
+    EXPECT_EQ(nullptr, nc::detail::LogCallback);
+    auto uut = MakeUut();
+    EXPECT_NE(nullptr, nc::detail::LogCallback);
+    EXPECT_NO_THROW(NC_LOG_INFO("a message"));
+}
+
+TEST_F(FileLoggerTest, Destructor_flushes)
+{
+    EXPECT_EQ(0, std::filesystem::file_size(testLogPath));
+
+    {
+        auto uut = MakeUut();
+        NC_LOG_INFO("a message");
+        EXPECT_EQ(0, std::filesystem::file_size(testLogPath));
+    }
+
+    EXPECT_LT(0, std::filesystem::file_size(testLogPath));
+}
+
+TEST_F(FileLoggerTest, Destructor_resetsCallback)
+{
+    {
+        auto uut = MakeUut();
+    }
+
+    // Logger should have reset to default logging to avoid leaving a dangling ptr registered
+    EXPECT_EQ(nc::detail::DefaultLogCallback, nc::detail::LogCallback);
+    testing::internal::CaptureStdout();
+    NC_LOG_INFO("headed to stdout");
+    EXPECT_FALSE(testing::internal::GetCapturedStdout().empty());
+}
+
+TEST_F(FileLoggerTest, Destructor_alternativeCallbackSet_doesNotResetCallback)
+{
+    static auto called = false;
+    auto callback = [](nc::LogCategory,
+                       std::string_view,
+                       std::string_view,
+                       int,
+                       std::string_view)
+    {
+        called = true;
+    };
+
+    {
+        auto uut = MakeUut();
+        nc::SetLogCallback(callback);
+        EXPECT_EQ(nc::detail::LogCallback, callback);
+    }
+
+    // Callback was changed out from under us - no dangling ptr left behind, so we should have left the callback as is.
+    EXPECT_EQ(nc::detail::LogCallback, callback);
+    EXPECT_NO_THROW(NC_LOG_INFO("test"));
+    EXPECT_TRUE(called);
+}
+
+TEST_F(FileLoggerTest, Log_exceedSpecifiedMessageCount_flushes)
+{
+    static_assert(MaxMessageCount == 3ull);
+    auto uut = MakeUut(); // logs an initial timestamp message
+    NC_LOG_INFO("second message");
+    NC_LOG_INFO("third message");
+    EXPECT_EQ(0, std::filesystem::file_size(testLogPath));
+    NC_LOG_INFO("should flush to file");
+    EXPECT_LT(0, std::filesystem::file_size(testLogPath));
+}

--- a/test/smoke_test/run_smoke_test.sh
+++ b/test/smoke_test/run_smoke_test.sh
@@ -17,7 +17,7 @@ if [[ "$OSTYPE" == "linux-gnu" ]]; then
     export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$ENGINE_INSTALL_DIR/sample"
 fi
 
-./Sample --run-test --config-path "$SMOKE_TEST_DIR/smoke_test_config.ini" --log-path "$SMOKE_TEST_DIR/SmokeTest.log"
+./Sample --run-test --config-path "$SMOKE_TEST_DIR/smoke_test_config.ini" --log-path "$ENGINE_INSTALL_DIR/SmokeTest.log"
 EXIT_CODE=$?
 echo "smoke test exit code: $EXIT_CODE"
 

--- a/test/smoke_test/run_smoke_test.sh
+++ b/test/smoke_test/run_smoke_test.sh
@@ -17,7 +17,7 @@ if [[ "$OSTYPE" == "linux-gnu" ]]; then
     export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$ENGINE_INSTALL_DIR/sample"
 fi
 
-./Sample --run-test --config-path "$SMOKE_TEST_DIR/smoke_test_config.ini"
+./Sample --run-test --config-path "$SMOKE_TEST_DIR/smoke_test_config.ini" --log-path "$SMOKE_TEST_DIR/SmokeTest.log"
 EXIT_CODE=$?
 echo "smoke test exit code: $EXIT_CODE"
 

--- a/test/smoke_test/run_smoke_test.sh
+++ b/test/smoke_test/run_smoke_test.sh
@@ -12,12 +12,13 @@ echo "ENGINE_INSTALL_DIR: $ENGINE_INSTALL_DIR"
 echo "SMOKE_TEST_DIR: $SMOKE_TEST_DIR"
 
 cd "$ENGINE_INSTALL_DIR/sample"
+cp "$SMOKE_TEST_DIR/vk_layer_settings.txt" "./"
 
 if [[ "$OSTYPE" == "linux-gnu" ]]; then
     export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$ENGINE_INSTALL_DIR/sample"
 fi
 
-./Sample --run-test --config-path "$SMOKE_TEST_DIR/smoke_test_config.ini" --log-path "$ENGINE_INSTALL_DIR/SmokeTest.log"
+./Sample --run-test --config-path "$SMOKE_TEST_DIR/smoke_test_config.ini" --log-path "SmokeTest.log"
 EXIT_CODE=$?
 echo "smoke test exit code: $EXIT_CODE"
 

--- a/test/smoke_test/smoke_test_config.ini
+++ b/test/smoke_test/smoke_test_config.ini
@@ -1,7 +1,5 @@
 [project_settings]
 project_name=NcEngine Smoke Test
-log_file_path=SmokeTest.log
-log_max_file_size=1000000
 [engine_settings]
 time_step=0.01667
 max_time_step=0.1


### PR DESCRIPTION
Updates to logging to mostly address logging issues when `NcEngine`'s constructor throws and limited logging extensibility

Summary
- Logging macros now go through a configurable callback, which defaults to printing to stdout.
- Added `FileLogger` for basic file logging. This is almost exactly what we have now, but is opt-in and can operate outside of the engine's lifetime.
- Moved log-related options from config into `FileLogger`.
- Added a command line argument to the sample to use file logging. The default is stdout, but the smoke test writes to a file so we can publish it.
- Since things are a bit more publicly exposed now, I replaced the naked prefix characters with a `LogCategory` enum.
- Routing diligent messages through our logging.
  - Diligent messages don't always have file/line info, so I've added a subsystem indicator to the front of log entries to make the source less mysterious. Looks like:
    >> V [NcEngine] NcGraphicsImpl2.cpp:121: Building NcGraphics module
V [Diligent] User-defined allocator is not provided. Using default allocator.