### PR TITLE
Disallow Changing a Material's Passes + add SetMaterial()

### DIFF
--- a/include/ncengine/graphics/Material.h
+++ b/include/ncengine/graphics/Material.h
@@ -103,6 +103,8 @@ class MaterialInstance
         static inline graphics::MaterialRegistry* s_registry = nullptr;
 
         MaterialInstanceHandle m_handle;
+
+        void Release() noexcept;
 };
 
 inline MaterialInstance::MaterialInstance(MaterialInstance&& other) noexcept
@@ -114,9 +116,15 @@ inline MaterialInstance& MaterialInstance::operator=(MaterialInstance&& other) n
 {
     if (this != &other)
     {
+        Release();
         m_handle = std::exchange(other.m_handle, NullMaterialInstanceHandle);
     }
 
     return *this;
+}
+
+inline MaterialInstance::~MaterialInstance() noexcept
+{
+    Release();
 }
 } // namespace nc

--- a/include/ncengine/graphics/Material.h
+++ b/include/ncengine/graphics/Material.h
@@ -48,16 +48,22 @@ constexpr auto ShadowedToonMaterial = MaterialPass::Shadow |
                                       MaterialPass::Outline;
 
 /** @brief Properties for constructing a MaterialInstance. */
-struct MaterialDesc
+struct MaterialProperties
 {
-    std::string name = "DefaultMaterial";
-    MaterialPasses passes = ShadowedToonMaterial;
     asset::TextureView diffuseTexture = asset::TextureView{};
     asset::TextureView normalTexture = asset::TextureView{};
     Vector3 gradientStart = Vector3::One();
     Vector3 gradientEnd = Vector3::One();
     Vector3 outlineColor = Vector3::Zero();
     float outlineWidth = 1.0f;
+};
+
+/** @brief Properties for constructing a MaterialInstance. */
+struct MaterialDesc
+{
+    std::string name = "DefaultMaterial";
+    MaterialPasses passes = ShadowedToonMaterial;
+    MaterialProperties properties = MaterialProperties{};
 };
 
 /** @brief Owning wrapper around a material in GPU memory. */
@@ -75,17 +81,16 @@ class MaterialInstance
         /** @brief Create a new MaterialInstance from this instance's properties. */
         auto Clone() const -> MaterialInstance;
 
-        /** @brief Get the instance's properties. */
-        auto GetDesc() const -> const MaterialDesc&;
-
-        /** @brief Update the instance's properties. */
-        void SetDesc(const MaterialDesc& desc);
-
-        /**
-         * @brief Update the instance's name.
-         * @note Prefer this over SetDesc() when only changing the name to avoid an unnecessary GPU-side update.
-         */
+        /** @name Name Functions */
+        auto GetName() const -> std::string_view;
         void SetName(std::string_view name);
+
+        /** @name MaterialPass Functions */
+        auto GetPasses() const -> MaterialPasses;
+
+        /** @name MaterialProperties Functions */
+        auto GetProperties() const -> const MaterialProperties&;
+        void SetProperties(const MaterialProperties& properties);
 
         /** @brief Get the instance's handle. */
         auto GetHandle() const -> MaterialInstanceHandle

--- a/include/ncengine/graphics/MeshRenderer2.h
+++ b/include/ncengine/graphics/MeshRenderer2.h
@@ -30,6 +30,7 @@ class MeshRenderer2 : public ComponentBase
         /** @name Material Functions */
         auto GetMaterial() const -> const MaterialInstance& { return m_material; }
         auto GetMaterial() -> MaterialInstance& { return m_material; }
+        void SetMaterial(const MaterialDesc& materialDesc) { m_material = MaterialInstance{materialDesc}; }
 
     private:
         asset::MeshView m_mesh;

--- a/sample/source/scenes/PhysicsTest_Diligent.cpp
+++ b/sample/source/scenes/PhysicsTest_Diligent.cpp
@@ -956,7 +956,7 @@ class RayCaster : public FreeComponent
                     // possible the entity was deleted, if so we don't want to check for renderer
                     if (world.Contains<Entity>(entity))
                     {
-                        world.Get<MeshRenderer2>(entity).GetMaterial().SetDesc(material);
+                        world.Get<MeshRenderer2>(entity).GetMaterial().SetProperties(material);
                     }
                 }
 
@@ -974,7 +974,7 @@ class RayCaster : public FreeComponent
         graphics::NcGraphics* m_ncGraphics;
         CollisionQuery m_query = CollisionQuery{};
         std::vector<Entity> m_hits;
-        std::vector<MaterialDesc> m_restoreMaterials;
+        std::vector<MaterialProperties> m_restoreMaterials;
         Entity m_shapeParent = Entity::Null();
 
         void UpdateHit(ecs::Ecs world, Entity hit)
@@ -983,8 +983,8 @@ class RayCaster : public FreeComponent
             {
                 auto& renderer = world.Get<MeshRenderer2>(hit);
                 m_hits.push_back(hit);
-                m_restoreMaterials.push_back(renderer.GetMaterial().GetDesc());
-                renderer.GetMaterial().SetDesc(material::Yellow);
+                m_restoreMaterials.push_back(renderer.GetMaterial().GetProperties());
+                renderer.GetMaterial().SetProperties(material::Yellow.properties);
             }
         }
 

--- a/sample/source/shared/Prefabs.cpp
+++ b/sample/source/shared/Prefabs.cpp
@@ -142,21 +142,21 @@ void ReloadPrefabs()
     mesh::HalfPipe = asset::AcquireMeshAsset(mesh::HalfPipePath);
 
     const auto normal = asset::AcquireTextureAsset(asset::DefaultNormal);
-    material::Default.diffuseTexture = asset::AcquireTextureAsset(asset::DefaultBaseColor);
-    material::Default.normalTexture = normal;
-    material::Red.diffuseTexture = asset::AcquireTextureAsset("solid_color/Red.nca");
-    material::Red.normalTexture = normal;
-    material::Green.diffuseTexture = asset::AcquireTextureAsset("solid_color/Green.nca");
-    material::Green.normalTexture = normal;
-    material::Blue.diffuseTexture = asset::AcquireTextureAsset("solid_color/Blue.nca");
-    material::Blue.normalTexture = normal;
-    material::Orange.diffuseTexture = asset::AcquireTextureAsset("solid_color/Orange.nca");
-    material::Orange.normalTexture = normal;
-    material::Purple.diffuseTexture = asset::AcquireTextureAsset("solid_color/Purple.nca");
-    material::Purple.normalTexture = normal;
-    material::Teal.diffuseTexture = asset::AcquireTextureAsset("solid_color/Teal.nca");
-    material::Teal.normalTexture = normal;
-    material::Yellow.diffuseTexture = asset::AcquireTextureAsset("solid_color/Yellow.nca");
-    material::Yellow.normalTexture = normal;
+    material::Default.properties.diffuseTexture = asset::AcquireTextureAsset(asset::DefaultBaseColor);
+    material::Default.properties.normalTexture = normal;
+    material::Red.properties.diffuseTexture = asset::AcquireTextureAsset("solid_color/Red.nca");
+    material::Red.properties.normalTexture = normal;
+    material::Green.properties.diffuseTexture = asset::AcquireTextureAsset("solid_color/Green.nca");
+    material::Green.properties.normalTexture = normal;
+    material::Blue.properties.diffuseTexture = asset::AcquireTextureAsset("solid_color/Blue.nca");
+    material::Blue.properties.normalTexture = normal;
+    material::Orange.properties.diffuseTexture = asset::AcquireTextureAsset("solid_color/Orange.nca");
+    material::Orange.properties.normalTexture = normal;
+    material::Purple.properties.diffuseTexture = asset::AcquireTextureAsset("solid_color/Purple.nca");
+    material::Purple.properties.normalTexture = normal;
+    material::Teal.properties.diffuseTexture = asset::AcquireTextureAsset("solid_color/Teal.nca");
+    material::Teal.properties.normalTexture = normal;
+    material::Yellow.properties.diffuseTexture = asset::AcquireTextureAsset("solid_color/Yellow.nca");
+    material::Yellow.properties.normalTexture = normal;
 }
 } // namespace sample

--- a/source/ncengine/engine/ComponentFactories.cpp
+++ b/source/ncengine/engine/ComponentFactories.cpp
@@ -54,8 +54,10 @@ auto CreateMeshRenderer2(Entity entity, const std::any&) -> MeshRenderer2
         entity,
         meshService->Acquire(asset::CubeMesh),
         MaterialDesc{
-            .diffuseTexture = textureService->Acquire(asset::DefaultBaseColor),
-            .normalTexture = textureService->Acquire(asset::DefaultNormal)
+            .properties = MaterialProperties{
+                .diffuseTexture = textureService->Acquire(asset::DefaultBaseColor),
+                .normalTexture = textureService->Acquire(asset::DefaultNormal)
+            }
         }
     };
 }

--- a/source/ncengine/graphics2/Material.cpp
+++ b/source/ncengine/graphics2/Material.cpp
@@ -8,14 +8,6 @@ MaterialInstance::MaterialInstance(const MaterialDesc& desc)
 {
 }
 
-MaterialInstance::~MaterialInstance() noexcept
-{
-    if (m_handle != NullMaterialInstanceHandle)
-    {
-        s_registry->DestroyInstance(m_handle);
-    }
-}
-
 auto MaterialInstance::Clone() const -> MaterialInstance
 {
     return MaterialInstance{s_registry->GetInstanceDesc(m_handle)};
@@ -44,5 +36,13 @@ auto MaterialInstance::GetProperties() const -> const MaterialProperties&
 void MaterialInstance::SetProperties(const MaterialProperties& desc)
 {
     s_registry->SetInstanceProperties(m_handle, desc);
+}
+
+void MaterialInstance::Release() noexcept
+{
+    if (m_handle != NullMaterialInstanceHandle)
+    {
+        s_registry->DestroyInstance(m_handle);
+    }
 }
 } // namespace nc

--- a/source/ncengine/graphics2/Material.cpp
+++ b/source/ncengine/graphics2/Material.cpp
@@ -21,18 +21,28 @@ auto MaterialInstance::Clone() const -> MaterialInstance
     return MaterialInstance{s_registry->GetInstanceDesc(m_handle)};
 }
 
-auto MaterialInstance::GetDesc() const -> const MaterialDesc&
+auto MaterialInstance::GetName() const -> std::string_view
 {
-    return s_registry->GetInstanceDesc(m_handle);
-}
-
-void MaterialInstance::SetDesc(const MaterialDesc& desc)
-{
-    s_registry->SetInstanceDesc(m_handle, desc);
+    return s_registry->GetInstanceDesc(m_handle).name;
 }
 
 void MaterialInstance::SetName(std::string_view name)
 {
     s_registry->SetInstanceName(m_handle, name);
+}
+
+auto MaterialInstance::GetPasses() const -> MaterialPasses
+{
+    return s_registry->GetInstanceDesc(m_handle).passes;
+}
+
+auto MaterialInstance::GetProperties() const -> const MaterialProperties&
+{
+    return s_registry->GetInstanceDesc(m_handle).properties;
+}
+
+void MaterialInstance::SetProperties(const MaterialProperties& desc)
+{
+    s_registry->SetInstanceProperties(m_handle, desc);
 }
 } // namespace nc

--- a/source/ncengine/graphics2/frontend/subsystem/MaterialRegistry.cpp
+++ b/source/ncengine/graphics2/frontend/subsystem/MaterialRegistry.cpp
@@ -7,15 +7,15 @@
 
 namespace
 {
-auto ToMaterialData(const nc::MaterialDesc& desc) -> nc::graphics::MaterialData
+auto ToMaterialData(const nc::MaterialProperties& properties) -> nc::graphics::MaterialData
 {
     return nc::graphics::MaterialData{
-        .gradientStart = desc.gradientStart,
-        .diffuseTexIndex = desc.diffuseTexture.index,
-        .gradientEnd = desc.gradientEnd,
-        .normalTexIndex = desc.normalTexture.index,
-        .outlineColor = desc.outlineColor,
-        .outlineWidth = desc.outlineWidth
+        .gradientStart = properties.gradientStart,
+        .diffuseTexIndex = properties.diffuseTexture.index,
+        .gradientEnd = properties.gradientEnd,
+        .normalTexIndex = properties.normalTexture.index,
+        .outlineColor = properties.outlineColor,
+        .outlineWidth = properties.outlineWidth
     };
 }
 } // anonymous namespace
@@ -33,7 +33,7 @@ auto MaterialRegistry::CreateInstance(const MaterialDesc& desc) -> MaterialInsta
     if (m_freeList.empty())
     {
         NC_ASSERT(m_nextIndex < m_maxIndex, "Max material instances exceeded");
-        m_data.push_back(ToMaterialData(desc));
+        m_data.push_back(ToMaterialData(desc.properties));
         m_descriptions.push_back(desc);
         m_dirty.push_back(m_nextIndex);
         return m_nextIndex++;
@@ -41,7 +41,7 @@ auto MaterialRegistry::CreateInstance(const MaterialDesc& desc) -> MaterialInsta
 
     const auto index = m_freeList.back();
     m_freeList.pop_back();
-    m_data[index] = ToMaterialData(desc);
+    m_data[index] = ToMaterialData(desc.properties);
     m_descriptions[index] = desc;
     m_dirty.push_back(index);
     return index;
@@ -60,11 +60,11 @@ auto MaterialRegistry::GetInstanceDesc(MaterialInstanceHandle index) const -> co
     return m_descriptions[index];
 }
 
-void MaterialRegistry::SetInstanceDesc(MaterialInstanceHandle index, const MaterialDesc& desc)
+void MaterialRegistry::SetInstanceProperties(MaterialInstanceHandle index, const MaterialProperties& properties)
 {
     NC_ASSERT(index < m_data.size(), "Invalid MaterialInstanceHandle");
-    m_data[index] = ToMaterialData(desc);
-    m_descriptions[index] = desc;
+    m_data[index] = ToMaterialData(properties);
+    m_descriptions[index].properties = properties;
     m_dirty.push_back(index);
 }
 

--- a/source/ncengine/graphics2/frontend/subsystem/MaterialRegistry.h
+++ b/source/ncengine/graphics2/frontend/subsystem/MaterialRegistry.h
@@ -17,7 +17,7 @@ class MaterialRegistry : public StableAddress
         auto CreateInstance(const MaterialDesc& desc = MaterialDesc{}) -> MaterialInstanceHandle;
         void DestroyInstance(MaterialInstanceHandle index);
         auto GetInstanceDesc(MaterialInstanceHandle index) const -> const MaterialDesc&;
-        void SetInstanceDesc(MaterialInstanceHandle index, const MaterialDesc& desc);
+        void SetInstanceProperties(MaterialInstanceHandle index, const MaterialProperties& properties);
         auto GetInstanceData(MaterialInstanceHandle index) const -> const MaterialData&;
         void SetInstanceName(MaterialInstanceHandle index, std::string_view name);
         auto HasPendingChanges() const -> bool;

--- a/source/ncengine/graphics2/frontend/subsystem/MeshRendererSubsystem.cpp
+++ b/source/ncengine/graphics2/frontend/subsystem/MeshRendererSubsystem.cpp
@@ -21,7 +21,7 @@ auto MeshRendererSubsystem::BuildState(ecs::ExplicitEcs<MeshRenderer2, Transform
         auto& renderer = ecs.Get<MeshRenderer2>(entity);
         const auto& material = renderer.GetMaterial();
         m_passCache.AddDynamicTarget(
-            material.GetDesc().passes,
+            material.GetPasses(),
             static_cast<uint32_t>(i),
             renderer.GetMesh()
         );

--- a/source/ncengine/ui/editor/impl/ComponentWidgets.cpp
+++ b/source/ncengine/ui/editor/impl/ComponentWidgets.cpp
@@ -72,15 +72,21 @@ void MeshAssetDropdown(nc::MeshRenderer2& meshRenderer, nc::asset::NcAsset& ncAs
     }
 }
 
-void MaterialPassesWidget(nc::MaterialPasses passes)
+auto MaterialPassesWidget(nc::MaterialPasses& passes) -> bool
 {
-    IMGUI_SCOPE(nc::ui::DisableIf, true);
+    auto modified = false;
     const auto passInfo = std::views::zip(nc::GetMaterialPassNames(), nc::GetMaterialPassFlags());
     for (const auto& [name, flag] : passInfo)
     {
         auto isEnabled = static_cast<bool>(passes & flag);
-        nc::ui::Checkbox(isEnabled, name.data());
+        if (nc::ui::Checkbox(isEnabled, name.data()))
+        {
+            modified = true;
+            isEnabled ? passes |= flag : passes &= ~flag;
+        }
     }
+
+    return modified;
 }
 
 auto MaterialTexturesWidget(nc::MaterialProperties& properties, nc::asset::NcAsset& ncAsset) -> bool
@@ -699,7 +705,9 @@ void MeshRenderer2UIWidget(MeshRenderer2& meshRenderer, EditorContext& ctx, cons
     if (ImGui::TreeNodeEx("Material"))
     {
         auto& material = meshRenderer.GetMaterial();
+        auto passes = material.GetPasses();
         auto properties = material.GetProperties();
+        auto passesModified = false;
         auto modified = false;
 
         ImGui::Separator();
@@ -718,7 +726,7 @@ void MeshRenderer2UIWidget(MeshRenderer2& meshRenderer, EditorContext& ctx, cons
         ImGui::Separator();
         if (ImGui::TreeNodeEx("Passes"))
         {
-            mesh_renderer2_ext::MaterialPassesWidget(material.GetPasses());
+            passesModified = mesh_renderer2_ext::MaterialPassesWidget(passes);
             ImGui::TreePop();
         }
 
@@ -743,7 +751,11 @@ void MeshRenderer2UIWidget(MeshRenderer2& meshRenderer, EditorContext& ctx, cons
             ImGui::TreePop();
         }
 
-        if (modified)
+        if (passesModified)
+        {
+            meshRenderer.SetMaterial(MaterialDesc{std::string{material.GetName()}, passes, properties});
+        }
+        else if (modified)
         {
             material.SetProperties(properties);
         }

--- a/source/ncengine/ui/editor/impl/ComponentWidgets.cpp
+++ b/source/ncengine/ui/editor/impl/ComponentWidgets.cpp
@@ -72,58 +72,51 @@ void MeshAssetDropdown(nc::MeshRenderer2& meshRenderer, nc::asset::NcAsset& ncAs
     }
 }
 
-auto MaterialPassesWidget(nc::MaterialDesc& desc) -> bool
+void MaterialPassesWidget(nc::MaterialPasses passes)
 {
+    IMGUI_SCOPE(nc::ui::DisableIf, true);
     const auto passInfo = std::views::zip(nc::GetMaterialPassNames(), nc::GetMaterialPassFlags());
-    auto& passes = desc.passes;
-    auto modified = false;
     for (const auto& [name, flag] : passInfo)
     {
         auto isEnabled = static_cast<bool>(passes & flag);
-        if (nc::ui::Checkbox(isEnabled, name.data()))
-        {
-            modified = true;
-            isEnabled ? passes |= flag : passes &= ~flag;
-        }
+        nc::ui::Checkbox(isEnabled, name.data());
     }
-
-    return modified;
 }
 
-auto MaterialTexturesWidget(nc::MaterialDesc& desc, nc::asset::NcAsset& ncAsset) -> bool
+auto MaterialTexturesWidget(nc::MaterialProperties& properties, nc::asset::NcAsset& ncAsset) -> bool
 {
     /** @todo 353 Get asset views from ncAsset, once implemented */
     constexpr auto assetType = nc::asset::AssetType::Texture;
     const auto textureAssets = nc::ui::editor::GetLoadedAssets(assetType);
-    auto diffusePath = std::string{ncAsset.GetAssetPath(assetType, desc.diffuseTexture.id)};
-    auto normalPath = std::string{ncAsset.GetAssetPath(assetType, desc.normalTexture.id)};
+    auto diffusePath = std::string{ncAsset.GetAssetPath(assetType, properties.diffuseTexture.id)};
+    auto normalPath = std::string{ncAsset.GetAssetPath(assetType, properties.normalTexture.id)};
     auto modified = false;
     if (nc::ui::Combobox(diffusePath, "diffuse", textureAssets))
     {
         modified = true;
-        desc.diffuseTexture = nc::asset::AssetService<nc::asset::TextureView>::Get()->Acquire(diffusePath);
+        properties.diffuseTexture = nc::asset::AssetService<nc::asset::TextureView>::Get()->Acquire(diffusePath);
     }
 
     if (nc::ui::Combobox(normalPath, "normal", textureAssets))
     {
         modified = true;
-        desc.normalTexture = nc::asset::AssetService<nc::asset::TextureView>::Get()->Acquire(normalPath);
+        properties.normalTexture = nc::asset::AssetService<nc::asset::TextureView>::Get()->Acquire(normalPath);
     }
 
     return modified;
 }
 
-auto MaterialColorWidget(nc::MaterialDesc& desc) -> bool
+auto MaterialColorWidget(nc::MaterialProperties& properties) -> bool
 {
-    auto modified = nc::ui::InputColor3(desc.gradientStart, "start");
-    modified = nc::ui::InputColor3(desc.gradientEnd, "end") || modified;
+    auto modified = nc::ui::InputColor3(properties.gradientStart, "start");
+    modified = nc::ui::InputColor3(properties.gradientEnd, "end") || modified;
     return modified;
 }
 
-auto MaterialOutlineWidget(nc::MaterialDesc& desc) -> bool
+auto MaterialOutlineWidget(nc::MaterialProperties& properties) -> bool
 {
-    auto modified = nc::ui::InputColor3(desc.outlineColor, "color");
-    modified = nc::ui::DragFloat(desc.outlineWidth, "width", 0.1f, 0.0f, 10.0f) || modified;
+    auto modified = nc::ui::InputColor3(properties.outlineColor, "color");
+    modified = nc::ui::DragFloat(properties.outlineWidth, "width", 0.1f, 0.0f, 10.0f) || modified;
     return modified;
 }
 } // namespace mesh_renderer2_ext
@@ -705,17 +698,18 @@ void MeshRenderer2UIWidget(MeshRenderer2& meshRenderer, EditorContext& ctx, cons
     ImGui::Separator();
     if (ImGui::TreeNodeEx("Material"))
     {
-        auto& materialInstance = meshRenderer.GetMaterial();
-        auto materialDesc = materialInstance.GetDesc();
-        auto descModified = false;
+        auto& material = meshRenderer.GetMaterial();
+        auto properties = material.GetProperties();
+        auto modified = false;
 
         ImGui::Separator();
         if (ImGui::TreeNodeEx("Metadata"))
         {
-            ImGui::Text("Handle: %hu", materialInstance.GetHandle());
-            if (ui::InputText(materialDesc.name, "name"))
+            ImGui::Text("Handle: %hu", material.GetHandle());
+            auto materialName = std::string{material.GetName()};
+            if (ui::InputText(materialName, "name"))
             {
-                materialInstance.SetName(materialDesc.name);
+                material.SetName(materialName);
             }
 
             ImGui::TreePop();
@@ -724,34 +718,34 @@ void MeshRenderer2UIWidget(MeshRenderer2& meshRenderer, EditorContext& ctx, cons
         ImGui::Separator();
         if (ImGui::TreeNodeEx("Passes"))
         {
-            descModified = mesh_renderer2_ext::MaterialPassesWidget(materialDesc) || descModified;
+            mesh_renderer2_ext::MaterialPassesWidget(material.GetPasses());
             ImGui::TreePop();
         }
 
         ImGui::Separator();
         if (ImGui::TreeNodeEx("Textures"))
         {
-            descModified = mesh_renderer2_ext::MaterialTexturesWidget(materialDesc, ncAsset) || descModified;
+            modified = mesh_renderer2_ext::MaterialTexturesWidget(properties, ncAsset) || modified;
             ImGui::TreePop();
         }
 
         ImGui::Separator();
         if (ImGui::TreeNodeEx("Gradient Color"))
         {
-            descModified = mesh_renderer2_ext::MaterialColorWidget(materialDesc) || descModified;
+            modified = mesh_renderer2_ext::MaterialColorWidget(properties) || modified;
             ImGui::TreePop();
         }
 
         ImGui::Separator();
         if (ImGui::TreeNodeEx("Outline"))
         {
-            descModified = mesh_renderer2_ext::MaterialOutlineWidget(materialDesc) || descModified;
+            modified = mesh_renderer2_ext::MaterialOutlineWidget(properties) || modified;
             ImGui::TreePop();
         }
 
-        if (descModified)
+        if (modified)
         {
-            materialInstance.SetDesc(materialDesc);
+            material.SetProperties(properties);
         }
 
         ImGui::TreePop();

--- a/test/ncengine/graphics2/MaterialRegistry_tests.cpp
+++ b/test/ncengine/graphics2/MaterialRegistry_tests.cpp
@@ -27,30 +27,32 @@ TEST(MaterialRegistryTest, CreateInstance_constructsValidInstance)
     const auto expectedDesc = nc::MaterialDesc{
         .name = "test",
         .passes = nc::MaterialPass::Toon,
-        .diffuseTexture = nc::asset::TextureView{
-            .id = 42,
-            .index = 2
-        },
-        .normalTexture = nc::asset::TextureView{
-            .id = 10,
-            .index = 13
-        },
-        .gradientStart = nc::Vector3::One(),
-        .gradientEnd = nc::Vector3::Zero(),
-        .outlineColor = nc::Vector3::Splat(0.5f),
-        .outlineWidth = 0.2f
+        .properties = nc::MaterialProperties{
+            .diffuseTexture = nc::asset::TextureView{
+                .id = 42,
+                .index = 2
+            },
+            .normalTexture = nc::asset::TextureView{
+                .id = 10,
+                .index = 13
+            },
+            .gradientStart = nc::Vector3::One(),
+            .gradientEnd = nc::Vector3::Zero(),
+            .outlineColor = nc::Vector3::Splat(0.5f),
+            .outlineWidth = 0.2f
+        }
     };
 
     auto uut = nc::graphics::MaterialRegistry{5u};
     const auto actualIndex = uut.CreateInstance(expectedDesc);
     const auto actualProperties = uut.GetInstanceData(actualIndex);
     EXPECT_EQ(0u, actualIndex);
-    EXPECT_EQ(expectedDesc.diffuseTexture.index, actualProperties.diffuseTexIndex);
-    EXPECT_EQ(expectedDesc.normalTexture.index, actualProperties.normalTexIndex);
-    EXPECT_EQ(expectedDesc.gradientStart, actualProperties.gradientStart);
-    EXPECT_EQ(expectedDesc.gradientEnd, actualProperties.gradientEnd);
-    EXPECT_EQ(expectedDesc.outlineColor, actualProperties.outlineColor);
-    EXPECT_EQ(expectedDesc.outlineWidth, actualProperties.outlineWidth);
+    EXPECT_EQ(expectedDesc.properties.diffuseTexture.index, actualProperties.diffuseTexIndex);
+    EXPECT_EQ(expectedDesc.properties.normalTexture.index, actualProperties.normalTexIndex);
+    EXPECT_EQ(expectedDesc.properties.gradientStart, actualProperties.gradientStart);
+    EXPECT_EQ(expectedDesc.properties.gradientEnd, actualProperties.gradientEnd);
+    EXPECT_EQ(expectedDesc.properties.outlineColor, actualProperties.outlineColor);
+    EXPECT_EQ(expectedDesc.properties.outlineWidth, actualProperties.outlineWidth);
 }
 
 TEST(MaterialRegistryTest, CreateInstance_allocatesSequentialIndices)
@@ -103,7 +105,7 @@ TEST(MaterialRegistryTest, HasPendingChanges_returnsExpectedValue)
     EXPECT_TRUE(uut.HasPendingChanges());
     uut.CommitPendingChanges(listener.MakeCallback());
     EXPECT_FALSE(uut.HasPendingChanges());
-    uut.SetInstanceDesc(instance, nc::MaterialDesc{});
+    uut.SetInstanceProperties(instance, nc::MaterialProperties{});
     EXPECT_TRUE(uut.HasPendingChanges());
 }
 
@@ -112,7 +114,7 @@ TEST(MaterialRegistryTest, CommitPendingChanges_multipleWritesToSameInstance_rep
     auto uut = nc::graphics::MaterialRegistry{3};
     auto listener = UpdateListener{};
     auto instance = uut.CreateInstance();
-    uut.SetInstanceDesc(instance, nc::MaterialDesc{});
+    uut.SetInstanceProperties(instance, nc::MaterialProperties{});
     uut.CommitPendingChanges(listener.MakeCallback());
     ASSERT_EQ(1, listener.receivedInfo.dirtyRanges.size());
     const auto& [offset, count] = listener.receivedInfo.dirtyRanges[0];
@@ -142,8 +144,8 @@ TEST(MaterialRegistryTest, CommitPendingChanges_nonContiguousInstanceUpdates_rep
     auto third = uut.CreateInstance();
     uut.CommitPendingChanges(listener.MakeCallback());
 
-    uut.SetInstanceDesc(first, nc::MaterialDesc{});
-    uut.SetInstanceDesc(third, nc::MaterialDesc{});
+    uut.SetInstanceProperties(first, nc::MaterialProperties{});
+    uut.SetInstanceProperties(third, nc::MaterialProperties{});
     uut.CommitPendingChanges(listener.MakeCallback());
     ASSERT_EQ(2, listener.receivedInfo.dirtyRanges.size());
     const auto& [firstOffset, firstCount] = listener.receivedInfo.dirtyRanges[0];
@@ -160,21 +162,20 @@ TEST(MaterialRegistryTest, AllMethods_indexOutOfBounds_throws)
     const auto badIndex = nc::MaterialInstanceHandle{0};
     EXPECT_THROW(uut.DestroyInstance(badIndex), nc::NcError);
     EXPECT_THROW(uut.GetInstanceDesc(badIndex), nc::NcError);
-    EXPECT_THROW(uut.SetInstanceDesc(badIndex, nc::MaterialDesc()), nc::NcError);
+    EXPECT_THROW(uut.SetInstanceProperties(badIndex, nc::MaterialProperties()), nc::NcError);
     EXPECT_THROW(uut.GetInstanceData(badIndex), nc::NcError);
 }
 
 TEST(MaterialRegistryTest, MaterialInstance_wrapsFunctions)
 {
     const auto originalDesc = nc::MaterialDesc{.name = "original"};
-    const auto newDesc = nc::MaterialDesc{.name = "original"};
     auto uut = nc::graphics::MaterialRegistry{3};
     auto first = nc::MaterialInstance{originalDesc};
     auto second = first.Clone();
-    first.SetDesc(newDesc);
+    first.SetName("new");
 
-    EXPECT_EQ(newDesc.name, first.GetDesc().name);
-    EXPECT_EQ(originalDesc.name, second.GetDesc().name);
+    EXPECT_EQ("new", first.GetName());
+    EXPECT_EQ(originalDesc.name, second.GetName());
 }
 
 TEST(MaterialRegistryTest, MaterialInstance_desctructor_destroysInstanceIfOwner)

--- a/test/ncengine/graphics2/MeshRendererSubsystem_tests.cpp
+++ b/test/ncengine/graphics2/MeshRendererSubsystem_tests.cpp
@@ -20,9 +20,9 @@ const auto g_materialDesc = nc::MaterialDesc{
 namespace nc
 {
 MaterialInstance::MaterialInstance(const MaterialDesc&){}
-MaterialInstance::~MaterialInstance() = default;
 auto MaterialInstance::GetPasses()     const ->       MaterialPasses      { return g_materialDesc.passes;     }
 auto MaterialInstance::GetProperties() const -> const MaterialProperties& { return g_materialDesc.properties; }
+void MaterialInstance::Release() noexcept {}
 } // namespace nc
 
 class MeshRendererSubsystemTest : public testing::Test,

--- a/test/ncengine/graphics2/MeshRendererSubsystem_tests.cpp
+++ b/test/ncengine/graphics2/MeshRendererSubsystem_tests.cpp
@@ -21,10 +21,8 @@ namespace nc
 {
 MaterialInstance::MaterialInstance(const MaterialDesc&){}
 MaterialInstance::~MaterialInstance() = default;
-auto MaterialInstance::GetDesc() const -> const MaterialDesc&
-{
-    return g_materialDesc;
-}
+auto MaterialInstance::GetPasses()     const ->       MaterialPasses      { return g_materialDesc.passes;     }
+auto MaterialInstance::GetProperties() const -> const MaterialProperties& { return g_materialDesc.properties; }
 } // namespace nc
 
 class MeshRendererSubsystemTest : public testing::Test,


### PR DESCRIPTION
prereq for #798 

Making passes immutable after material construction and adding `MeshRenderer2::SetMaterial()` as an alternative way to update passes for an object. Also splitting out shader-visible values from `MaterialDesc` into a `MaterialProperties` struct so API getters/setters are little clearer with respect to mutability.

Once we start caching instance/static instance data, it becomes really obnoxious to remap objects to new passes when they change on the material side. Somebody (like the material) needs to know all of the `MeshRenderer`s using a particular material, so that on update, we can go and shuffle around each affected object's cached state. How we actually want to do this is not by changing the material's passes, but simply assigning a new material to a `MeshRenderer`.