### PR TITLE
Fix Bug in RigidBody Batching

### DIFF
--- a/source/ncengine/physics/jolt/BodyManager.cpp
+++ b/source/ncengine/physics/jolt/BodyManager.cpp
@@ -66,6 +66,7 @@ void BodyManager::AddBody(RigidBody& added)
 
 void BodyManager::RemoveBody(Entity toRemove)
 {
+    NC_ASSERT(!m_deferInitialization, "Cannot remove bodies while a batch is in progress");
     if (m_deferCleanup)
     {
         return;
@@ -97,10 +98,10 @@ void BodyManager::EndBatch(size_t batchBegin)
     }
 
     NC_ASSERT(batchBegin < numBodies, "Body batching out-of-sync");
-    auto beg = &*(m_bodies.begin() + batchBegin);
-    auto count = static_cast<int>(numBodies - batchBegin);
-    auto batchCtx = m_ctx->interface.AddBodiesPrepare(beg, count);
-    m_ctx->interface.AddBodiesFinalize(beg, count, batchCtx, JPH::EActivation::Activate);
+    auto batch = std::vector<JPH::BodyID>{m_bodies.begin() + batchBegin, m_bodies.end()};
+    const auto count = static_cast<int>(batch.size());
+    auto batchCtx = m_ctx->interface.AddBodiesPrepare(batch.data(), count);
+    m_ctx->interface.AddBodiesFinalize(batch.data(), count, batchCtx, JPH::EActivation::Activate);
 }
 
 void BodyManager::Clear()


### PR DESCRIPTION
During the `RigidBody` batch add process, `AddBodiesPrepare()` can modify the input array. Updating to pass a copy of the new ids, instead of a pointer into our map.