### PR TITLE
Notify InstanceCache On MaterialPass Update

### DIFF
--- a/include/ncengine/graphics/MeshRenderer2.h
+++ b/include/ncengine/graphics/MeshRenderer2.h
@@ -63,7 +63,7 @@ class MeshRenderer2
         /** @name Material Functions */
         auto GetMaterial() const -> const MaterialInstance& { return m_material; }
         auto GetMaterial() -> MaterialInstance& { return m_material; }
-        void SetMaterial(const MaterialDesc& materialDesc) { m_material = MaterialInstance{materialDesc}; }
+        void SetMaterial(const MaterialDesc& materialDesc);
 
     private:
         friend class graphics::MeshRendererSubsystem;

--- a/source/ncengine/graphics2/MeshRenderer2.cpp
+++ b/source/ncengine/graphics2/MeshRenderer2.cpp
@@ -21,18 +21,30 @@ MeshRenderer2::MeshRenderer2(Entity self,
 
 void MeshRenderer2::SetMesh(const asset::MeshView& mesh)
 {
-    const auto passes = m_material.GetPasses();
     s_subsystem->SetInstanceMesh(
         m_self,
         m_transformDataHandle,
         m_material.GetHandle(),
-        passes,
-        passes,
+        m_material.GetPasses(),
         m_meshId,
         mesh
     );
 
     m_meshId = mesh.id;
+}
+
+void MeshRenderer2::SetMaterial(const MaterialDesc& materialDesc)
+{
+    const auto currentPasses = m_material.GetPasses();
+    m_material = MaterialInstance{materialDesc};
+    s_subsystem->SetInstanceMaterial(
+        m_self,
+        m_transformDataHandle,
+        m_material.GetHandle(),
+        currentPasses,
+        m_material.GetPasses(),
+        m_meshId
+    );
 }
 
 void MeshRenderer2::Release() noexcept

--- a/source/ncengine/graphics2/frontend/subsystem/MeshRendererSubsystem.cpp
+++ b/source/ncengine/graphics2/frontend/subsystem/MeshRendererSubsystem.cpp
@@ -4,6 +4,7 @@
 #include "ncengine/ecs/Transform.h"
 #include "ncengine/graphics/MeshRenderer2.h"
 #include "ncengine/graphics/GraphicsUtility.h"
+#include "asset/AssetService.h"
 
 #include "ncengine/debug/Profile.h"
 
@@ -45,17 +46,39 @@ void MeshRendererSubsystem::RemoveInstance(Entity entity,
 void MeshRendererSubsystem::SetInstanceMesh(Entity entity,
                                             uint32_t transformIndex,
                                             MaterialInstanceHandle materialIndex,
-                                            MaterialPasses oldPasses,
-                                            MaterialPasses newPasses,
+                                            MaterialPasses passes,
                                             uint64_t oldMeshId,
                                             const asset::MeshView& newMesh)
 {
     m_instanceCache.GetStagingArea().UpdateInstance(
         entity.Index(),
-        oldPasses,
-        newPasses,
+        passes,
+        passes,
         oldMeshId,
         newMesh,
+        InstanceData{
+            transformIndex,
+            materialIndex
+        }
+    );
+}
+
+void MeshRendererSubsystem::SetInstanceMaterial(Entity entity,
+                                                uint32_t transformIndex,
+                                                MaterialInstanceHandle materialIndex,
+                                                MaterialPasses oldPasses,
+                                                MaterialPasses newPasses,
+                                                uint64_t meshId)
+{
+    const auto meshService = asset::AssetService<asset::MeshView>::Get();
+    const auto meshPath = std::string{meshService->GetPath(meshId)};
+    const auto meshView = meshService->Acquire(meshPath);
+    m_instanceCache.GetStagingArea().UpdateInstance(
+        entity.Index(),
+        oldPasses,
+        newPasses,
+        meshId,
+        meshView,
         InstanceData{
             transformIndex,
             materialIndex

--- a/source/ncengine/graphics2/frontend/subsystem/MeshRendererSubsystem.h
+++ b/source/ncengine/graphics2/frontend/subsystem/MeshRendererSubsystem.h
@@ -33,10 +33,16 @@ class MeshRendererSubsystem
         void SetInstanceMesh(Entity entity,
                              uint32_t transformIndex,
                              MaterialInstanceHandle materialIndex,
-                             MaterialPasses oldPasses,
-                             MaterialPasses newPasses,
+                             MaterialPasses passes,
                              uint64_t oldMeshId,
                              const asset::MeshView& newMesh);
+
+        void SetInstanceMaterial(Entity entity,
+                                 uint32_t transformIndex,
+                                 MaterialInstanceHandle materialIndex,
+                                 MaterialPasses oldPasses,
+                                 MaterialPasses newPasses,
+                                 uint64_t meshId);
 
         auto BuildState(ecs::ExplicitEcs<MeshRenderer2, Transform> ecs) -> MeshRendererRenderState;
         void OnBeforeSceneLoad();

--- a/test/ncengine/graphics2/MeshRendererSubsystem_tests.cpp
+++ b/test/ncengine/graphics2/MeshRendererSubsystem_tests.cpp
@@ -1,4 +1,5 @@
 #include "gtest/gtest.h"
+#include "../AssetServiceStub.h"
 #include "../EcsFixture.inl"
 #include "ncengine/Events.h"
 #include "ncengine/ecs/Entity.h"
@@ -11,10 +12,6 @@
 #include <array>
 #include <ranges>
 
-constexpr auto g_materialPasses = std::array{
-    nc::MaterialPass::Toon
-};
-
 const auto g_materialDesc = nc::MaterialDesc{
     .passes = nc::MaterialPass::Toon
 };
@@ -22,6 +19,8 @@ const auto g_materialDesc = nc::MaterialDesc{
 constexpr auto g_meshView = nc::asset::MeshView{
     .id = 42
 };
+
+DEFINE_ASSET_SERVICE_STUB(meshAssetManager, nc::asset::AssetType::Mesh, nc::asset::MeshView, std::string);
 
 namespace nc
 {
@@ -159,6 +158,21 @@ TEST_F(MeshRendererSubsystemTest, MeshRendererUpdateMesh_PatchesTrackedState)
     EXPECT_EQ(1, actualBatch1.instanceCount);
     EXPECT_EQ(2, actualBatch2.firstInstance);
     EXPECT_EQ(1, actualBatch2.instanceCount);
+
+    registry.Clear();
+}
+
+TEST_F(MeshRendererSubsystemTest, MeshRendererUpdateMaterial_Succeeds)
+{
+    auto world = GetTestWorld();
+    auto& registry = GetTestComponentRegistry();
+    const auto entity = AddEntity(world);
+    registry.CommitPendingChanges();
+    uut.BuildState(world); // discard - just updating internal tracking
+
+    // Only 1 pass is implemented currently, so we can't actually assign new passes/move to a new batch.
+    // Eventually, we should make this test more interesting.
+    EXPECT_NO_THROW(world.Get<nc::MeshRenderer2>(entity).SetMaterial(g_materialDesc));
 
     registry.Clear();
 }


### PR DESCRIPTION
resolves #809 

`InstanceCache` needs to know when a new `MaterialInstance` is assigned to a `MeshRenderer` so it can update the index in the instance buffer. I could have done this in the initial PR - thought there was more to it for some reason.