### PR TITLE
Add Batch Size Hint to Config

### DIFF
--- a/include/ncengine/config/Config.h
+++ b/include/ncengine/config/Config.h
@@ -76,6 +76,7 @@ struct GraphicsSettings
     unsigned targetFPS = 60;             ///< target frame rate
     bool useShadows = true;              ///< enable shadow mapping and shadow rendering
     unsigned antialiasing = 8u;          ///< the number of samples for MSAA
+    unsigned initialBatchSize = 1u;      ///< default instance capacity for render batch allocation (size hint - can grow beyond this)
     bool useValidationLayers = false;    ///< turn on validation layers in debug builds
 };
 

--- a/sample/config.ini
+++ b/sample/config.ini
@@ -49,6 +49,7 @@ screen_height=900
 target_fps=60
 use_shadows=1
 antialiasing=8
+initial_batch_size=1
 use_validation_layers=0
 [audio_settings]
 audio_enabled=1

--- a/source/ncengine/config/Config.cpp
+++ b/source/ncengine/config/Config.cpp
@@ -72,6 +72,7 @@ constexpr auto ScreenHeightKey = "screen_height"sv;
 constexpr auto TargetFpsKey = "target_fps"sv;
 constexpr auto UseShadowsKey = "use_shadows"sv; /** @todo: Make this a property of the material */
 constexpr auto AntialiasingKey = "antialiasing"sv;
+constexpr auto InitialBatchSize = "initial_batch_size"sv;
 constexpr auto UseValidationLayersKey = "use_validation_layers"sv;
 
 // audio
@@ -229,6 +230,7 @@ auto BuildFromConfigMap(const std::unordered_map<std::string, std::string>& kvPa
         ParseValueIfExists(out.targetFPS, TargetFpsKey, kvPairs);
         ParseValueIfExists(out.useShadows, UseShadowsKey, kvPairs);
         ParseValueIfExists(out.antialiasing, AntialiasingKey, kvPairs);
+        ParseValueIfExists(out.initialBatchSize, InitialBatchSize, kvPairs);
         ParseValueIfExists(out.useValidationLayers, UseValidationLayersKey, kvPairs);
     }
     else if constexpr (std::same_as<Struct_t, nc::config::PhysicsSettings>)
@@ -393,6 +395,7 @@ void Write(std::ostream& stream, const Config& config, bool writeSections)
     ::WriteKVPair(stream, TargetFpsKey, config.graphicsSettings.targetFPS);
     ::WriteKVPair(stream, UseShadowsKey, config.graphicsSettings.useShadows);
     ::WriteKVPair(stream, AntialiasingKey, config.graphicsSettings.antialiasing);
+    ::WriteKVPair(stream, InitialBatchSize, config.graphicsSettings.initialBatchSize);
     ::WriteKVPair(stream, UseValidationLayersKey, config.graphicsSettings.useValidationLayers);
 
     if (writeSections) stream << "[audio_settings]\n";

--- a/source/ncengine/config/default_config.ini
+++ b/source/ncengine/config/default_config.ini
@@ -46,6 +46,7 @@ screen_height=1000
 target_fps=60
 use_shadows=1
 antialiasing=8
+initial_batch_size=1
 use_validation_layers=0
 [audio_settings]
 audio_enabled=1

--- a/source/ncengine/graphics2/NcGraphicsImpl2.cpp
+++ b/source/ncengine/graphics2/NcGraphicsImpl2.cpp
@@ -177,6 +177,7 @@ NcGraphicsImpl2::NcGraphicsImpl2(const config::GraphicsSettings& graphicsSetting
             modules,
             events,
             memorySettings.maxRenderers,
+            graphicsSettings.initialBatchSize,
             modules.Get<asset::NcAsset>()->OnTextureUpdate(),
             modules.Get<asset::NcAsset>()->OnMeshUpdate()
           },

--- a/source/ncengine/graphics2/frontend/GraphicsFrontend.h
+++ b/source/ncengine/graphics2/frontend/GraphicsFrontend.h
@@ -24,13 +24,14 @@ class GraphicsFrontend
                          ModuleProvider modules,
                          SystemEvents& events,
                          uint32_t maxRenderers,
+                         uint32_t initialBatchSize,
                          Signal<const asset::TextureUpdateEventData&>& onTextureEvent,
                          Signal<const asset::MeshUpdateEventData&>& onMeshEvent)
             : m_assetDispatch{context, device, textureBuffer, meshBuffer, onTextureEvent, onMeshEvent},
               m_materialRegistry{maxRenderers},
               m_uiSystem{world, modules, events},
               m_cameraSystem{},
-              m_meshRendererSystem{events, maxRenderers}
+              m_meshRendererSystem{events, maxRenderers, initialBatchSize}
         {
         }
 

--- a/source/ncengine/graphics2/frontend/subsystem/MeshRendererSubsystem.cpp
+++ b/source/ncengine/graphics2/frontend/subsystem/MeshRendererSubsystem.cpp
@@ -9,9 +9,9 @@
 
 namespace nc::graphics
 {
-MeshRendererSubsystem::MeshRendererSubsystem(SystemEvents& events, uint32_t maxMeshRenderers)
+MeshRendererSubsystem::MeshRendererSubsystem(SystemEvents& events, uint32_t maxMeshRenderers, uint32_t initialBatchSize)
     : m_transformCache{maxMeshRenderers},
-      m_instanceCache{maxMeshRenderers},
+      m_instanceCache{maxMeshRenderers, initialBatchSize},
       m_rebuildStaticsConnection{events.rebuildStatics.Connect(this, &MeshRendererSubsystem::OnRebuildStatics)}
 {
     MeshRenderer2::s_subsystem = this;

--- a/source/ncengine/graphics2/frontend/subsystem/MeshRendererSubsystem.h
+++ b/source/ncengine/graphics2/frontend/subsystem/MeshRendererSubsystem.h
@@ -18,7 +18,7 @@ namespace graphics
 class MeshRendererSubsystem
 {
     public:
-        explicit MeshRendererSubsystem(SystemEvents& events, uint32_t maxMeshRenderers);
+        explicit MeshRendererSubsystem(SystemEvents& events, uint32_t maxMeshRenderers, uint32_t initialBatchSize);
 
         auto AddInstance(Entity entity,
                          MaterialInstanceHandle material,

--- a/test/ncengine/config/collateral/config.ini
+++ b/test/ncengine/config/collateral/config.ini
@@ -60,6 +60,7 @@ launch_fullscreen=0
 target_fps=60
 use_shadows=1
 antialiasing=8
+initial_batch_size=1
 use_validation_layers=0
 [audio_settings]
 audio_enabled=1

--- a/test/ncengine/graphics2/MeshRendererSubsystem_tests.cpp
+++ b/test/ncengine/graphics2/MeshRendererSubsystem_tests.cpp
@@ -53,7 +53,7 @@ class MeshRendererSubsystemTest : public testing::Test,
 
         MeshRendererSubsystemTest()
             : EcsFixture{MaxEntities},
-              uut{systemEvents, MaxEntities}
+              uut{systemEvents, MaxEntities, 1}
         {
             GetTestComponentRegistry().RegisterType<nc::MeshRenderer2>(MaxEntities);
         }

--- a/test/smoke_test/smoke_test_config.ini
+++ b/test/smoke_test/smoke_test_config.ini
@@ -47,6 +47,7 @@ screen_height=500
 target_fps=60
 use_shadows=1
 antialiasing=8
+initial_batch_size=1
 use_validation_layers=1
 [audio_settings]
 audio_enabled=1


### PR DESCRIPTION
`InstanceCache` reserves a block in the GPU buffer when creating new batches, defaulting to a capacity of 1. Larger capacities make sense with low batch count + high object count to reduce (re)allocations, and lower capacities may be wanted when objects are spread out across many batches/meshes. Leaving it as an exercise for the reader and adding the option to the config.