### PR TITLE
Add InstanceCache

### DIFF
--- a/source/ncengine/graphics2/ShaderTypes.h
+++ b/source/ncengine/graphics2/ShaderTypes.h
@@ -24,6 +24,14 @@ struct GlobalEnvironmentData
 };
 
 // Object model for MeshRenderers (type: StructuredBuffer element type).
+// @todo 808 Replace MeshRendererData with this
+struct InstanceData
+{
+    uint32_t transformIndex = std::numeric_limits<uint32_t>::max();
+    uint32_t materialIndex = std::numeric_limits<uint32_t>::max();
+};
+
+// Object model for MeshRenderers (type: StructuredBuffer element type).
 struct MeshRendererData
 {
     DirectX::XMMATRIX modelMatrix = DirectX::XMMatrixIdentity(); // Transforms the object from object space to world space.

--- a/source/ncengine/graphics2/frontend/subsystem/CMakeLists.txt
+++ b/source/ncengine/graphics2/frontend/subsystem/CMakeLists.txt
@@ -1,6 +1,7 @@
 target_sources(${NC_ENGINE_LIB}
     PRIVATE
         CameraSubsystem.cpp
+        InstanceCache.cpp
         LightSubsystem.cpp
         MaterialRegistry.cpp
         MeshRendererSubsystem.cpp

--- a/source/ncengine/graphics2/frontend/subsystem/InstanceCache.cpp
+++ b/source/ncengine/graphics2/frontend/subsystem/InstanceCache.cpp
@@ -154,7 +154,7 @@ auto InstanceCache::BuildState() -> BufferUpdateInfo<InstanceData>
 auto InstanceCache::BuildBatches(std::span<const MaterialPass::type> passes) -> std::vector<std::vector<Batch>>
 {
     NC_PROFILE_SCOPE("InstanceCache::BuildBatches()", ProfileCategory::Rendering);
-    auto out = std::vector<std::vector<Batch>>(passes.size(), {});
+    auto out = std::vector<std::vector<Batch>>(passes.size());
     for (const auto& region : m_batches)
     {
         if (region.batch.instanceCount == 0)

--- a/source/ncengine/graphics2/frontend/subsystem/InstanceCache.cpp
+++ b/source/ncengine/graphics2/frontend/subsystem/InstanceCache.cpp
@@ -1,0 +1,347 @@
+#include "InstanceCache.h"
+
+#include "ncengine/debug/Profile.h"
+
+namespace
+{
+void IncrementBatchCount(nc::graphics::BatchRegion& region, uint32_t count)
+{
+    region.batch.instanceCount += count;
+    if (region.batch.instanceCount > region.capacity)
+    {
+        region.capacity = region.batch.instanceCount;
+    }
+}
+
+auto WalkBatch(const nc::graphics::Batch& batch)
+{
+    return std::views::iota(
+        batch.instanceOffset,
+        batch.instanceOffset + batch.instanceCount
+    );
+}
+} // anonymous namespace
+
+namespace nc::graphics
+{
+void InstanceCacheStaging::AddInstance(uint32_t entityId,
+                                       MaterialPasses passes,
+                                       const asset::MeshView& mesh,
+                                       const InstanceData& instanceData)
+{
+    m_hasStagedState = true;
+    const auto key = BatchKey{passes, mesh.id};
+    const auto staging = std::ranges::find(m_stagedInstances, key, &StagedBatchInstances::key);
+    if (staging != m_stagedInstances.end())
+    {
+        staging->instances.emplace_back(entityId, instanceData);
+        return;
+    }
+
+    m_stagedInstances.emplace_back(
+        key,
+        std::vector<StagedInstance>{
+            StagedInstance{
+                entityId,
+                instanceData
+            }
+        }
+    );
+
+    m_stagedRegions.emplace_back(passes, mesh);
+}
+
+void InstanceCacheStaging::RemoveInstance(uint32_t entityId,
+                                          MaterialPasses passes,
+                                          uint64_t meshId)
+{
+    m_hasStagedState = true;
+    m_stagedRemovals.emplace_back(BatchKey{passes, meshId}, entityId);
+}
+
+void InstanceCacheStaging::UpdateInstance(uint32_t entityId,
+                                          MaterialPasses oldPasses,
+                                          MaterialPasses newPasses,
+                                          uint64_t oldMeshId,
+                                          const asset::MeshView& newMesh,
+                                          const InstanceData& instanceData)
+{
+    m_hasStagedState = true;
+    RemoveInstance(entityId, oldPasses, oldMeshId);
+    AddInstance(entityId, newPasses, newMesh, instanceData);
+}
+
+void InstanceCacheStaging::ClearStaged()
+{
+    m_hasStagedState = false;
+    m_stagedRegions.clear();
+    m_stagedRemovals.clear();
+    for (auto& pending : m_stagedInstances)
+    {
+        pending.instances.clear();
+    }
+}
+
+void InstanceCacheStaging::Purge(std::span<const BatchRegion> toKeep) noexcept
+{
+    m_stagedRegions.clear();
+    m_stagedRegions.shrink_to_fit();
+    m_stagedRemovals.clear();
+    m_stagedRemovals.shrink_to_fit();
+    std::erase_if(m_stagedInstances, [&toKeep](auto& staging)
+    {
+        if (!std::ranges::contains(toKeep, staging.key, &BatchRegion::key))
+        {
+            return true;
+        }
+
+        staging.instances.clear();
+        staging.instances.shrink_to_fit();
+        return false;
+    });
+
+    m_stagedInstances.shrink_to_fit();
+}
+
+InstanceCache::InstanceCache(uint32_t maxMeshRenderers,
+                             uint32_t initialBatchSize)
+    : m_batches{},
+      m_entityToIndex{100, maxMeshRenderers},
+      m_initialBatchSize{initialBatchSize}
+{
+    NC_ASSERT(initialBatchSize > 0, "Invalid initial batch size");
+}
+
+void InstanceCache::CommitPendingChanges()
+{
+    NC_PROFILE_SCOPE("InstanceCache::CommitPendingChanges()", ProfileCategory::Rendering);
+    if (!m_stagingArea.HasStagedState())
+    {
+        return;
+    }
+
+    const auto& stagedRegions = m_stagingArea.GetStagedBatchRegions();
+    const auto newBatchCount = stagedRegions.size();
+    CommitBatchRegions(stagedRegions);
+    CommitRemovals(m_stagingArea.GetStagedRemovals());
+    CommitAdditions(m_stagingArea.GetStagedInstances(), newBatchCount);
+    m_stagingArea.ClearStaged();
+}
+
+auto InstanceCache::BuildState() -> BufferUpdateInfo<InstanceData>
+{
+    // For simplicity, we're only tracking one dirty range from the first modified index to the buffer
+    // end. This can result in more copies than necessary for non-shifting insertions and removals, but the
+    // data is pretty cheap to copy.
+    const auto begin = std::exchange(m_dirtyBegin, NullBatchIndex);
+    if (begin == NullBatchIndex)
+    {
+        return BufferUpdateInfo<InstanceData>{};
+    }
+
+    const auto count = static_cast<uint32_t>(m_buffer.size()) - begin;
+    if (count == 0)
+    {
+        return BufferUpdateInfo<InstanceData>{};
+    }
+
+    return BufferUpdateInfo<InstanceData>{
+        .instances = m_buffer,
+        .dirtyRanges = {{begin, count}}
+    };
+}
+
+auto InstanceCache::BuildBatches(std::span<const MaterialPass::type> passes) -> std::vector<std::vector<Batch>>
+{
+    NC_PROFILE_SCOPE("InstanceCache::BuildBatches()", ProfileCategory::Rendering);
+    auto out = std::vector<std::vector<Batch>>(passes.size(), {});
+    for (const auto& region : m_batches)
+    {
+        if (region.batch.instanceCount == 0)
+        {
+            continue;
+        }
+
+        for (auto [passId, passOut] : std::views::zip(passes, out))
+        {
+            if (region.key.passes & passId)
+            {
+                passOut.push_back(region.batch);
+            }
+        }
+    }
+
+    return out;
+}
+
+void InstanceCache::Purge() noexcept
+{
+    CommitPendingChanges();
+    m_dirtyBegin = 0u;
+    auto bufferEnd = 0u;
+    for (auto& region : m_batches)
+    {
+        if (region.batch.instanceCount > 0)
+        {
+            auto insertIndex = bufferEnd;
+            for (const auto currentIndex : WalkBatch(region.batch))
+            {
+                MoveInstance(currentIndex, insertIndex++);
+            }
+
+            region.batch.instanceOffset = bufferEnd;
+            region.capacity = std::max(region.batch.instanceCount, m_initialBatchSize);
+            bufferEnd += region.capacity;
+        }
+    }
+
+    std::erase_if(m_batches, [](const auto& region)
+    {
+        return region.batch.instanceCount == 0;
+    });
+
+    m_batches.shrink_to_fit();
+    m_buffer.resize(bufferEnd);
+    m_buffer.shrink_to_fit();
+    m_indexToEntity.resize(bufferEnd);
+    m_indexToEntity.shrink_to_fit();
+    m_stagingArea.Purge(m_batches);
+}
+
+void InstanceCache::MarkDirtyStartingFrom(uint32_t instanceIndex)
+{
+    m_dirtyBegin = std::min(m_dirtyBegin, instanceIndex);
+}
+
+void InstanceCache::ResetDirtyRange() noexcept
+{
+    m_dirtyBegin = NullBatchIndex;
+}
+
+void InstanceCache::InsertInstance(uint32_t index, const StagedInstance& instance)
+{
+    m_buffer[index] = instance.instanceData;
+    m_indexToEntity[index] = instance.entityId;
+    m_entityToIndex.emplace(instance.entityId, index);
+}
+
+void InstanceCache::MoveInstance(uint32_t from, uint32_t to)
+{
+    m_buffer[to] = m_buffer[from];
+    const auto entity = std::exchange(m_indexToEntity[from], NullBatchIndex);
+    m_indexToEntity[to] = entity;
+    m_entityToIndex.at(entity) = to;
+}
+
+auto InstanceCache::EraseInstance(uint32_t entityId) -> uint32_t
+{
+    const auto instanceIndex = m_entityToIndex.at(entityId);
+    m_entityToIndex.erase(entityId);
+    m_indexToEntity.at(instanceIndex) = NullBatchIndex;
+    return instanceIndex;
+}
+
+void InstanceCache::CommitBatchRegions(const std::vector<StagedBatchRegion>& stagedRegions)
+{
+    auto batchIndex = static_cast<uint32_t>(m_buffer.size());
+    for (const auto& [passes, mesh] : stagedRegions)
+    {
+        m_batches.emplace_back(
+            BatchKey{passes, mesh.id},
+            Batch{batchIndex, mesh},
+            m_initialBatchSize
+        );
+
+        batchIndex += m_initialBatchSize;
+    }
+}
+
+void InstanceCache::CommitRemovals(const std::vector<StagedRemoval>& stagedRemovals)
+{
+    for (const auto& toRemove : stagedRemovals)
+    {
+        const auto instanceIndex = EraseInstance(toRemove.entityId);
+        auto& batch = GetRegion(toRemove.key).batch;
+        const auto batchEndIndex = batch.instanceOffset + batch.instanceCount - 1;
+        --batch.instanceCount;
+
+        // If this is the last batch instance, decrementing the count is sufficient, else swap with last.
+        if (instanceIndex < batchEndIndex)
+        {
+            MoveInstance(batchEndIndex, instanceIndex);
+            MarkDirtyStartingFrom(instanceIndex);
+        }
+    }
+}
+
+void InstanceCache::CommitAdditions(const std::vector<StagedBatchInstances>& stagedInstances, size_t newBatchCount)
+{
+    NC_ASSERT(m_batches.size() == stagedInstances.size(), "Batch size mismatch");
+    const auto perBatchShift = EvaluateAdditions(stagedInstances, newBatchCount);
+
+    // The range from the end of the last batch to buffer end is newly allocated space. Visiting in reverse lets
+    // us freely shift each batch to the right. We can then write new instances into the free spaces between batches.
+    auto reverseView = std::views::reverse(std::views::zip(m_batches, stagedInstances, perBatchShift));
+    for (auto [current, pending, shiftBy] : reverseView)
+    {
+        if (shiftBy > 0)
+        {
+            for (const auto currentIndex : std::views::reverse(WalkBatch(current.batch)))
+            {
+                MoveInstance(currentIndex, currentIndex + shiftBy);
+            }
+
+            current.batch.instanceOffset += shiftBy;
+        }
+
+        const auto insertCount = static_cast<uint32_t>(pending.instances.size());
+        if (insertCount == 0)
+        {
+            continue;
+        }
+
+        auto instanceIndex = current.batch.instanceOffset + current.batch.instanceCount;
+        IncrementBatchCount(current, insertCount);
+        for (auto& toAdd : pending.instances)
+        {
+            InsertInstance(instanceIndex, toAdd);
+            ++instanceIndex;
+        }
+    }
+}
+
+auto InstanceCache::EvaluateAdditions(const std::vector<StagedBatchInstances>& stagedInstances, size_t newBatchCount) -> std::vector<uint32_t>
+{
+    // Want to minimize number of shifts required when inserting new items. Traverse new instances
+    // once to calculate the required shift amount for each batch.
+    auto perBatchShift = std::vector<uint32_t>{};
+    perBatchShift.reserve(m_batches.size());
+    auto accumulatedShifts = 0u;
+    for (auto [current, pending] : std::views::zip(m_batches, stagedInstances))
+    {
+        if (pending.instances.empty())
+        {
+            perBatchShift.push_back(accumulatedShifts);
+            continue;
+        }
+
+        const auto freeSlots = current.capacity - current.batch.instanceCount;
+        const auto newInstances = static_cast<uint32_t>(pending.instances.size());
+        const auto slotsNeeded = newInstances >= freeSlots ? newInstances - freeSlots : 0u;
+        perBatchShift.push_back(accumulatedShifts);
+        accumulatedShifts += slotsNeeded;
+        MarkDirtyStartingFrom(current.batch.instanceOffset);
+    }
+
+    // Each batch starts with some capacity. This needs to be allocated in addition to the new instance/shift count.
+    const auto additionalSpaceRequired = accumulatedShifts + newBatchCount * m_initialBatchSize;
+    if (additionalSpaceRequired > 0u)
+    {
+        const auto newSize = m_buffer.size() + additionalSpaceRequired;
+        m_buffer.resize(newSize);
+        m_indexToEntity.resize(newSize, NullBatchIndex);
+    }
+
+    return perBatchShift;
+}
+} // namespace nc::graphics

--- a/source/ncengine/graphics2/frontend/subsystem/InstanceCache.h
+++ b/source/ncengine/graphics2/frontend/subsystem/InstanceCache.h
@@ -182,7 +182,7 @@ class InstanceCache
         sparse_map<uint32_t> m_entityToIndex;
         std::vector<uint32_t> m_indexToEntity;
         InstanceCacheStaging m_stagingArea;
-        uint32_t m_dirtyBegin = UINT_MAX;
+        uint32_t m_dirtyBegin = NullBatchIndex;
         uint32_t m_initialBatchSize;
 
         void InsertInstance(uint32_t index, const StagedInstance& instance);

--- a/source/ncengine/graphics2/frontend/subsystem/InstanceCache.h
+++ b/source/ncengine/graphics2/frontend/subsystem/InstanceCache.h
@@ -1,0 +1,198 @@
+#pragma once
+
+#include "graphics2/ShaderTypes.h"
+#include "graphics2/frontend/subsystem/MeshRendererRenderState.h"
+
+#include "ncengine/asset/AssetViews.h"
+#include "ncengine/utility/SparseMap.h"
+
+#include <limits>
+#include <ranges>
+#include <vector>
+
+namespace nc::graphics
+{
+constexpr auto NullBatchIndex = std::numeric_limits<uint32_t>::max();
+
+// A batch is uniquely identified by a mesh and set of material passes.
+struct BatchKey
+{
+    MaterialPasses passes = NullBatchIndex;
+    uint64_t meshId = std::numeric_limits<uint64_t>::max();
+
+    friend auto operator==(const BatchKey& lhs, const BatchKey& rhs) -> bool
+    {
+        return lhs.passes == rhs.passes && lhs.meshId == rhs.meshId;
+    }
+};
+
+// Batch state describing a contiguous region in the instance buffer as well as draw attributes.
+struct BatchRegion
+{
+    BatchKey key = BatchKey{};
+    Batch batch;
+    uint32_t capacity = 0;
+};
+
+// A new batch waiting to be added to the instance buffer.
+struct StagedBatchRegion
+{
+    MaterialPasses passes = MaterialPasses{};
+    asset::MeshView mesh = asset::MeshView{};
+};
+
+// InstanceData for a MeshRenderer waiting to added to a batch.
+struct StagedInstance
+{
+    uint32_t entityId = NullBatchIndex;
+    InstanceData instanceData = InstanceData{};
+};
+
+// Per-batch staging area.
+struct StagedBatchInstances
+{
+    BatchKey key = BatchKey{};
+    std::vector<StagedInstance> instances = {};
+};
+
+// MeshRenderer instance waiting to be removed from a batch.
+struct StagedRemoval
+{
+    BatchKey key = BatchKey{};
+    uint32_t entityId = NullBatchIndex;
+};
+
+// InstanceCache interface for adding, removing, and updating MeshRenderer instances. Events
+// originating from game logic/API should only be routed to here to avoid race conditions
+// with the actual InstanceCache buffer.
+class InstanceCacheStaging
+{
+    public:
+        // API-Facing Functions
+        void AddInstance(uint32_t entityId,
+                         MaterialPasses passes,
+                         const asset::MeshView& mesh,
+                         const InstanceData& instanceData);
+
+        void RemoveInstance(uint32_t entityId,
+                            MaterialPasses passes,
+                            uint64_t meshId);
+
+        void UpdateInstance(uint32_t entityId,
+                            MaterialPasses oldPasses,
+                            MaterialPasses newPasses,
+                            uint64_t oldMeshId,
+                            const asset::MeshView& newMesh,
+                            const InstanceData& instanceData);
+
+        // For Use By InstanceCache
+        auto HasStagedState()        const -> bool                                     { return m_hasStagedState; }
+        auto GetStagedBatchRegions() const -> const std::vector<StagedBatchRegion>&    { return m_stagedRegions; }
+        auto GetStagedInstances()    const -> const std::vector<StagedBatchInstances>& { return m_stagedInstances; }
+        auto GetStagedRemovals()     const -> const std::vector<StagedRemoval>&        { return m_stagedRemovals; }
+        void ClearStaged();
+        void Purge(std::span<const BatchRegion> toKeep) noexcept;
+
+    private:
+        std::vector<StagedBatchRegion> m_stagedRegions;
+        std::vector<StagedBatchInstances> m_stagedInstances;
+        std::vector<StagedRemoval> m_stagedRemovals;
+        bool m_hasStagedState = false;
+};
+
+// CPU-side buffer for InstanceData. Elements are sorted by Batch, where a Batch corresponds to an instanced
+// draw call for all objects that share a mesh and material pass combination. Buffer modifications are held
+// in a staging area to improve performance when adding many elements and to allow concurrent reads and writes
+// from the graphics backend and game logic, respectively.
+class InstanceCache
+{
+    public:
+        explicit InstanceCache(uint32_t maxMeshRenderers,
+                               uint32_t initialBatchSize = 1u);
+
+        // Get the staging area for enqueueing buffer writes.
+        auto GetStagingArea() -> InstanceCacheStaging&
+        {
+            return m_stagingArea;
+        }
+
+        // Build info specifying modified buffer ranges.
+        auto BuildState() -> BufferUpdateInfo<InstanceData>;
+
+        // Generate draw call information for batches. The return value contains a collection of batches
+        // to be drawn per material pass provided in the input 'passes'.
+        auto BuildBatches(std::span<const MaterialPass::type> passes) -> std::vector<std::vector<Batch>>;
+
+        // Merge staging area into the buffer.
+        // IMPORTANT: Staging area cannot be modified while this is running (game logic cannot be running).
+        void CommitPendingChanges();
+
+        // Clean and compress unused state. Intended for scene changes but could also be called periodically, if needed.
+        // - Removes all empty batches
+        // - Shrinks excess batch capacity
+        // - Compacts buffer by shifting instances/batches towards the front
+        // IMPORTANT: Staging area cannot be modified while this is running (game logic cannot be running).
+        void Purge() noexcept;
+
+        auto IsValidInstance(uint32_t entityId) const -> bool
+        {
+            return m_entityToIndex.contains(entityId);
+        }
+
+        auto GetInstanceIndex(uint32_t entityId) const -> uint32_t
+        {
+            return m_entityToIndex.at(entityId);
+        }
+
+        auto GetEntityId(uint32_t instanceIndex) const -> uint32_t
+        {
+            return m_indexToEntity.at(instanceIndex);
+        }
+
+        auto GetInstanceData(uint32_t instanceIndex) const -> const InstanceData&
+        {
+            return m_buffer.at(instanceIndex);
+        }
+
+        auto HasBatchFor(const BatchKey& key) -> bool
+        {
+            return std::ranges::contains(m_batches, key, &BatchRegion::key);
+        }
+
+        auto GetRegion(const BatchKey& key) -> BatchRegion&
+        {
+            auto pos = std::ranges::find(m_batches, key, &BatchRegion::key);
+            NC_ASSERT(pos != m_batches.end(), "Batch not found");
+            return *pos;
+        }
+
+        auto GetInstanceCountUpperBound() const -> size_t
+        {
+            return m_buffer.size();
+        }
+
+        auto GetBatchCount() const -> size_t
+        {
+            return m_batches.size();
+        }
+
+    private:
+        std::vector<InstanceData> m_buffer;
+        std::vector<BatchRegion> m_batches;
+        sparse_map<uint32_t> m_entityToIndex;
+        std::vector<uint32_t> m_indexToEntity;
+        InstanceCacheStaging m_stagingArea;
+        uint32_t m_dirtyBegin = UINT_MAX;
+        uint32_t m_initialBatchSize;
+
+        void InsertInstance(uint32_t index, const StagedInstance& instance);
+        void MoveInstance(uint32_t from, uint32_t to);
+        auto EraseInstance(uint32_t entityId) -> uint32_t;
+        void MarkDirtyStartingFrom(uint32_t instanceIndex);
+        void ResetDirtyRange() noexcept;
+        void CommitBatchRegions(const std::vector<StagedBatchRegion>& stagedRegions);
+        void CommitRemovals(const std::vector<StagedRemoval>& stagedRemovals);
+        void CommitAdditions(const std::vector<StagedBatchInstances>& stagedInstances, size_t newBatchCount);
+        auto EvaluateAdditions(const std::vector<StagedBatchInstances>& stagedInstances, size_t newBatchCount) -> std::vector<uint32_t>;
+};
+} // namespace nc::graphics

--- a/source/ncengine/graphics2/frontend/subsystem/MeshRendererRenderState.h
+++ b/source/ncengine/graphics2/frontend/subsystem/MeshRendererRenderState.h
@@ -9,6 +9,25 @@
 
 namespace nc::graphics
 {
+// @todo 808 Replace PassTarget with this
+struct Batch
+{
+    explicit Batch(uint32_t instanceIndex, const asset::MeshView& mesh)
+        : instanceOffset{instanceIndex},
+          instanceCount{0},
+          indexOffset{mesh.firstIndex},
+          indexCount{mesh.indexCount},
+          vertexOffset{mesh.firstVertex}
+    {
+    }
+
+    uint32_t instanceOffset;
+    uint32_t instanceCount;
+    uint32_t indexOffset;
+    uint32_t indexCount;
+    uint32_t vertexOffset;
+};
+
 struct PassTarget
 {
     explicit PassTarget(uint32_t instanceIndex, const asset::MeshView& mesh)

--- a/test/ncengine/graphics2/CMakeLists.txt
+++ b/test/ncengine/graphics2/CMakeLists.txt
@@ -26,6 +26,31 @@ target_link_libraries(CameraSubsystem_tests
 
 add_test(CameraSubsystem_tests CameraSubsystem_tests)
 
+### InstanceCache Tests ###
+add_executable(InstanceCache_tests
+    InstanceCache_tests.cpp
+    ${NC_SOURCE_DIR}/graphics2/frontend/subsystem/InstanceCache.cpp
+)
+
+target_include_directories(InstanceCache_tests
+    PRIVATE
+        ${NC_INCLUDE_DIR}
+        ${NC_SOURCE_DIR}
+)
+
+target_compile_options(InstanceCache_tests
+    PUBLIC
+        ${NC_COMPILER_FLAGS}
+)
+
+target_link_libraries(InstanceCache_tests
+    PRIVATE
+        gtest_main
+        NcMath
+)
+
+add_test(InstanceCache_tests InstanceCache_tests)
+
 ### MaterialPassCache Tests ###
 add_executable(MaterialPassCache_tests
     MaterialPassCache_tests.cpp

--- a/test/ncengine/graphics2/InstanceCache_tests.cpp
+++ b/test/ncengine/graphics2/InstanceCache_tests.cpp
@@ -1,0 +1,676 @@
+#include "gtest/gtest.h"
+#include "graphics2/frontend/subsystem/InstanceCache.h"
+
+#include <array>
+
+constexpr auto g_mesh1 = nc::asset::MeshView{
+    .id = 11111111,
+    .firstVertex = 0,
+    .vertexCount = 4,
+    .firstIndex = 0,
+    .indexCount = 6
+};
+
+constexpr auto g_mesh2 = nc::asset::MeshView{
+    .id = 22222222,
+    .firstVertex = 4,
+    .vertexCount = 4,
+    .firstIndex = 6,
+    .indexCount = 6
+};
+
+constexpr auto g_mesh3 = nc::asset::MeshView{
+    .id = 33333333,
+    .firstVertex = 8,
+    .vertexCount = 8,
+    .firstIndex = 12,
+    .indexCount = 24
+};
+
+constexpr auto g_allBatches = std::array{
+    nc::MaterialPass::Shadow,
+    nc::MaterialPass::Toon,
+    nc::MaterialPass::Alpha
+};
+
+struct TestObjectInfo
+{
+    uint32_t transformIndex;
+    nc::MaterialInstanceHandle materialIndex;
+    nc::MaterialPasses passes;
+    nc::asset::MeshView mesh;
+};
+
+struct Batch1
+{
+    static constexpr auto passes = nc::MaterialPass::Toon;
+    static constexpr auto& mesh = g_mesh1;
+    static constexpr auto key = nc::graphics::BatchKey{passes, mesh.id};
+    static constexpr auto objects = std::array{
+        TestObjectInfo{0, 0, passes, mesh},
+        TestObjectInfo{1, 1, passes, mesh},
+        TestObjectInfo{2, 2, passes, mesh},
+        TestObjectInfo{3, 3, passes, mesh},
+        TestObjectInfo{4, 4, passes, mesh}
+    };
+};
+
+struct Batch2
+{
+    static constexpr auto passes = nc::MaterialPass::Toon;
+    static constexpr auto& mesh = g_mesh2;
+    static constexpr auto key = nc::graphics::BatchKey{passes, mesh.id};
+    static constexpr auto objects = std::array{
+        TestObjectInfo{5, 5, passes, mesh},
+        TestObjectInfo{6, 6, passes, mesh},
+        TestObjectInfo{7, 7, passes, mesh}
+    };
+};
+
+struct Batch3
+{
+    static constexpr auto passes = nc::MaterialPass::Shadow |
+                                   nc::MaterialPass::Toon |
+                                   nc::MaterialPass::Alpha;
+    static constexpr auto& mesh = g_mesh1;
+    static constexpr auto key = nc::graphics::BatchKey{passes, mesh.id};
+    static constexpr auto objects = std::array{
+        TestObjectInfo{8, 8, passes, mesh},
+        TestObjectInfo{9, 9, passes, mesh},
+        TestObjectInfo{10, 10, passes, mesh}
+    };
+};
+
+void AddTestInstance(nc::graphics::InstanceCache& uut, uint32_t entityId, const TestObjectInfo& info)
+{
+    return uut.GetStagingArea().AddInstance(
+        entityId,
+        info.passes,
+        info.mesh,
+        nc::graphics::InstanceData{
+            info.transformIndex,
+            info.materialIndex
+        }
+    );
+}
+
+template<class BatchDesc>
+void RemoveTestInstance(nc::graphics::InstanceCache& uut, uint32_t entityId)
+{
+    uut.GetStagingArea().RemoveInstance(entityId, BatchDesc::passes, BatchDesc::mesh.id);
+}
+
+template<class BatchDesc>
+void VerifyBatch(nc::graphics::InstanceCache& uut,
+                 uint32_t offset,
+                 uint32_t count,
+                 uint32_t capacity)
+{
+    const auto key = nc::graphics::BatchKey{BatchDesc::passes, BatchDesc::mesh.id};
+    const auto& region = uut.GetRegion(key);
+    EXPECT_EQ(offset, region.batch.instanceOffset);
+    EXPECT_EQ(count, region.batch.instanceCount);
+    EXPECT_EQ(capacity, region.capacity);
+
+    EXPECT_EQ(BatchDesc::mesh.firstIndex, region.batch.indexOffset);
+    EXPECT_EQ(BatchDesc::mesh.indexCount, region.batch.indexCount);
+    EXPECT_EQ(BatchDesc::mesh.firstVertex, region.batch.vertexOffset);
+}
+
+void VerifyInstance(const nc::graphics::InstanceCache& uut,
+                    uint32_t entityId,
+                    uint32_t instanceIndex,
+                    const TestObjectInfo& expectedInfo)
+{
+    EXPECT_TRUE(uut.IsValidInstance(entityId));
+    EXPECT_EQ(instanceIndex, uut.GetInstanceIndex(entityId));
+    EXPECT_EQ(entityId, uut.GetEntityId(instanceIndex));
+
+    const auto& instanceData = uut.GetInstanceData(instanceIndex);
+    EXPECT_EQ(instanceData.transformIndex, expectedInfo.transformIndex);
+    EXPECT_EQ(instanceData.materialIndex, expectedInfo.materialIndex);
+}
+
+TEST(InstanceCacheTest, AddInstance_single)
+{
+    auto uut = nc::graphics::InstanceCache{32};
+    const auto id1 = 0;
+    const auto& info1 = Batch1::objects.at(0);
+    AddTestInstance(uut, id1, info1);
+    uut.CommitPendingChanges();
+
+    EXPECT_EQ(1, uut.GetInstanceCountUpperBound());
+    EXPECT_EQ(1, uut.GetBatchCount());
+    VerifyInstance(uut, id1, 0, info1);
+    VerifyBatch<Batch1>(uut, 0, 1, 1);
+}
+
+TEST(InstanceCacheTest, AddInstance_multiple)
+{
+    auto uut = nc::graphics::InstanceCache{32};
+    const auto id1 = 0;
+    const auto id2 = 1;
+    const auto id3 = 2;
+    const auto& info1 = Batch1::objects.at(0);
+    const auto& info2 = Batch1::objects.at(1);
+    const auto& info3 = Batch1::objects.at(2);
+    AddTestInstance(uut, id1, info1);
+    AddTestInstance(uut, id2, info2);
+    AddTestInstance(uut, id3, info3);
+    uut.CommitPendingChanges();
+
+    EXPECT_EQ(3, uut.GetInstanceCountUpperBound());
+    EXPECT_EQ(1, uut.GetBatchCount());
+    VerifyInstance(uut, id1, 0, info1);
+    VerifyInstance(uut, id2, 1, info2);
+    VerifyInstance(uut, id3, 2, info3);
+    VerifyBatch<Batch1>(uut, 0, 3, 3);
+}
+
+TEST(InstanceCacheTests, AddInstance_multipleBatches)
+{
+    auto uut = nc::graphics::InstanceCache{32};
+    const auto id1 = 0;
+    const auto id2 = 1;
+    const auto id3 = 2;
+    const auto id4 = 3;
+    const auto& info1 = Batch1::objects.at(0);
+    const auto& info2 = Batch2::objects.at(0);
+    const auto& info3 = Batch3::objects.at(0);
+    const auto& info4 = Batch3::objects.at(1);
+    AddTestInstance(uut, id1, info1);
+    AddTestInstance(uut, id2, info2);
+    AddTestInstance(uut, id3, info3);
+    AddTestInstance(uut, id4, info4);
+    uut.CommitPendingChanges();
+
+    EXPECT_EQ(4, uut.GetInstanceCountUpperBound());
+    EXPECT_EQ(3, uut.GetBatchCount());
+    VerifyInstance(uut, id1, 0, info1);
+    VerifyInstance(uut, id2, 1, info2);
+    VerifyInstance(uut, id3, 2, info3);
+    VerifyInstance(uut, id4, 3, info4);
+    VerifyBatch<Batch1>(uut, 0, 1, 1);
+    VerifyBatch<Batch2>(uut, 1, 1, 1);
+    VerifyBatch<Batch3>(uut, 2, 2, 2);
+}
+
+TEST(InstanceCacheTests, AddInstance_hasSubsequentBatches)
+{
+    auto uut = nc::graphics::InstanceCache{32};
+    const auto id1 = 0;
+    const auto id2 = 1;
+    const auto id3 = 2;
+    const auto& info1 = Batch1::objects.at(0);
+    const auto& info2 = Batch2::objects.at(0);
+    const auto& info3 = Batch3::objects.at(0);
+    AddTestInstance(uut, id1, info1);
+    AddTestInstance(uut, id2, info2);
+    AddTestInstance(uut, id3, info3);
+    uut.CommitPendingChanges();
+
+    const auto id4 = 3;
+    const auto& info4 = Batch1::objects.at(1);
+    AddTestInstance(uut, id4, info4);
+    uut.CommitPendingChanges();
+
+    // Initial State:
+    // | B1 | B2 | B3 |
+    //  id1, id2, id3
+    //
+    // State After Insertion:
+    // |    B1   | B2 | B3 |
+    //  id1, id4, id2, id3
+
+    EXPECT_EQ(4, uut.GetInstanceCountUpperBound());
+    EXPECT_EQ(3, uut.GetBatchCount());
+    VerifyInstance(uut, id1, 0, info1);
+    VerifyInstance(uut, id4, 1, info4);
+    VerifyInstance(uut, id2, 2, info2);
+    VerifyInstance(uut, id3, 3, info3);
+    VerifyBatch<Batch1>(uut, 0, 2, 2);
+    VerifyBatch<Batch2>(uut, 2, 1, 1);
+    VerifyBatch<Batch3>(uut, 3, 1, 1);
+}
+
+TEST(InstanceCacheTests, Remove)
+{
+    auto uut = nc::graphics::InstanceCache{32};
+    const auto id1 = 0;
+    const auto id2 = 1;
+    const auto id3 = 2;
+    const auto& info1 = Batch1::objects.at(0);
+    const auto& info2 = Batch2::objects.at(0);
+    const auto& info3 = Batch3::objects.at(0);
+    AddTestInstance(uut, id1, info1);
+    AddTestInstance(uut, id2, info2);
+    AddTestInstance(uut, id3, info3);
+    uut.CommitPendingChanges();
+
+    RemoveTestInstance<Batch1>(uut, id1);
+    RemoveTestInstance<Batch2>(uut, id2);
+    RemoveTestInstance<Batch3>(uut, id3);
+    uut.CommitPendingChanges();
+
+    // Initial State:
+    // | B1 | B2 | B3 |
+    //  id1, id2, id3
+    //
+    // State After Removals:
+    // | B1 | B2 | B3 |
+    //   NA,  NA,  NA
+
+    EXPECT_EQ(3, uut.GetInstanceCountUpperBound());
+    EXPECT_EQ(3, uut.GetBatchCount());
+    EXPECT_FALSE(uut.IsValidInstance(id1));
+    EXPECT_FALSE(uut.IsValidInstance(id2));
+    EXPECT_FALSE(uut.IsValidInstance(id3));
+    VerifyBatch<Batch1>(uut, 0, 0, 1);
+    VerifyBatch<Batch2>(uut, 1, 0, 1);
+    VerifyBatch<Batch3>(uut, 2, 0, 1);
+}
+
+TEST(InstanceCacheTests, InsertAfterRemove)
+{
+    auto uut = nc::graphics::InstanceCache{32};
+    const auto id1 = 0;
+    const auto id2 = 1;
+    const auto id3 = 2;
+    const auto& info1 = Batch1::objects.at(0);
+    const auto& info2 = Batch1::objects.at(1);
+    const auto& info3 = Batch2::objects.at(2);
+    AddTestInstance(uut, id1, info1);
+    AddTestInstance(uut, id2, info2);
+    AddTestInstance(uut, id3, info3);
+    uut.CommitPendingChanges();
+
+    RemoveTestInstance<Batch1>(uut, id1);
+    RemoveTestInstance<Batch1>(uut, id2);
+    RemoveTestInstance<Batch2>(uut, id3);
+    uut.CommitPendingChanges();
+
+    AddTestInstance(uut, id1, info1);
+    uut.CommitPendingChanges();
+
+    // Initial State:
+    // |   B1    | B2 |
+    //  id1, id2, id3
+    //
+    // State After Removals + Insertion:
+    // |    B1   | B2 |
+    //   id1, NA,  NA
+
+    EXPECT_EQ(3, uut.GetInstanceCountUpperBound());
+    EXPECT_EQ(2, uut.GetBatchCount());
+    EXPECT_FALSE(uut.IsValidInstance(id2));
+    EXPECT_FALSE(uut.IsValidInstance(id3));
+    VerifyInstance(uut, id1, 0, info1);
+    VerifyBatch<Batch1>(uut, 0, 1, 2);
+    VerifyBatch<Batch2>(uut, 2, 0, 1);
+}
+
+TEST(InstanceCacheTests, Purge_clearAll)
+{
+    auto uut = nc::graphics::InstanceCache{32};
+    const auto id1 = 0;
+    const auto id2 = 1;
+    const auto id3 = 2;
+    const auto& info1 = Batch1::objects.at(0);
+    const auto& info2 = Batch2::objects.at(0);
+    const auto& info3 = Batch3::objects.at(0);
+    AddTestInstance(uut, id1, info1);
+    AddTestInstance(uut, id2, info2);
+    AddTestInstance(uut, id3, info3);
+    uut.CommitPendingChanges();
+
+    RemoveTestInstance<Batch1>(uut, id1);
+    RemoveTestInstance<Batch2>(uut, id2);
+    RemoveTestInstance<Batch3>(uut, id3);
+    uut.Purge();
+
+    // Expect totally empty state
+    EXPECT_EQ(0, uut.GetInstanceCountUpperBound());
+    EXPECT_EQ(0, uut.GetBatchCount());
+    EXPECT_FALSE(uut.IsValidInstance(id1));
+    EXPECT_FALSE(uut.IsValidInstance(id2));
+    EXPECT_FALSE(uut.IsValidInstance(id3));
+    EXPECT_FALSE(uut.HasBatchFor(Batch1::key));
+    EXPECT_FALSE(uut.HasBatchFor(Batch2::key));
+    EXPECT_FALSE(uut.HasBatchFor(Batch3::key));
+}
+
+TEST(InstanceCacheTests, Purge_preservesPersistingObjects)
+{
+    const auto batchSize = 2u;
+    auto uut = nc::graphics::InstanceCache{32, batchSize};
+    const auto id1 = 0;
+    const auto id2 = 1;
+    const auto id3 = 2;
+    const auto id4 = 3;
+    const auto id5 = 4;
+    const auto id6 = 5;
+    const auto& info1 = Batch1::objects.at(0);
+    const auto& info2 = Batch2::objects.at(0);
+    const auto& info3 = Batch2::objects.at(1);
+    const auto& info4 = Batch2::objects.at(2);
+    const auto& info5 = Batch3::objects.at(0);
+    const auto& info6 = Batch3::objects.at(1);
+    AddTestInstance(uut, id1, info1);
+    AddTestInstance(uut, id2, info2);
+    AddTestInstance(uut, id3, info3);
+    AddTestInstance(uut, id4, info4);
+    AddTestInstance(uut, id5, info5);
+    AddTestInstance(uut, id6, info6);
+    uut.CommitPendingChanges();
+
+    RemoveTestInstance<Batch1>(uut, id1);
+    RemoveTestInstance<Batch2>(uut, id2);
+    RemoveTestInstance<Batch2>(uut, id4);
+    RemoveTestInstance<Batch3>(uut, id6);
+    uut.Purge();
+
+    // id3 & id5 are kept, which should preserve Batch2 & Batch3, compacting them towards the front
+    // Initial State:
+    // |   B1   |      B2      |   B3   |
+    //  id1, NA, id2, id3, id4, id5, id6
+    //
+    // State After Purge:
+    // |   B2   |   B3  |
+    //  id3, NA, id5, NA
+    EXPECT_EQ(batchSize * 2, uut.GetInstanceCountUpperBound());
+    EXPECT_EQ(2, uut.GetBatchCount());
+    VerifyInstance(uut, id3, 0, info3);
+    VerifyInstance(uut, id5, batchSize, info5);
+    VerifyBatch<Batch2>(uut, 0, 1, batchSize);
+    VerifyBatch<Batch3>(uut, batchSize, 1, batchSize);
+
+    EXPECT_FALSE(uut.IsValidInstance(id1));
+    EXPECT_FALSE(uut.IsValidInstance(id2));
+    EXPECT_FALSE(uut.IsValidInstance(id4));
+    EXPECT_FALSE(uut.IsValidInstance(id6));
+    EXPECT_FALSE(uut.HasBatchFor(Batch1::key));
+}
+
+TEST(InstanceCacheTests, AddInstance_afterClear)
+{
+    auto uut = nc::graphics::InstanceCache{32};
+    const auto id1 = 0;
+    const auto id2 = 1;
+    const auto id3 = 2;
+    const auto id4 = 3;
+    const auto& info1 = Batch1::objects.at(0);
+    const auto& info2 = Batch2::objects.at(0);
+    const auto& info3 = Batch2::objects.at(1);
+    const auto& info4 = Batch3::objects.at(0);
+    AddTestInstance(uut, id1, info1);
+    AddTestInstance(uut, id2, info2);
+    AddTestInstance(uut, id3, info3);
+    AddTestInstance(uut, id4, info4);
+    uut.CommitPendingChanges();
+
+    RemoveTestInstance<Batch1>(uut, id1);
+    RemoveTestInstance<Batch2>(uut, id2);
+    RemoveTestInstance<Batch3>(uut, id4);
+    uut.Purge();
+
+    AddTestInstance(uut, id1, info1);
+    AddTestInstance(uut, id2, info2);
+    uut.CommitPendingChanges();
+
+    // id3 is kept preserving Batch2. id1 & id2 are then added back
+    // Initial State:
+    // | B1 |   B2    | B3 |
+    //  id1, id2, id3, id4
+    //
+    // State After Purge + Readd:
+    // |   B2    | B1 |
+    //  id3, id2,  id1
+
+    EXPECT_EQ(3, uut.GetInstanceCountUpperBound());
+    EXPECT_EQ(2, uut.GetBatchCount());
+    VerifyInstance(uut, id3, 0, info3);
+    VerifyInstance(uut, id2, 1, info2);
+    VerifyInstance(uut, id1, 2, info1);
+    VerifyBatch<Batch2>(uut, 0, 2, 2);
+    VerifyBatch<Batch1>(uut, 2, 1, 1);
+
+    EXPECT_FALSE(uut.IsValidInstance(id4));
+    EXPECT_FALSE(uut.HasBatchFor(Batch3::key));
+}
+
+TEST(InstanceCacheTests, UpdateInstance)
+{
+    auto uut = nc::graphics::InstanceCache{32};
+    const auto id1 = 0;
+    const auto id2 = 1;
+    const auto id3 = 2;
+    const auto& info1 = Batch1::objects.at(0);
+    const auto& info2 = Batch2::objects.at(0);
+    const auto& info3 = Batch3::objects.at(0);
+    AddTestInstance(uut, id1, info1);
+    AddTestInstance(uut, id2, info2);
+    AddTestInstance(uut, id3, info3);
+    uut.CommitPendingChanges();
+
+    const auto& newInfo1 = Batch3::objects.at(1);
+    const auto& newInfo2 = Batch3::objects.at(2);
+
+    uut.GetStagingArea().UpdateInstance(
+        id1,
+        info1.passes,
+        newInfo1.passes,
+        info1.mesh.id,
+        newInfo1.mesh,
+        nc::graphics::InstanceData{
+            newInfo1.transformIndex,
+            newInfo1.materialIndex
+        }
+    );
+
+    uut.GetStagingArea().UpdateInstance(
+        id2,
+        info2.passes,
+        newInfo2.passes,
+        info2.mesh.id,
+        newInfo2.mesh,
+        nc::graphics::InstanceData{
+            newInfo2.transformIndex,
+            newInfo2.materialIndex
+        }
+    );
+
+    uut.CommitPendingChanges();
+
+    // id1 & id2 moved to Batch3
+    // Initial State:
+    // | B1  | B2  | B3 |
+    //   id1,  id2,  id3
+    //
+    // State After Update:
+    // | B1 | B2 |      B3      |
+    //   NA,  NA,  id3, id1, id2
+
+    EXPECT_EQ(5, uut.GetInstanceCountUpperBound());
+    EXPECT_EQ(3, uut.GetBatchCount());
+    VerifyInstance(uut, id3, 2, info3);
+    VerifyInstance(uut, id1, 3, newInfo1);
+    VerifyInstance(uut, id2, 4, newInfo2);
+    VerifyBatch<Batch1>(uut, 0, 0, 1);
+    VerifyBatch<Batch2>(uut, 1, 0, 1);
+    VerifyBatch<Batch3>(uut, 2, 3, 3);
+}
+
+TEST(InstanceCacheTests, BuildState)
+{
+    auto uut = nc::graphics::InstanceCache{32};
+
+    // empty state - not dirty
+    {
+        auto actual = uut.BuildState();
+        EXPECT_TRUE(actual.instances.empty());
+        EXPECT_TRUE(actual.dirtyRanges.empty());
+    }
+
+    const auto id1 = 0;
+    const auto id2 = 1;
+    const auto id3 = 2;
+    const auto id4 = 3;
+    const auto& info1 = Batch1::objects.at(0);
+    const auto& info2 = Batch1::objects.at(1);
+    const auto& info3 = Batch2::objects.at(0);
+    const auto& info4 = Batch2::objects.at(1);
+
+    // add batch - whole batch dirty
+    AddTestInstance(uut, id1, info1);
+    AddTestInstance(uut, id2, info2);
+    uut.CommitPendingChanges();
+    {
+        auto actual = uut.BuildState();
+        EXPECT_FALSE(actual.instances.empty());
+        ASSERT_EQ(1, actual.dirtyRanges.size());
+        EXPECT_EQ(0, actual.dirtyRanges[0].offset);
+        EXPECT_EQ(2, actual.dirtyRanges[0].count);
+    }
+
+    // add subsequent batch batch - dirty from new batch to end
+    AddTestInstance(uut, id3, info3);
+    AddTestInstance(uut, id4, info4);
+    uut.CommitPendingChanges();
+    {
+        auto actual = uut.BuildState();
+        EXPECT_FALSE(actual.instances.empty());
+        ASSERT_EQ(1, actual.dirtyRanges.size());
+        EXPECT_EQ(2, actual.dirtyRanges[0].offset);
+        EXPECT_EQ(2, actual.dirtyRanges[0].count);
+    }
+
+    // no changes - not dirty
+    {
+        auto actual = uut.BuildState();
+        EXPECT_TRUE(actual.instances.empty());
+        EXPECT_TRUE(actual.dirtyRanges.empty());
+    }
+
+    // last item in batch changed - not dirty
+    RemoveTestInstance<Batch1>(uut, id2);
+    uut.CommitPendingChanges();
+    {
+        auto actual = uut.BuildState();
+        EXPECT_TRUE(actual.instances.empty());
+        EXPECT_TRUE(actual.dirtyRanges.empty());
+    }
+
+    // last batch changed - dirty from modified to end
+    RemoveTestInstance<Batch2>(uut, id3);
+    uut.CommitPendingChanges();
+    {
+        auto actual = uut.BuildState();
+        EXPECT_FALSE(actual.instances.empty());
+        ASSERT_EQ(1, actual.dirtyRanges.size());
+        EXPECT_EQ(2, actual.dirtyRanges[0].offset);
+        EXPECT_EQ(2, actual.dirtyRanges[0].count);
+    }
+
+    // multiple batches changed - dirty from leftmost batch to end
+    RemoveTestInstance<Batch1>(uut, id1);
+    RemoveTestInstance<Batch2>(uut, id4);
+    AddTestInstance(uut, id1, info1);
+    uut.CommitPendingChanges();
+    {
+        auto actual = uut.BuildState();
+        EXPECT_FALSE(actual.instances.empty());
+        ASSERT_EQ(1, actual.dirtyRanges.size());
+        EXPECT_EQ(0, actual.dirtyRanges[0].offset);
+        EXPECT_EQ(4, actual.dirtyRanges[0].count);
+    }
+
+    // after purge with item remaining - dirty from begin to end
+    uut.Purge();
+    {
+        auto actual = uut.BuildState();
+        EXPECT_FALSE(actual.instances.empty());
+        ASSERT_EQ(1, actual.dirtyRanges.size());
+        EXPECT_EQ(0, actual.dirtyRanges[0].offset);
+        EXPECT_EQ(1, actual.dirtyRanges[0].count);
+    }
+
+    // after purge all - not dirty
+    RemoveTestInstance<Batch1>(uut, id1);
+    uut.Purge();
+    {
+        auto actual = uut.BuildState();
+        EXPECT_TRUE(actual.instances.empty());
+        EXPECT_TRUE(actual.dirtyRanges.empty());
+    }
+}
+
+TEST(InstanceCacheTests, BuildBatches)
+{
+    auto uut = nc::graphics::InstanceCache{32, 100};
+    const auto id1 = 0;
+    const auto id2 = 1;
+    const auto id3 = 2;
+    const auto& info1 = Batch1::objects.at(0); // toon
+    const auto& info2 = Batch2::objects.at(0); // toon
+    const auto& info3 = Batch3::objects.at(0); // shader | toon | alpha
+    constexpr auto batchCount = g_allBatches.size();
+
+    // no batches - all passes empty
+    {
+        auto actual = uut.BuildBatches(g_allBatches);
+        EXPECT_EQ(batchCount, actual.size());
+        for (const auto& pass : actual)
+        {
+            EXPECT_TRUE(pass.empty());
+        }
+    }
+
+    // has batches - batches reported across all associated passes
+    AddTestInstance(uut, id1, info1);
+    AddTestInstance(uut, id2, info2);
+    AddTestInstance(uut, id3, info3);
+    uut.CommitPendingChanges();
+    {
+        auto actual = uut.BuildBatches(g_allBatches);
+        EXPECT_EQ(batchCount, actual.size());
+        EXPECT_EQ(1, actual.at(0).size()); // shadow
+        EXPECT_EQ(3, actual.at(1).size()); // toon
+        EXPECT_EQ(1, actual.at(2).size()); // alpha
+    }
+
+    // has empty batch - not reported in passes
+    RemoveTestInstance<Batch3>(uut, id3);
+    uut.CommitPendingChanges();
+    uut.CommitPendingChanges();
+    {
+        auto actual = uut.BuildBatches(g_allBatches);
+        EXPECT_EQ(batchCount, actual.size());
+        EXPECT_EQ(0, actual.at(0).size()); // shadow
+        EXPECT_EQ(2, actual.at(1).size()); // toon
+        EXPECT_EQ(0, actual.at(2).size()); // alpha
+    }
+}
+
+TEST(InstanceCacheTests, LargerInitialBatchSize)
+{
+    auto uut = nc::graphics::InstanceCache{32, 100};
+    const auto id1 = 0;
+    const auto id2 = 1;
+    const auto id3 = 2;
+    const auto& info1 = Batch1::objects.at(0);
+    const auto& info2 = Batch2::objects.at(0);
+    const auto& info3 = Batch3::objects.at(0);
+    AddTestInstance(uut, id1, info1);
+    AddTestInstance(uut, id2, info2);
+    AddTestInstance(uut, id3, info3);
+    uut.CommitPendingChanges();
+
+    EXPECT_EQ(300, uut.GetInstanceCountUpperBound());
+    EXPECT_EQ(3, uut.GetBatchCount());
+    VerifyInstance(uut, id1, 0, info1);
+    VerifyInstance(uut, id2, 100, info2);
+    VerifyInstance(uut, id3, 200, info3);
+    VerifyBatch<Batch1>(uut, 0, 1, 100);
+    VerifyBatch<Batch2>(uut, 100, 1, 100);
+    VerifyBatch<Batch3>(uut, 200, 1, 100);
+}


### PR DESCRIPTION
part of #808 

Adding `InstanceCache`, which manages state required for instancing `MeshRenderer`s. Just adding the type + tests for now because its a lot of code just for that.