### PR TITLE
Adjustments to SwapChain + Preferred Api

### DIFF
--- a/include/ncengine/config/Config.h
+++ b/include/ncengine/config/Config.h
@@ -67,23 +67,16 @@ struct MemorySettings
 /** @brief Options for configuring NcGraphics. */
 struct GraphicsSettings
 {
-    bool enabled = true;              ///< enable the NcGraphics module
-    /**
-    api is the target graphics api from a predetermined list (narrowed at build time by platform)
-    of vulkan or d3d12. See nc::graphics::GetSupportedApis().
-    If the target api is not detected as compatible, the next in the list returned by GetSupportedApis()
-    will be chosen as a fallback.
-     */
-    std::string api = "vulkan";       ///< possible values: vulkan, d3d12
-    bool isHeadless = false;          ///< run the api in headless mode
-    bool useNativeResolution = false; ///< use the monitor's native resolution
-    bool launchInFullscreen = false;  ///< launch a fullscreen window
-    unsigned screenWidth = 1000;      ///< width of the screen
-    unsigned screenHeight = 1000;     ///< height of the screen
-    unsigned targetFPS = 60;          ///< target frame rate
-    bool useShadows = true;           ///< enable shadow mapping and shadow rendering
-    unsigned antialiasing = 8u;       ///< the number of samples for MSAA
-    bool useValidationLayers = false; ///< turn on validation layers in debug builds
+    bool enabled = true;                 ///< enable the NcGraphics module
+    std::string preferredApi = "vulkan"; ///< desired graphics api, see NcGraphics for more info (possible values: vulkan, d3d12)
+    bool useNativeResolution = false;    ///< use the monitor's native resolution
+    bool launchInFullscreen = false;     ///< launch a fullscreen window
+    unsigned screenWidth = 1000;         ///< width of the screen
+    unsigned screenHeight = 1000;        ///< height of the screen
+    unsigned targetFPS = 60;             ///< target frame rate
+    bool useShadows = true;              ///< enable shadow mapping and shadow rendering
+    unsigned antialiasing = 8u;          ///< the number of samples for MSAA
+    bool useValidationLayers = false;    ///< turn on validation layers in debug builds
 };
 
 /** @brief Options for configuring NcPhysics. */

--- a/include/ncengine/graphics/NcGraphics.h
+++ b/include/ncengine/graphics/NcGraphics.h
@@ -95,6 +95,13 @@ struct NcGraphics : public Module
      * is not cleared as it can be set on a persistent Entity.
      */
     virtual void ClearEnvironment() = 0;
+
+    /**
+     * @brief Get the graphics api being used.
+     * @note Typically, this will be equal to GraphicsSettings::preferredApi, but insufficient device support or
+     *       initialization failure may result in a fallback api being selected.
+     */
+    virtual auto GetApi() const noexcept -> std::string_view = 0;
 };
 
 /**
@@ -105,8 +112,10 @@ auto GetSupportedApis() -> std::span<const std::string_view>;
 
 /**
  * @brief Build an NcGraphics instance.
- * 
- * The NcAsset, NcScene, and NcWindow modules must be registered prior to initializing NcGraphics.
+ * @note GraphicsSettings::preferredApi must be one of the values returned from GetSupportedApis(). If initialization
+ *       fails with the preferred option, another attempt will be made with a fallback, if available. The api in use
+ *       can be checked with NcGraphics::GetApi().
+ * @note The NcAsset, NcScene, and NcWindow modules must be registered prior to initializing NcGraphics.
  */
 auto BuildGraphicsModule(const config::ProjectSettings& projectSettings,
                          const config::GraphicsSettings& graphicsSettings,

--- a/include/ncengine/graphics/NcGraphics.h
+++ b/include/ncengine/graphics/NcGraphics.h
@@ -97,9 +97,9 @@ struct NcGraphics : public Module
     virtual void ClearEnvironment() = 0;
 
     /**
-     * @brief Get the graphics api being used.
+     * @brief Get the graphics API being used.
      * @note Typically, this will be equal to GraphicsSettings::preferredApi, but insufficient device support or
-     *       initialization failure may result in a fallback api being selected.
+     *       initialization failure may result in a fallback API being selected.
      */
     virtual auto GetApi() const noexcept -> std::string_view = 0;
 };
@@ -113,7 +113,7 @@ auto GetSupportedApis() -> std::span<const std::string_view>;
 /**
  * @brief Build an NcGraphics instance.
  * @note GraphicsSettings::preferredApi must be one of the values returned from GetSupportedApis(). If initialization
- *       fails with the preferred option, another attempt will be made with a fallback, if available. The api in use
+ *       fails with the preferred option, another attempt will be made with a fallback, if available. The API in use
  *       can be checked with NcGraphics::GetApi().
  * @note The NcAsset, NcScene, and NcWindow modules must be registered prior to initializing NcGraphics.
  */

--- a/sample/config.ini
+++ b/sample/config.ini
@@ -41,8 +41,7 @@ time_before_sleep=0.5
 sleep_threshold=0.03
 [graphics_settings]
 graphics_enabled=1
-api=vulkan
-is_headless=0
+preferred_api=vulkan
 use_native_resolution=0
 launch_fullscreen=0
 screen_width=1600

--- a/sample/source/SampleMain.cpp
+++ b/sample/source/SampleMain.cpp
@@ -64,11 +64,11 @@ int main(int argc, char** argv)
                 throw std::runtime_error("No supported graphics APIs were found on the system.");
             }
 
-            const auto& targetApi = config.graphicsSettings.api;
-            if (!std::ranges::contains(supportedGraphicsApis, targetApi))
+            auto& preferredApi = config.graphicsSettings.preferredApi;
+            if (!std::ranges::contains(supportedGraphicsApis, preferredApi))
             {
-                std::cerr << fmt::format("Warning: The target graphics API ({0}) was not found on the system. Falling back to: {1}.", targetApi, supportedGraphicsApis[0]);
-                config.graphicsSettings.api = supportedGraphicsApis[0];
+                std::cerr << fmt::format("Warning: The target graphics API ({0}) was not found on the system. Falling back to: {1}.", preferredApi, supportedGraphicsApis[0]);
+                preferredApi = supportedGraphicsApis[0];
             }
         }
 

--- a/source/ncengine/config/Config.cpp
+++ b/source/ncengine/config/Config.cpp
@@ -64,8 +64,7 @@ constexpr auto SleepThresholdKey = "sleep_threshold"sv;
 
 // graphics
 constexpr auto GraphicsEnabledKey = "graphics_enabled"sv;
-constexpr auto ApiKey = "api"sv;
-constexpr auto IsHeadlessKey = "is_headless"sv;
+constexpr auto PreferredApiKey = "preferred_api"sv;
 constexpr auto UseNativeResolutionKey = "use_native_resolution"sv;
 constexpr auto LaunchInFullscreenKey = "launch_fullscreen"sv;
 constexpr auto ScreenWidthKey = "screen_width"sv;
@@ -222,8 +221,7 @@ auto BuildFromConfigMap(const std::unordered_map<std::string, std::string>& kvPa
     else if constexpr (std::same_as<Struct_t, nc::config::GraphicsSettings>)
     {
         ParseValueIfExists(out.enabled, GraphicsEnabledKey, kvPairs);
-        ParseValueIfExists(out.api, ApiKey, kvPairs);
-        ParseValueIfExists(out.isHeadless, IsHeadlessKey, kvPairs);
+        ParseValueIfExists(out.preferredApi, PreferredApiKey, kvPairs);
         ParseValueIfExists(out.useNativeResolution, UseNativeResolutionKey, kvPairs);
         ParseValueIfExists(out.launchInFullscreen, LaunchInFullscreenKey, kvPairs);
         ParseValueIfExists(out.screenWidth, ScreenWidthKey, kvPairs);
@@ -387,8 +385,7 @@ void Write(std::ostream& stream, const Config& config, bool writeSections)
 
     if (writeSections) stream << "[graphics_settings]\n";
     ::WriteKVPair(stream, GraphicsEnabledKey, config.graphicsSettings.enabled);
-    ::WriteKVPair(stream, ApiKey, config.graphicsSettings.api);
-    ::WriteKVPair(stream, IsHeadlessKey, config.graphicsSettings.isHeadless);
+    ::WriteKVPair(stream, PreferredApiKey, config.graphicsSettings.preferredApi);
     ::WriteKVPair(stream, UseNativeResolutionKey, config.graphicsSettings.useNativeResolution);
     ::WriteKVPair(stream, LaunchInFullscreenKey, config.graphicsSettings.launchInFullscreen);
     ::WriteKVPair(stream, ScreenWidthKey, config.graphicsSettings.screenWidth);
@@ -416,7 +413,7 @@ bool Validate(const Config& config)
            (config.assetSettings.texturesPath != "") &&
            (config.assetSettings.cubeMapsPath != "") &&
            (config.assetSettings.fontsPath != "") &&
-           (config.graphicsSettings.api != "") &&
+           (config.graphicsSettings.preferredApi != "") &&
            (config.graphicsSettings.screenWidth != 0) &&
            (config.graphicsSettings.screenHeight != 0) &&
            (config.graphicsSettings.targetFPS != 0) &&

--- a/source/ncengine/config/default_config.ini
+++ b/source/ncengine/config/default_config.ini
@@ -38,8 +38,7 @@ time_before_sleep=0.5
 sleep_threshold=0.03
 [graphics_settings]
 graphics_enabled=1
-api=vulkan
-is_headless=0
+preferred_api=vulkan
 use_native_resolution=0
 launch_fullscreen=0
 screen_width=1000

--- a/source/ncengine/graphics/NcGraphicsImpl.cpp
+++ b/source/ncengine/graphics/NcGraphicsImpl.cpp
@@ -53,6 +53,7 @@ namespace
             );
         }
 
+        auto GetApi() const noexcept -> std::string_view override { return ""; }
         void SetCamera(nc::graphics::Camera*) noexcept override {}
         auto GetCamera() noexcept -> nc::graphics::Camera* override { return nullptr; }
         void SetUi(nc::ui::IUI*) noexcept override {}

--- a/source/ncengine/graphics/NcGraphicsImpl.cpp
+++ b/source/ncengine/graphics/NcGraphicsImpl.cpp
@@ -83,7 +83,6 @@ namespace nc::graphics
             ncWindow->SetWindow(window::WindowInfo
             {
                 .dimensions = Vector2{static_cast<float>(graphicsSettings.screenWidth), static_cast<float>(graphicsSettings.screenHeight)},
-                .isHeadless = graphicsSettings.isHeadless,
                 .useNativeResolution = graphicsSettings.useNativeResolution,
                 .launchInFullScreen = graphicsSettings.launchInFullscreen,
                 .isResizable = false

--- a/source/ncengine/graphics/NcGraphicsImpl.h
+++ b/source/ncengine/graphics/NcGraphicsImpl.h
@@ -31,6 +31,7 @@ class NcGraphicsImpl : public NcGraphics
                        std::unique_ptr<IGraphics> graphics,
                        window::NcWindow& window);
 
+        auto GetApi() const noexcept -> std::string_view override { return "vulkan"; }
         void SetCamera(Camera* camera) noexcept override;
         auto GetCamera() noexcept -> Camera* override;
         void SetUi(ui::IUI* ui) noexcept override;

--- a/source/ncengine/graphics/NcGraphicsImpl.h
+++ b/source/ncengine/graphics/NcGraphicsImpl.h
@@ -31,7 +31,7 @@ class NcGraphicsImpl : public NcGraphics
                        std::unique_ptr<IGraphics> graphics,
                        window::NcWindow& window);
 
-        auto GetApi() const noexcept -> std::string_view override { return "vulkan"; }
+        auto GetApi() const noexcept -> std::string_view override { return api::Vulkan; }
         void SetCamera(Camera* camera) noexcept override;
         auto GetCamera() noexcept -> Camera* override;
         void SetUi(ui::IUI* ui) noexcept override;

--- a/source/ncengine/graphics2/NcGraphicsImpl2.cpp
+++ b/source/ncengine/graphics2/NcGraphicsImpl2.cpp
@@ -50,6 +50,7 @@ struct NcGraphicsStub2 : nc::graphics::NcGraphics
         );
     }
 
+    auto GetApi() const noexcept -> std::string_view override { return ""; }
     void SetCamera(nc::graphics::Camera*) noexcept override {}
     auto GetCamera() noexcept -> nc::graphics::Camera* override { return nullptr; }
     void SetUi(nc::ui::IUI*) noexcept override {}
@@ -115,7 +116,6 @@ namespace nc::graphics
             ncWindow->SetWindow(window::WindowInfo
             {
                 .dimensions = Vector2{static_cast<float>(graphicsSettings.screenWidth), static_cast<float>(graphicsSettings.screenHeight)},
-                .isHeadless = graphicsSettings.isHeadless,
                 .useNativeResolution = graphicsSettings.useNativeResolution,
                 .launchInFullScreen = graphicsSettings.launchInFullscreen,
                 .isResizable = false
@@ -183,6 +183,11 @@ NcGraphicsImpl2::NcGraphicsImpl2(const config::GraphicsSettings& graphicsSetting
 
 NcGraphicsImpl2::~NcGraphicsImpl2()
 {
+}
+
+auto NcGraphicsImpl2::GetApi() const noexcept -> std::string_view
+{
+    return m_engine.GetApi();
 }
 
 void NcGraphicsImpl2::SetCamera(Camera* camera) noexcept

--- a/source/ncengine/graphics2/NcGraphicsImpl2.h
+++ b/source/ncengine/graphics2/NcGraphicsImpl2.h
@@ -30,6 +30,7 @@ class NcGraphicsImpl2 : public NcGraphics
 
         ~NcGraphicsImpl2() noexcept;
 
+        auto GetApi() const noexcept -> std::string_view override;
         void SetCamera(Camera* camera) noexcept override;
         auto GetCamera() noexcept -> Camera* override;
         void SetUi(ui::IUI* ui) noexcept override;

--- a/source/ncengine/graphics2/diligent/DiligentEngine.h
+++ b/source/ncengine/graphics2/diligent/DiligentEngine.h
@@ -34,7 +34,7 @@ class DiligentEngine
         auto GetContext()       -> Diligent::IDeviceContext& { return *m_pImmediateContext; }
         auto GetSwapChain()     -> Diligent::ISwapChain&     { return *m_pSwapChain; }
         auto GetShaderFactory() -> ShaderFactory&            { return *m_shaderFactory; }
-        auto GetApi()           -> std::string_view          { return m_renderApi; }
+        auto GetApi() const     -> std::string_view          { return m_renderApi; }
 
     private:
         Diligent::RefCntAutoPtr<Diligent::IRenderDevice>  m_pDevice;

--- a/source/ncengine/graphics2/diligent/DiligentEngineLinux.cpp
+++ b/source/ncengine/graphics2/diligent/DiligentEngineLinux.cpp
@@ -32,11 +32,10 @@ DiligentEngine::DiligentEngine(const config::GraphicsSettings& graphicsSettings,
 {
     using namespace Diligent;
 
-    const std::string_view& renderApi = graphicsSettings.api;
     auto preferredApiOrder = std::vector<std::string_view>{};
     preferredApiOrder.reserve(2);
     std::ranges::copy(supportedApis, std::back_inserter(preferredApiOrder));
-    RotateElementToBeginning(preferredApiOrder, renderApi);
+    RotateElementToBeginning(preferredApiOrder, std::string_view{graphicsSettings.preferredApi});
 
     std::string errorMessage;
     LinuxNativeWindow window;
@@ -63,16 +62,13 @@ DiligentEngine::DiligentEngine(const config::GraphicsSettings& graphicsSettings,
 
                 auto engineCI = EngineVkCreateInfo{engineCreateInfo};
                 pFactoryVk->CreateDeviceAndContextsVk(engineCI, &m_pDevice, &m_pImmediateContext);
-
                 if (!m_pDevice || !m_pImmediateContext)
                 {
                     throw nc::NcError("Failed to create the Vulkan device or context.");
                 }
 
-                if (!graphicsSettings.isHeadless)
-                    pFactoryVk->CreateSwapChainVk(m_pDevice, m_pImmediateContext, SCDesc, window, &m_pSwapChain);
-
-                if (!graphicsSettings.isHeadless && !m_pSwapChain)
+                pFactoryVk->CreateSwapChainVk(m_pDevice, m_pImmediateContext, SCDesc, window, &m_pSwapChain);
+                if (!m_pSwapChain)
                 {
                     throw nc::NcError("Failed to create the Vulkan swapchain.");
                 }

--- a/source/ncengine/graphics2/diligent/DiligentEngineWin32.cpp
+++ b/source/ncengine/graphics2/diligent/DiligentEngineWin32.cpp
@@ -39,11 +39,10 @@ DiligentEngine::DiligentEngine(const config::GraphicsSettings& graphicsSettings,
 {
     using namespace Diligent;
 
-    const std::string_view& renderApi = graphicsSettings.api;
     auto preferredApiOrder = std::vector<std::string_view>{};
     preferredApiOrder.reserve(3);
     std::ranges::copy(supportedApis, std::back_inserter(preferredApiOrder));
-    RotateElementToBeginning(preferredApiOrder, renderApi);
+    RotateElementToBeginning(preferredApiOrder, std::string_view{graphicsSettings.preferredApi});
 
     std::string errorMessage;
     auto glfwWindowHandle = glfwGetWin32Window(window_);
@@ -76,10 +75,8 @@ DiligentEngine::DiligentEngine(const config::GraphicsSettings& graphicsSettings,
                     throw nc::NcError("Failed to create the D3D12 device or context.");
                 }
 
-                if (!graphicsSettings.isHeadless)
-                    pFactoryD3D12->CreateSwapChainD3D12(m_pDevice, m_pImmediateContext, SCDesc, FullScreenModeDesc{}, window, &m_pSwapChain);
-
-                if (!graphicsSettings.isHeadless && !m_pSwapChain)
+                pFactoryD3D12->CreateSwapChainD3D12(m_pDevice, m_pImmediateContext, SCDesc, FullScreenModeDesc{}, window, &m_pSwapChain);
+                if (!m_pSwapChain)
                 {
                     throw nc::NcError("Failed to create the D3D12 swapchain.");
                 }
@@ -112,16 +109,13 @@ DiligentEngine::DiligentEngine(const config::GraphicsSettings& graphicsSettings,
 
                 auto engineCI = EngineVkCreateInfo{engineCreateInfo};
                 pFactoryVk->CreateDeviceAndContextsVk(engineCI, &m_pDevice, &m_pImmediateContext);
-
                 if (!m_pDevice || !m_pImmediateContext)
                 {
                     throw nc::NcError("Failed to create the Vulkan device or context.");
                 }
 
-                if (!graphicsSettings.isHeadless)
-                    pFactoryVk->CreateSwapChainVk(m_pDevice, m_pImmediateContext, SCDesc, window, &m_pSwapChain);
-
-                if (!graphicsSettings.isHeadless && !m_pSwapChain)
+                pFactoryVk->CreateSwapChainVk(m_pDevice, m_pImmediateContext, SCDesc, window, &m_pSwapChain);
+                if (!m_pSwapChain)
                 {
                     throw nc::NcError("Failed to create the Vulkan swapchain.");
                 }

--- a/test/integration_test/ncengine/graphics2/DiligentEngineIntFixture.inl
+++ b/test/integration_test/ncengine/graphics2/DiligentEngineIntFixture.inl
@@ -106,19 +106,18 @@ void RenderSquare(nc::graphics::DiligentEngine* engine, Diligent::IPipelineState
     engine->GetContext().Draw(drawAttrs);
 }
 
-auto CreateDiligentEngine(bool isHeadless, std::string_view targetApi, std::span<const std::string_view> supportedApis, Diligent::EngineCreateInfo engineCI, nc::window::NcWindowStub* window = nullptr) -> nc::graphics::DiligentEngine
+auto CreateDiligentEngine(std::string_view targetApi, std::span<const std::string_view> supportedApis, Diligent::EngineCreateInfo engineCI, nc::window::NcWindowStub* window = nullptr) -> nc::graphics::DiligentEngine
 {
     /* Create config */
     auto graphicsSettings = nc::config::GraphicsSettings();
-    graphicsSettings.isHeadless = isHeadless;
-    graphicsSettings.api = targetApi;
+    graphicsSettings.preferredApi = targetApi;
     auto projectSettings = nc::config::ProjectSettings();
     projectSettings.projectName = "DiligentEngineLinux_tests";
 
     if (!window)
     {
         /* Create window */
-        auto info = nc::window::WindowInfo{.isHeadless = graphicsSettings.isHeadless};
+        auto info = nc::window::WindowInfo{};
         auto ncWindow = nc::window::NcWindowStub{info};
 
         /* Create DiligentEngine */

--- a/test/integration_test/ncengine/graphics2/DiligentEngineLinuxInt_tests.cpp
+++ b/test/integration_test/ncengine/graphics2/DiligentEngineLinuxInt_tests.cpp
@@ -7,11 +7,11 @@
 
 namespace nc::graphics
 {
-TEST(DiligentEngineLinux_tests, CreateDiligentEngine_VulkanNotHeadless_Succeeds)
+TEST(DiligentEngineLinux_tests, CreateDiligentEngine_Vulkan_Succeeds)
 {
     auto supportedApis = std::vector<std::string_view>{"vulkan"};
     auto engineCI = Diligent::EngineCreateInfo{};
-    EXPECT_NO_THROW(CreateDiligentEngine(false, "vulkan", supportedApis, engineCI));
+    EXPECT_NO_THROW(CreateDiligentEngine("vulkan", supportedApis, engineCI));
 }
 
 TEST(DiligentEngineLinux_tests, CreateDiligentEngine_VulkanRenderTriangle_Succeeds)
@@ -20,9 +20,9 @@ TEST(DiligentEngineLinux_tests, CreateDiligentEngine_VulkanRenderTriangle_Succee
     auto engineCI = Diligent::EngineCreateInfo{};
 
     /* Create window */
-    auto info = nc::window::WindowInfo{.isHeadless = false};
+    auto info = nc::window::WindowInfo{};
     auto ncWindow = nc::window::NcWindowStub{info};
-    auto engine = CreateDiligentEngine(false, "vulkan", supportedApis, engineCI, &ncWindow);
+    auto engine = CreateDiligentEngine("vulkan", supportedApis, engineCI, &ncWindow);
 
     Diligent::RefCntAutoPtr<Diligent::IPipelineState> m_pPSO;
     SetupSquare(&engine, m_pPSO.RawDblPtr());
@@ -38,17 +38,6 @@ TEST(DiligentEngineLinux_tests, CreateDiligentEngine_VulkanRenderTriangle_Succee
     }
 }
 
-TEST(DiligentEngineLinux_tests, CreateDiligentEngine_Headless_Succeeds)
-{
-    auto supportedApis = nc::graphics::GetSupportedApis();
-    auto engineCI = Diligent::EngineCreateInfo{};
-
-    for (const auto& api : supportedApis)
-    {
-        EXPECT_NO_THROW(CreateDiligentEngine(true, api, supportedApis, engineCI));
-    }
-}
-
 TEST(DiligentEngineLinux_tests, CreateDiligentEngine_APINotInSupportedApisList_Fails)
 {
     auto supportedApis = nc::graphics::GetSupportedApis();
@@ -56,7 +45,7 @@ TEST(DiligentEngineLinux_tests, CreateDiligentEngine_APINotInSupportedApisList_F
     if (!supportedApis.empty())
     {
         auto engineCI = Diligent::EngineCreateInfo{};
-        EXPECT_THROW(CreateDiligentEngine(true, "notInList", supportedApis, engineCI), nc::NcError);
+        EXPECT_THROW(CreateDiligentEngine("notInList", supportedApis, engineCI), nc::NcError);
     }
 }
 
@@ -68,7 +57,7 @@ TEST(DiligentEngineLinux_tests, CreateDiligentEngine_TargetAPIFails_NoFallback_F
 
     for (const auto& api : supportedApis)
     {
-        EXPECT_THROW(CreateDiligentEngine(true, api, supportedApis, engineCI), nc::NcError);
+        EXPECT_THROW(CreateDiligentEngine(api, supportedApis, engineCI), nc::NcError);
     }
 }
 } // namespace nc::graphics

--- a/test/integration_test/ncengine/graphics2/DiligentEngineParameterizedFixture.inl
+++ b/test/integration_test/ncengine/graphics2/DiligentEngineParameterizedFixture.inl
@@ -24,12 +24,10 @@ class DiligentEngineParameterizedFixture : public testing::TestWithParam<std::st
 {
     protected:
         static inline auto s_diligentErrorOut = std::stringstream{};
-        bool isHeadless;
         std::unique_ptr<nc::window::NcWindowStub> window;
         std::unique_ptr<nc::graphics::DiligentEngine> engine;
 
-        DiligentEngineParameterizedFixture(bool headless = true)
-            : isHeadless{headless}
+        DiligentEngineParameterizedFixture()
         {
             ClearErrorOutput();
         }
@@ -73,19 +71,14 @@ class DiligentEngineParameterizedFixture : public testing::TestWithParam<std::st
         //       INITIALIZE_DILIGENT_FIXTURE to conditionally initialize/skip the current test based on API support.
         void SetUp() override
         {
-            window = std::make_unique<nc::window::NcWindowStub>(
-                nc::window::WindowInfo{
-                    .isHeadless = isHeadless
-                }
-            );
+            window = std::make_unique<nc::window::NcWindowStub>(nc::window::WindowInfo{});
 
             auto engineCI = Diligent::EngineCreateInfo{};
             engineCI.Features.ShaderResourceRuntimeArrays = Diligent::DEVICE_FEATURE_STATE_ENABLED;
             engineCI.Features.BindlessResources = Diligent::DEVICE_FEATURE_STATE_ENABLED;
 
             auto graphicsSettings = nc::config::GraphicsSettings();
-            graphicsSettings.isHeadless = isHeadless;
-            graphicsSettings.api = GetTestApi();
+            graphicsSettings.preferredApi = GetTestApi();
 
             engine = std::make_unique<nc::graphics::DiligentEngine>(
                 graphicsSettings,

--- a/test/integration_test/ncengine/graphics2/DiligentEngineWin32Int_tests.cpp
+++ b/test/integration_test/ncengine/graphics2/DiligentEngineWin32Int_tests.cpp
@@ -7,19 +7,18 @@
 
 namespace nc::graphics
 {
-TEST(DiligentEngineWin32_tests, CreateDiligentEngine_VulkanNotHeadless_Succeeds)
+TEST(DiligentEngineWin32_tests, CreateDiligentEngine_Vulkan_Succeeds)
 {
     auto supportedApis = std::vector<std::string_view>{"vulkan"};
     auto engineCI = Diligent::EngineCreateInfo{};
-    EXPECT_NO_THROW(CreateDiligentEngine(false, "vulkan", supportedApis, engineCI));
+    EXPECT_NO_THROW(CreateDiligentEngine("vulkan", supportedApis, engineCI));
 }
 
-
-TEST(DiligentEngineWin32_tests, CreateDiligentEngine_D3D12LNotHeadless_Succeeds)
+TEST(DiligentEngineWin32_tests, CreateDiligentEngine_D3D12_Succeeds)
 {
     auto supportedApis = std::vector<std::string_view>{"d3d12"};
     auto engineCI = Diligent::EngineCreateInfo{};
-    EXPECT_NO_THROW(CreateDiligentEngine(false, "d3d12", supportedApis, engineCI));
+    EXPECT_NO_THROW(CreateDiligentEngine("d3d12", supportedApis, engineCI));
 }
 
 TEST(DiligentEngineWin32_tests, CreateDiligentEngine_D3D12RenderTriangle_Succeeds)
@@ -28,9 +27,9 @@ TEST(DiligentEngineWin32_tests, CreateDiligentEngine_D3D12RenderTriangle_Succeed
     auto engineCI = Diligent::EngineCreateInfo{};
 
     /* Create window */
-    auto info = nc::window::WindowInfo{.isHeadless = false};
+    auto info = nc::window::WindowInfo{};
     auto ncWindow = nc::window::NcWindowStub{info};
-    auto engine = CreateDiligentEngine(false, "d3d12", supportedApis, engineCI, &ncWindow);
+    auto engine = CreateDiligentEngine("d3d12", supportedApis, engineCI, &ncWindow);
 
     Diligent::RefCntAutoPtr<Diligent::IPipelineState> m_pPSO;
     SetupSquare(&engine, m_pPSO.RawDblPtr());
@@ -53,9 +52,9 @@ TEST(DiligentEngineWin32_tests, CreateDiligentEngine_VulkanRenderTriangle_Succee
     auto engineCI = Diligent::EngineCreateInfo{};
 
     /* Create window */
-    auto info = nc::window::WindowInfo{.isHeadless = false};
+    auto info = nc::window::WindowInfo{};
     auto ncWindow = nc::window::NcWindowStub{info};
-    auto engine = CreateDiligentEngine(false, "vulkan", supportedApis, engineCI, &ncWindow);
+    auto engine = CreateDiligentEngine("vulkan", supportedApis, engineCI, &ncWindow);
 
     Diligent::RefCntAutoPtr<Diligent::IPipelineState> m_pPSO;
     SetupSquare(&engine, m_pPSO.RawDblPtr());
@@ -71,17 +70,6 @@ TEST(DiligentEngineWin32_tests, CreateDiligentEngine_VulkanRenderTriangle_Succee
     }
 }
 
-TEST(DiligentEngineWin32_tests, CreateDiligentEngine_Headless_Succeeds)
-{
-    auto supportedApis = nc::graphics::GetSupportedApis();
-    auto engineCI = Diligent::EngineCreateInfo{};
-
-    for (const auto& api : supportedApis)
-    {
-        EXPECT_NO_THROW(CreateDiligentEngine(true, api, supportedApis, engineCI));
-    }
-}
-
 TEST(DiligentEngineWin32_tests, CreateDiligentEngine_APINotInSupportedApisList_Fails)
 {
     auto supportedApis = nc::graphics::GetSupportedApis();
@@ -89,7 +77,7 @@ TEST(DiligentEngineWin32_tests, CreateDiligentEngine_APINotInSupportedApisList_F
     if (!supportedApis.empty())
     {
         auto engineCI = Diligent::EngineCreateInfo{};
-        EXPECT_THROW(CreateDiligentEngine(true, "notInList", supportedApis, engineCI), nc::NcError);
+        EXPECT_THROW(CreateDiligentEngine("notInList", supportedApis, engineCI), nc::NcError);
     }
 }
 
@@ -109,7 +97,7 @@ TEST(DiligentEngineWin32_tests, CreateDiligentEngine_TargetAPIFails_FallbackIsAt
     {
         try
         {
-            CreateDiligentEngine(true, api, supportedApis, engineCI);
+            CreateDiligentEngine(api, supportedApis, engineCI);
         }
         catch (const std::runtime_error& error)
         {

--- a/test/integration_test/ncengine/graphics2/GlobalMeshBuffer_tests.cpp
+++ b/test/integration_test/ncengine/graphics2/GlobalMeshBuffer_tests.cpp
@@ -9,11 +9,6 @@ class GlobalMeshBufferTest : public DiligentEngineParameterizedFixture
     protected:
         std::unique_ptr<nc::graphics::GlobalMeshBuffer> uut;
 
-        GlobalMeshBufferTest()
-            : DiligentEngineParameterizedFixture{false}
-        {
-        }
-
         void SetUp() override
         {
             INITIALIZE_DILIGENT_FIXTURE;

--- a/test/integration_test/ncengine/graphics2/MaterialDataBufferResource_tests.cpp
+++ b/test/integration_test/ncengine/graphics2/MaterialDataBufferResource_tests.cpp
@@ -18,11 +18,6 @@ class MaterialDataBufferResourceTest : public DiligentEngineParameterizedFixture
         nc::graphics::MaterialDataBufferResource* uut = nullptr;
         std::array<nc::graphics::MaterialData, initialInstanceHint> properties;
 
-        MaterialDataBufferResourceTest()
-            : DiligentEngineParameterizedFixture{false}
-        {
-        }
-
         void SetUp() override
         {
             INITIALIZE_DILIGENT_FIXTURE;

--- a/test/integration_test/ncengine/graphics2/ShaderFactory_tests.cpp
+++ b/test/integration_test/ncengine/graphics2/ShaderFactory_tests.cpp
@@ -69,42 +69,28 @@ INSTANTIATE_TEST_SUITE_P(AllApis, ShaderFactoryTest, g_apiParams);
 
 #ifdef NC_RUNTIME_SHADER_COMPILATION
 
-TEST_P(ShaderFactoryTest, HasRuntimeCompilationSupport_hasRuntimeSupport_returnsTrue)
+TEST_P(ShaderFactoryTest, RuntimeSupport_happyPaths_succeed)
 {
     EXPECT_TRUE(uut->HasRuntimeCompilationSupport());
-}
 
-TEST_P(ShaderFactoryTest, MakeShaderFromSource_goodSource_succeeds)
-{
     EXPECT_NO_THROW(uut->MakeShaderFromSource(g_goodSource, "", g_shaderType));
-}
 
-TEST_P(ShaderFactoryTest, MakeShaderFromSource_invalidSyntax_throws)
-{
-    EXPECT_THROW(uut->MakeShaderFromSource(g_badSource, "", g_shaderType), nc::NcError);
-    ClearErrorOutput();
-}
-
-TEST_P(ShaderFactoryTest, ReadShaderFile_validFile_producesValidSource)
-{
     const auto source = nc::graphics::ReadShaderFile(testShaderPath.string());
     EXPECT_NO_THROW(uut->MakeShaderFromSource(source, "", g_shaderType));
 }
 
-TEST_P(ShaderFactoryTest, ReadShaderFile_badFile_throws)
+TEST_P(ShaderFactoryTest, RuntimeSupport_failurePaths_throw)
 {
+    EXPECT_THROW(uut->MakeShaderFromSource(g_badSource, "", g_shaderType), nc::NcError);
     EXPECT_THROW(nc::graphics::ReadShaderFile("not_a_shader.psh"), nc::NcError);
+    ClearErrorOutput();
 }
 
 #else
 
-TEST_P(ShaderFactoryTest, HasRuntimeCompilationSupport_noRuntimeSupport_returnsFalse)
+TEST_P(ShaderFactoryTest, NoRuntimeSupport_failurePaths_throw)
 {
     EXPECT_FALSE(uut->HasRuntimeCompilationSupport());
-}
-
-TEST_P(ShaderFactoryTest, MakeShaderFromSource_noRuntimeSupport_throws)
-{
     EXPECT_THROW(uut->MakeShaderFromSource(g_goodSource, "", g_shaderType), nc::NcError);
 }
 

--- a/test/integration_test/ncengine/graphics2/UIBackend_tests.cpp
+++ b/test/integration_test/ncengine/graphics2/UIBackend_tests.cpp
@@ -11,11 +11,6 @@ class UIBackendTest : public DiligentEngineParameterizedFixture
         std::unique_ptr<nc::graphics::UIBackend> uiBackend;
         std::unique_ptr<nc::graphics::UISubsystem> uiSubsystem;
 
-        UIBackendTest()
-            : DiligentEngineParameterizedFixture{false}
-        {
-        }
-
         void SetUp() override
         {
             INITIALIZE_DILIGENT_FIXTURE;

--- a/test/ncengine/config/Config_tests.cpp
+++ b/test/ncengine/config/Config_tests.cpp
@@ -131,7 +131,7 @@ TEST(ConfigTests, SaveLoad_roundTrip_preservesData)
     EXPECT_EQ(expected.memorySettings.maxParticles, actual.memorySettings.maxParticles);
 
     EXPECT_EQ(expected.graphicsSettings.enabled, actual.graphicsSettings.enabled);
-    EXPECT_EQ(expected.graphicsSettings.api, actual.graphicsSettings.api);
+    EXPECT_EQ(expected.graphicsSettings.preferredApi, actual.graphicsSettings.preferredApi);
     EXPECT_EQ(expected.graphicsSettings.useNativeResolution, actual.graphicsSettings.useNativeResolution);
     EXPECT_EQ(expected.graphicsSettings.launchInFullscreen, actual.graphicsSettings.launchInFullscreen);
     EXPECT_EQ(expected.graphicsSettings.screenWidth, actual.graphicsSettings.screenWidth);

--- a/test/ncengine/config/collateral/config.ini
+++ b/test/ncengine/config/collateral/config.ini
@@ -48,8 +48,7 @@ time_before_sleep=0.4
 sleep_threshold=0.04
 [graphics_settings]
 graphics_enabled=1
-api=vulkan
-is_headless=0
+preferred_api=vulkan
 use_native_resolution=0
 
 

--- a/test/smoke_test/smoke_test_config.ini
+++ b/test/smoke_test/smoke_test_config.ini
@@ -39,8 +39,7 @@ time_before_sleep=0.5
 sleep_threshold=0.03
 [graphics_settings]
 graphics_enabled=1
-api=vulkan
-is_headless=0
+preferred_api=vulkan
 use_native_resolution=0
 launch_fullscreen=0
 screen_width=500


### PR DESCRIPTION
resolves #778, resolves #734

- Removing 'headless' mode from graphics + unconditionally creating the swapchain. (to me, `useGraphics == false` is a proper enough headless mode, I think we talked about this a bit).
- Adding method to `NcGraphics` to expose the actual selected api and renaming the `GraphicsSettings` api member to `preferredApi`.

Let thy concerns be voiced.