### PR TITLE
Add BoneCache

### DIFF
--- a/source/ncengine/graphics2/ShaderTypes.h
+++ b/source/ncengine/graphics2/ShaderTypes.h
@@ -64,6 +64,12 @@ struct MaterialData
     float outlineWidth = 1.0f;
 };
 
+// Object model for skeletal animations (type: StructuredBuffer element type).
+struct BoneData
+{
+    DirectX::XMMATRIX animatedBoneMatrix = DirectX::XMMatrixIdentity();
+};
+
 // Object model for DirectionalLights (type: StructuredBuffer element type).
 // Not targeting shadows for directional lights at the moment.
 // 32 bytes with a 16-byte alignment.

--- a/source/ncengine/graphics2/frontend/subsystem/BoneCache.cpp
+++ b/source/ncengine/graphics2/frontend/subsystem/BoneCache.cpp
@@ -9,8 +9,8 @@ auto BoneCacheStaging::Allocate(uint32_t count) -> BoneCacheHandle
 {
     const auto slot = std::ranges::find_if(
         m_freeList,
-        [count](const auto& slot) {
-            return count <= slot.capacity;
+        [count](const auto& freeSlot) {
+            return count <= freeSlot.capacity;
         }
     );
 

--- a/source/ncengine/graphics2/frontend/subsystem/BoneCache.cpp
+++ b/source/ncengine/graphics2/frontend/subsystem/BoneCache.cpp
@@ -1,0 +1,115 @@
+#include "BoneCache.h"
+
+#include <cstring>
+#include <ranges>
+
+namespace nc::graphics
+{
+auto BoneCacheStaging::Allocate(uint32_t count) -> BoneCacheHandle
+{
+    const auto slot = std::ranges::find_if(
+        m_freeList,
+        [count](const auto& slot) {
+            return count <= slot.capacity;
+        }
+    );
+
+    if (slot != m_freeList.end())
+    {
+        const auto handle = slot->index;
+        if (count < slot->capacity)
+        {
+            slot->index += count;
+            slot->capacity -= count;
+        }
+        else
+        {
+            *slot = m_freeList.back();
+            m_freeList.pop_back();
+        }
+
+        m_allocations.emplace(handle, count);
+        return handle;
+    }
+
+    NC_ASSERT(m_nextIndex + count < m_maxIndex, "BoneCache capacity exceeded");
+    const auto handle = m_nextIndex;
+    m_nextIndex += count;
+    m_allocations.emplace(handle, count);
+    return handle;
+}
+
+void BoneCacheStaging::Free(BoneCacheHandle handle)
+{
+    const auto capacity = m_allocations.at(handle);
+    m_allocations.erase(handle);
+    const auto pos = std::ranges::lower_bound(
+        m_freeList,
+        handle,
+        std::ranges::less{},
+        &FreeSlot::index
+    );
+
+    // if a contigous range can be made with preceeding slot, just add our capacity to that slot
+    if (pos != m_freeList.begin())
+    {
+        const auto left = pos - 1;
+        const auto leftEnd = left->index + left->capacity;
+        if (leftEnd == handle)
+        {
+            left->capacity += capacity;
+            if (pos != m_freeList.end())
+            {
+                // if new capacity makes contigous range with the next slot, combine them
+                if (left->index + left->capacity == pos->index)
+                {
+                    left->capacity += pos->capacity;
+                    m_freeList.erase(pos);
+                }
+            }
+
+            return;
+        }
+    }
+
+    // same check, but on the following slot
+    if (pos != m_freeList.end())
+    {
+        const auto freedEnd = handle + capacity;
+        if (pos->index == freedEnd)
+        {
+            pos->index = handle;
+            pos->capacity += capacity;
+            return;
+        }
+    }
+
+    // can't be combined with an existing slot so make a new one
+    m_freeList.emplace(pos, handle, capacity);
+}
+
+void BoneCache::UpdateRegion(BoneCacheHandle handle, std::span<const BoneData> data)
+{
+    NC_ASSERT(m_data.size() >= handle + data.size(), "BoneCache access out of bounds");
+    std::memcpy(m_data.data() + handle, data.data(), sizeof(BoneData) * data.size());
+}
+
+void BoneCache::CommitPendingChanges()
+{
+    const auto capacity = m_staging.GetCapacity();
+    if (capacity > m_data.size())
+    {
+        m_data.resize(capacity);
+    }
+}
+
+auto BoneCache::BuildUpdateInfo() -> BufferUpdateInfo<BoneData>
+{
+    return m_data.empty()
+        ? BufferUpdateInfo<BoneData>{}
+        : BufferUpdateInfo<BoneData>{
+            .instances = m_data,
+            .dirtyRanges = { {0, static_cast<uint32_t>(m_data.size())} }
+        };
+}
+} // namespace nc::graphics

--- a/source/ncengine/graphics2/frontend/subsystem/BoneCache.h
+++ b/source/ncengine/graphics2/frontend/subsystem/BoneCache.h
@@ -1,0 +1,84 @@
+#pragma once
+
+#include "graphics2/ShaderTypes.h"
+
+#include "ncengine/utility/SparseMap.h"
+
+#include <span>
+#include <vector>
+
+namespace nc::graphics
+{
+// Identifier for a range of bones in the BoneCache.
+using BoneCacheHandle = uint32_t;
+
+// BoneCache interface for allocating and freeing bone ranges. Events originating from game logic/API should only be
+// routed here to avoid race conditions with the actual buffer.
+class BoneCacheStaging
+{
+    struct FreeSlot
+    {
+        uint32_t index;
+        uint32_t capacity;
+    };
+
+    public:
+        explicit BoneCacheStaging(uint32_t maxBones)
+            : m_allocations{0u, maxBones},
+              m_maxIndex{maxBones}
+        {
+        }
+
+        /// API-Facing Functions
+        auto Allocate(uint32_t count) -> BoneCacheHandle;
+        void Free(BoneCacheHandle handle);
+
+        // Functions for Use by BoneCache
+        auto GetCapacity() const -> size_t { return m_nextIndex; }
+
+        // Functions for Testing
+        auto GetCapacity(BoneCacheHandle handle) { return m_allocations.at(handle); }
+        auto GetFreeList() const -> const std::vector<FreeSlot>& { return m_freeList; }
+
+    private:
+        sparse_map<uint32_t> m_allocations; // offset -> capacity
+        std::vector<FreeSlot> m_freeList;
+        uint32_t m_nextIndex = 0;
+        uint32_t m_maxIndex;
+};
+
+// CPU-side buffer for animated bone matrices. A region is allocated from the buffer per SkinnedMesh to store each of
+// its bones contiguously. Allocation returns a handle, indicating an offset where that mesh's bones may be written.
+//
+// Game logic and skeletal animation calculations may use this buffer concurrently. Allocations must be committed via
+// CommitPendingChanges() at a synchronization point when there is no other access to the buffer.
+class BoneCache
+{
+    public:
+        explicit BoneCache(uint32_t maxBones)
+            : m_staging{maxBones}
+        {
+        }
+
+        // Get an interface for allocating/freeing ranges within the buffer.
+        // IMPORTANT: All API-level events shall only access the staging area.
+        auto GetStagingArea() -> BoneCacheStaging& { return m_staging; }
+
+        // Get the total buffer size.
+        auto GetCapacity() const -> size_t { return m_data.size(); }
+
+        // Write bone data to the region owned by the handle.
+        void UpdateRegion(BoneCacheHandle handle, std::span<const BoneData> data);
+
+        // Commit allocations to the buffer.
+        // IMPORTANT: Neither the staging area nor buffer may be accessed while this in progress.
+        void CommitPendingChanges();
+
+        // Build info specifying modified buffer ranges
+        auto BuildUpdateInfo() -> BufferUpdateInfo<BoneData>;
+
+    private:
+        std::vector<BoneData> m_data;
+        BoneCacheStaging m_staging;
+};
+} // namespace nc::graphics

--- a/source/ncengine/graphics2/frontend/subsystem/CMakeLists.txt
+++ b/source/ncengine/graphics2/frontend/subsystem/CMakeLists.txt
@@ -1,5 +1,6 @@
 target_sources(${NC_ENGINE_LIB}
     PRIVATE
+        BoneCache.cpp
         CameraSubsystem.cpp
         LightSubsystem.cpp
         MaterialRegistry.cpp

--- a/test/ncengine/graphics2/BoneCache_tests.cpp
+++ b/test/ncengine/graphics2/BoneCache_tests.cpp
@@ -1,0 +1,192 @@
+#include "gtest/gtest.h"
+#include "graphics2/frontend/subsystem/BoneCache.h"
+#include "ncutility/NcError.h"
+
+#include <array>
+#include <cstring>
+
+TEST(BoneCacheTest, Allocate_consecutiveCalls_allocateContiguously)
+{
+    auto uut = nc::graphics::BoneCache{10};
+    auto& staging = uut.GetStagingArea();
+
+    const auto first = staging.Allocate(2);
+    const auto second = staging.Allocate(3);
+    EXPECT_EQ(0, first);
+    EXPECT_EQ(2, second);
+}
+
+TEST(BoneCacheTest, Allocate_availableSlotInFreeList_allocatesFromList)
+{
+    auto uut = nc::graphics::BoneCache{10};
+    auto& staging = uut.GetStagingArea();
+    staging.Free(staging.Allocate(3));
+
+    const auto handle = staging.Allocate(2);
+    EXPECT_EQ(0, handle);
+    const auto& freeList = staging.GetFreeList();
+    ASSERT_EQ(1, freeList.size());
+    EXPECT_EQ(2, freeList.at(0).index);
+    EXPECT_EQ(1, freeList.at(0).capacity);
+}
+
+TEST(BoneCacheTest, Allocate_largerThanFreeSlot_allocatesFromEnd)
+{
+    auto uut = nc::graphics::BoneCache{10};
+    auto& staging = uut.GetStagingArea();
+    staging.Free(staging.Allocate(3));
+
+    const auto handle = staging.Allocate(4);
+    EXPECT_EQ(3, handle);
+    const auto& freeList = staging.GetFreeList();
+    ASSERT_EQ(1, freeList.size());
+    EXPECT_EQ(0, freeList.at(0).index);
+    EXPECT_EQ(3, freeList.at(0).capacity);
+}
+
+TEST(BoneCacheTest, Allocate_exceedsCapacity_throws)
+{
+    auto uut = nc::graphics::BoneCache{10};
+    auto& staging = uut.GetStagingArea();
+    EXPECT_THROW(staging.Allocate(11), nc::NcError);
+}
+
+TEST(BoneCacheTest, Free_mergesFreeListLeft)
+{
+    auto uut = nc::graphics::BoneCache{30};
+    auto& staging = uut.GetStagingArea();
+
+    const auto first = staging.Allocate(2);
+    const auto second = staging.Allocate(2);
+    staging.Free(first);
+    staging.Free(second);
+    auto& freeList = staging.GetFreeList();
+    ASSERT_EQ(1, freeList.size());
+    EXPECT_EQ(0, freeList.at(0).index);
+    EXPECT_EQ(4, freeList.at(0).capacity);
+}
+
+TEST(BoneCacheTest, Free_mergesFreeListRight)
+{
+    auto uut = nc::graphics::BoneCache{30};
+    auto& staging = uut.GetStagingArea();
+
+    const auto first = staging.Allocate(2);
+    const auto second = staging.Allocate(2);
+    staging.Free(second);
+    staging.Free(first);
+    auto& freeList = staging.GetFreeList();
+    ASSERT_EQ(1, freeList.size());
+    EXPECT_EQ(0, freeList.at(0).index);
+    EXPECT_EQ(4, freeList.at(0).capacity);
+}
+
+TEST(BoneCacheTest, Free_mergesFreeListLeftAndRight)
+{
+    auto uut = nc::graphics::BoneCache{30};
+    auto& staging = uut.GetStagingArea();
+
+    const auto first = staging.Allocate(2);
+    const auto second = staging.Allocate(2);
+    const auto third = staging.Allocate(2);
+    staging.Free(third);
+    staging.Free(first);
+
+    {
+        auto& freeList = staging.GetFreeList();
+        ASSERT_EQ(2, freeList.size());
+    }
+
+    staging.Free(second);
+    auto& freeList = staging.GetFreeList();
+    ASSERT_EQ(1, freeList.size());
+    EXPECT_EQ(0, freeList.at(0).index);
+    EXPECT_EQ(6, freeList.at(0).capacity);
+}
+
+TEST(BoneCacheTest, UpdateRegion_validCall_writesData)
+{
+    auto uut = nc::graphics::BoneCache{30};
+    auto& staging = uut.GetStagingArea();
+    const auto handle = staging.Allocate(3);
+    uut.CommitPendingChanges();
+
+    const auto matrix = DirectX::XMMatrixScaling(1.0f, 2.0f, 3.0f);
+    const auto data = nc::graphics::BoneData{matrix};
+    const auto range = std::array{data, data, data};
+    uut.UpdateRegion(handle, range);
+
+    const auto [instances, _] = uut.BuildUpdateInfo();
+    ASSERT_EQ(range.size(), instances.size());
+    const auto sizeBytes = sizeof(nc::graphics::BoneData) * range.size();
+    EXPECT_EQ(0, std::memcmp(range.data(), instances.data(), sizeBytes));
+}
+
+TEST(BoneCacheTest, UpdateRegion_outOfBounds_throws)
+{
+    auto uut = nc::graphics::BoneCache{30};
+    auto& staging = uut.GetStagingArea();
+    const auto handle = staging.Allocate(2);
+    uut.CommitPendingChanges();
+
+    const auto data = nc::graphics::BoneData{};
+    const auto range = std::array{data, data, data};
+    EXPECT_THROW(uut.UpdateRegion(handle, range), nc::NcError);
+}
+
+TEST(BoneCacheTest, CommitPendingChanges_newAllocationsExceedCapacity_resizes)
+{
+    auto uut = nc::graphics::BoneCache{30};
+    auto& staging = uut.GetStagingArea();
+    ASSERT_EQ(0, uut.GetCapacity());
+
+    staging.Allocate(3);
+    uut.CommitPendingChanges();
+    EXPECT_EQ(3, uut.GetCapacity());
+
+    staging.Allocate(1);
+    uut.CommitPendingChanges();
+    EXPECT_EQ(4, uut.GetCapacity());
+}
+
+TEST(BoneCacheTest, CommitPendingChanges_newAllocationsReuseSlots_preservesSize)
+{
+    auto uut = nc::graphics::BoneCache{30};
+    auto& staging = uut.GetStagingArea();
+
+    const auto first = staging.Allocate(5);
+    const auto second = staging.Allocate(5);
+    uut.CommitPendingChanges();
+    ASSERT_EQ(10, uut.GetCapacity());
+
+    staging.Free(first);
+    staging.Free(second);
+    staging.Allocate(1);
+    staging.Allocate(7);
+    staging.Allocate(2);
+    uut.CommitPendingChanges();
+    EXPECT_EQ(10, uut.GetCapacity());
+}
+
+TEST(BoneCacheTest, BuildUpdateInfo_empty_returnsDefaultInfo)
+{
+    auto uut = nc::graphics::BoneCache{30};
+    const auto actual = uut.BuildUpdateInfo();
+    EXPECT_TRUE(actual.instances.empty());
+    EXPECT_TRUE(actual.dirtyRanges.empty());
+}
+
+TEST(BoneCacheTest, BuildUpdateInfo_nonEmpty_returnsWholeBuffer)
+{
+    auto uut = nc::graphics::BoneCache{30};
+    auto& staging = uut.GetStagingArea();
+    staging.Allocate(3);
+    staging.Allocate(2);
+    uut.CommitPendingChanges();
+
+    const auto actual = uut.BuildUpdateInfo();
+    EXPECT_EQ(5, actual.instances.size());
+    EXPECT_EQ(1, actual.dirtyRanges.size());
+    EXPECT_EQ(0, actual.dirtyRanges.at(0).offset);
+    EXPECT_EQ(5, actual.dirtyRanges.at(0).count);
+}

--- a/test/ncengine/graphics2/CMakeLists.txt
+++ b/test/ncengine/graphics2/CMakeLists.txt
@@ -1,3 +1,28 @@
+### BoneCache Tests ###
+add_executable(BoneCache_tests
+    BoneCache_tests.cpp
+    ${NC_SOURCE_DIR}/graphics2/frontend/subsystem/BoneCache.cpp
+)
+
+target_include_directories(BoneCache_tests
+    PRIVATE
+        ${NC_INCLUDE_DIR}
+        ${NC_SOURCE_DIR}
+)
+
+target_compile_options(BoneCache_tests
+    PUBLIC
+        ${NC_COMPILER_FLAGS}
+)
+
+target_link_libraries(BoneCache_tests
+    PRIVATE
+        gtest_main
+        NcMath
+)
+
+add_test(BoneCache_tests BoneCache_tests)
+
 ### CameraSubsystem Tests ###
 add_executable(CameraSubsystem_tests
     CameraSubsystem_tests.cpp


### PR DESCRIPTION
Reverted back to draft - might want to tweak some things.

Precursor to skeletal animation migration. We need a way to manage offsets/counts in the animated bone buffer. These have to be stable so the `InstanceCache` for `SkinnedMesh`es doesn't have to get thrashed every frame. Enter the `BoneCache`.