### PR TITLE
Pass Renaming

### DIFF
--- a/include/ncengine/graphics/GraphicsUtility.h
+++ b/include/ncengine/graphics/GraphicsUtility.h
@@ -16,23 +16,23 @@ namespace nc
 auto GetMaterialPassNames() -> std::span<const std::string_view>;
 
 /** @brief Returns a view of all material pass flags, ordered by ascending flag value. */
-auto GetMaterialPassFlags() -> std::span<const MaterialPass::type>;
+auto GetMaterialPassFlags() -> std::span<const MaterialPassFlag::type>;
 
 /**
  * @brief Returns a view of all currently implemented material pass flags.
  * @todo 794 Temporary solution while passes are being implemented. Add passes as they become available.
  *           Eventually, usage of this should switch to GetMaterialPassFlags().
  */
-auto GetImplementedMaterialPassFlags() -> std::span<const MaterialPass::type>;
+auto GetImplementedMaterialPassFlags() -> std::span<const MaterialPassFlag::type>;
 
 /** @brief Returns a view of all post process pass names, ordered by ascending flag value. */
 auto GetPostProcessPassNames() -> std::span<const std::string_view>;
 
 /** @brief Returns a view of all post process pass flags, ordered by ascending flag value. */
-auto GetPostProcessPassFlags() -> std::span<const PostProcessPass::type>;
+auto GetPostProcessPassFlags() -> std::span<const PostProcessPassFlag::type>;
 
 /** @brief Returns the name of a post process pass. */
-auto GetPostProcessPassName(PostProcessPass::type pass) -> std::string_view;
+auto GetPostProcessPassName(PostProcessPassFlag::type pass) -> std::string_view;
 
 /** @brief Returns a view of all post process effect names, ordered by ascending flag value. */
 auto GetPostProcessEffectNames() -> std::span<const std::string_view>;
@@ -41,8 +41,8 @@ auto GetPostProcessEffectNames() -> std::span<const std::string_view>;
 auto GetPostProcessEffectIds() -> std::span<const PostProcessEffectId>;
 
 /** @brief Returns a view of the post process passes used by an effect, ordered by ascending flag value. */
-auto GetPostProcessEffectPassFlags(PostProcessEffectId effectId) -> std::span<const PostProcessPass::type>;
+auto GetPostProcessEffectPassFlags(PostProcessEffectId effectId) -> std::span<const PostProcessPassFlag::type>;
 
 /** @brief Returns the combined post process pass flags used by an effect. */
-auto GetCombinedPostProcessEffectPassFlags(PostProcessEffectId effectId) -> PostProcessEffectPasses;
+auto GetCombinedPostProcessEffectPassFlags(PostProcessEffectId effectId) -> PostProcessEffectPassFlags;
 } // namespace nc

--- a/include/ncengine/graphics/Material.h
+++ b/include/ncengine/graphics/Material.h
@@ -24,7 +24,7 @@ using MaterialInstanceHandle = uint32_t;
 constexpr auto NullMaterialInstanceHandle = std::numeric_limits<MaterialInstanceHandle>::max();
 
 /** @brief Material pass flags. */
-struct MaterialPass
+struct MaterialPassFlag
 {
     using type = uint64_t;
 
@@ -33,10 +33,10 @@ struct MaterialPass
 };
 
 /** @brief Set of flags indicating a MaterialInstance's enabled passes. */
-using MaterialPasses = MaterialPass::type;
+using MaterialPassFlags = MaterialPassFlag::type;
 
 /** @brief Default passes for a toon material. */
-constexpr auto ShadowedToonMaterial = MaterialPass::Shadow | MaterialPass::Toon;
+constexpr auto ShadowedToonMaterial = MaterialPassFlag::Shadow | MaterialPassFlag::Toon;
 
 /** @brief Properties of a MaterialInstance passed to shaders. */
 struct MaterialProperties
@@ -53,7 +53,7 @@ struct MaterialProperties
 struct MaterialDesc
 {
     std::string name = "DefaultMaterial";
-    MaterialPasses passes = ShadowedToonMaterial;
+    MaterialPassFlags passes = ShadowedToonMaterial;
     MaterialProperties properties = MaterialProperties{};
 };
 
@@ -77,7 +77,7 @@ class MaterialInstance
         void SetName(std::string_view name);
 
         /** @name MaterialPass Functions */
-        auto GetPasses() const -> MaterialPasses;
+        auto GetPasses() const -> MaterialPassFlags;
 
         /** @name MaterialProperties Functions */
         auto GetProperties() const -> const MaterialProperties&;

--- a/include/ncengine/graphics/NcGraphics.h
+++ b/include/ncengine/graphics/NcGraphics.h
@@ -100,11 +100,11 @@ struct NcGraphics : public Module
 
     /** @brief Get the pass properties for a post process effect. */
     virtual auto GetPostProcessEffectProperties(PostProcessEffectId effectId,
-                                                PostProcessPass::type pass) const -> const PostProcessPassProperties& = 0;
+                                                PostProcessPassFlag::type pass) const -> const PostProcessPassProperties& = 0;
 
     /** @brief Set the pass properties for a post process effect. */
     virtual void SetPostProcessEffectProperties(PostProcessEffectId effectId,
-                                                PostProcessPass::type pass,
+                                                PostProcessPassFlag::type pass,
                                                 const PostProcessPassProperties& properties) = 0;
 };
 

--- a/include/ncengine/graphics/PostProcess.h
+++ b/include/ncengine/graphics/PostProcess.h
@@ -12,7 +12,7 @@
 namespace nc
 {
 /** @brief Post process pass flags */
-struct PostProcessPass
+struct PostProcessPassFlag
 {
     using type = uint64_t;
 
@@ -27,7 +27,7 @@ struct PostProcessPass
 using PostProcessEffectId = uint32_t;
 
 /** @brief Set of flags indicating the passes used by a post process effect. */
-using PostProcessEffectPasses = PostProcessPass::type;
+using PostProcessEffectPassFlags = PostProcessPassFlag::type;
 
 /** @brief Null identifier for a post process effect. */
 constexpr auto NullPostProcessEffectId = std::numeric_limits<PostProcessEffectId>::max();
@@ -36,10 +36,10 @@ constexpr auto NullPostProcessEffectId = std::numeric_limits<PostProcessEffectId
 constexpr auto MoebiusEffectId = PostProcessEffectId{0};
 
 /** @brief Pass flags for the moebius post process effect. */
-constexpr auto MoebiusEffectPasses = PostProcessPass::Alpha   |
-                                     PostProcessPass::Depth   |
-                                     PostProcessPass::Normals |
-                                     PostProcessPass::Outline;
+constexpr auto MoebiusEffectPassFlags = PostProcessPassFlag::Alpha   |
+                                     PostProcessPassFlag::Depth   |
+                                     PostProcessPassFlag::Normals |
+                                     PostProcessPassFlag::Outline;
 
 /** @brief Post process property type representing an empty or uninitialized state. */
 struct EmptyPassProperties {};
@@ -56,8 +56,8 @@ using PostProcessPassProperties = std::variant<EmptyPassProperties,
                                                OutlinePassProperties>;
 
 /** @brief Returns if a post process pass has a property type. */
-auto PassHasProperties(PostProcessPass::type pass) -> bool;
+auto PassHasProperties(PostProcessPassFlag::type pass) -> bool;
 
 /** @brief Construct a PostProcessPassProperties holding the property type for a pass. */
-auto MakeDefaultPassProperties(PostProcessPass::type pass) -> PostProcessPassProperties;
+auto MakeDefaultPassProperties(PostProcessPassFlag::type pass) -> PostProcessPassProperties;
 } // namespace nc

--- a/source/ncengine/graphics/NcGraphicsImpl.cpp
+++ b/source/ncengine/graphics/NcGraphicsImpl.cpp
@@ -62,10 +62,10 @@ namespace
         auto IsPostProcessEffectEnabled(nc::PostProcessEffectId) const -> bool override { return false; }
         void SetPostProcessEffectEnabled(nc::PostProcessEffectId, bool) override {}
         void SetPostProcessEffectProperties(nc::PostProcessEffectId,
-                                            nc::PostProcessPass::type,
+                                            nc::PostProcessPassFlag::type,
                                             const nc::PostProcessPassProperties&) override {}
         auto GetPostProcessEffectProperties(nc::PostProcessEffectId,
-                                            nc::PostProcessPass::type) const -> const nc::PostProcessPassProperties& override
+                                            nc::PostProcessPassFlag::type) const -> const nc::PostProcessPassProperties& override
         {
             static auto dummy = nc::PostProcessPassProperties{};
             return dummy;

--- a/source/ncengine/graphics/NcGraphicsImpl.h
+++ b/source/ncengine/graphics/NcGraphicsImpl.h
@@ -44,10 +44,10 @@ class NcGraphicsImpl : public NcGraphics
         auto IsPostProcessEffectEnabled(PostProcessEffectId) const -> bool override { return false; }
         void SetPostProcessEffectEnabled(PostProcessEffectId, bool) override {}
         void SetPostProcessEffectProperties(PostProcessEffectId,
-                                            PostProcessPass::type,
+                                            PostProcessPassFlag::type,
                                             const PostProcessPassProperties&) override {}
         auto GetPostProcessEffectProperties(PostProcessEffectId,
-                                            PostProcessPass::type) const -> const PostProcessPassProperties& override
+                                            PostProcessPassFlag::type) const -> const PostProcessPassProperties& override
         {
             static auto dummy = PostProcessPassProperties{};
             return dummy;

--- a/source/ncengine/graphics2/GraphicsUtility.cpp
+++ b/source/ncengine/graphics2/GraphicsUtility.cpp
@@ -14,8 +14,8 @@ constexpr auto g_materialPassNames = std::array{
 };
 
 constexpr auto g_materialPassFlags = std::array{
-    nc::MaterialPass::Shadow,
-    nc::MaterialPass::Toon
+    nc::MaterialPassFlag::Shadow,
+    nc::MaterialPassFlag::Toon
 };
 
 constexpr auto g_postProcessPassNames = std::array{
@@ -26,10 +26,10 @@ constexpr auto g_postProcessPassNames = std::array{
 };
 
 constexpr auto g_postProcessPassFlags = std::array{
-    nc::PostProcessPass::Alpha,
-    nc::PostProcessPass::Depth,
-    nc::PostProcessPass::Normals,
-    nc::PostProcessPass::Outline
+    nc::PostProcessPassFlag::Alpha,
+    nc::PostProcessPassFlag::Depth,
+    nc::PostProcessPassFlag::Normals,
+    nc::PostProcessPassFlag::Outline
 };
 
 constexpr auto g_postProcessEffectNames = std::array{
@@ -42,15 +42,15 @@ constexpr auto g_postProcessEffectIds = std::array{
 
 const auto g_postProcessEffectPassFlags = std::array{
     std::vector{
-        nc::PostProcessPass::Alpha,
-        nc::PostProcessPass::Depth,
-        nc::PostProcessPass::Normals,
-        nc::PostProcessPass::Outline
+        nc::PostProcessPassFlag::Alpha,
+        nc::PostProcessPassFlag::Depth,
+        nc::PostProcessPassFlag::Normals,
+        nc::PostProcessPassFlag::Outline
     }
 };
 
 constexpr auto g_combinedPostProcessEffectPassFlags = std::array{
-    nc::MoebiusEffectPasses
+    nc::MoebiusEffectPassFlags
 };
 
 static_assert(g_materialPassNames.size() == g_materialPassFlags.size());
@@ -67,14 +67,14 @@ auto GetMaterialPassNames() -> std::span<const std::string_view>
     return g_materialPassNames;
 }
 
-auto GetMaterialPassFlags() -> std::span<const MaterialPass::type>
+auto GetMaterialPassFlags() -> std::span<const MaterialPassFlag::type>
 {
     return g_materialPassFlags;
 }
 
-auto GetImplementedMaterialPassFlags() -> std::span<const MaterialPass::type>
+auto GetImplementedMaterialPassFlags() -> std::span<const MaterialPassFlag::type>
 {
-    return std::span<const MaterialPass::type>{g_materialPassFlags.data() + 1, 1};
+    return std::span<const MaterialPassFlag::type>{g_materialPassFlags.data() + 1, 1};
 }
 
 auto GetPostProcessPassNames() -> std::span<const std::string_view>
@@ -82,12 +82,12 @@ auto GetPostProcessPassNames() -> std::span<const std::string_view>
     return g_postProcessPassNames;
 }
 
-auto GetPostProcessPassFlags() -> std::span<const PostProcessPass::type>
+auto GetPostProcessPassFlags() -> std::span<const PostProcessPassFlag::type>
 {
     return g_postProcessPassFlags;
 }
 
-auto GetPostProcessPassName(PostProcessPass::type pass) -> std::string_view
+auto GetPostProcessPassName(PostProcessPassFlag::type pass) -> std::string_view
 {
     const auto pos = std::ranges::find(g_postProcessPassFlags, pass);
     NC_ASSERT(pos != g_postProcessPassFlags.end(), "Invalid post process pass");
@@ -105,12 +105,12 @@ auto GetPostProcessEffectIds() -> std::span<const PostProcessEffectId>
     return g_postProcessEffectIds;
 }
 
-auto GetPostProcessEffectPassFlags(PostProcessEffectId effectId) -> std::span<const PostProcessPass::type>
+auto GetPostProcessEffectPassFlags(PostProcessEffectId effectId) -> std::span<const PostProcessPassFlag::type>
 {
     return g_postProcessEffectPassFlags.at(effectId);
 }
 
-auto GetCombinedPostProcessEffectPassFlags(PostProcessEffectId effectId) -> PostProcessEffectPasses
+auto GetCombinedPostProcessEffectPassFlags(PostProcessEffectId effectId) -> PostProcessEffectPassFlags
 {
     return g_combinedPostProcessEffectPassFlags.at(effectId);
 }

--- a/source/ncengine/graphics2/Material.cpp
+++ b/source/ncengine/graphics2/Material.cpp
@@ -23,7 +23,7 @@ void MaterialInstance::SetName(std::string_view name)
     s_registry->SetInstanceName(m_handle, name);
 }
 
-auto MaterialInstance::GetPasses() const -> MaterialPasses
+auto MaterialInstance::GetPasses() const -> MaterialPassFlags
 {
     return s_registry->GetInstanceDesc(m_handle).passes;
 }

--- a/source/ncengine/graphics2/NcGraphicsImpl2.cpp
+++ b/source/ncengine/graphics2/NcGraphicsImpl2.cpp
@@ -60,10 +60,10 @@ struct NcGraphicsStub2 : nc::graphics::NcGraphics
     auto IsPostProcessEffectEnabled(nc::PostProcessEffectId) const -> bool override { return false; }
     void SetPostProcessEffectEnabled(nc::PostProcessEffectId, bool) override {}
     void SetPostProcessEffectProperties(nc::PostProcessEffectId,
-                                        nc::PostProcessPass::type,
+                                        nc::PostProcessPassFlag::type,
                                         const nc::PostProcessPassProperties&) override {}
     auto GetPostProcessEffectProperties(nc::PostProcessEffectId,
-                                        nc::PostProcessPass::type) const -> const nc::PostProcessPassProperties& override
+                                        nc::PostProcessPassFlag::type) const -> const nc::PostProcessPassProperties& override
     {
         static auto dummy = nc::PostProcessPassProperties{};
         return dummy;
@@ -257,13 +257,13 @@ void NcGraphicsImpl2::SetPostProcessEffectEnabled(PostProcessEffectId effectId, 
 }
 
 auto NcGraphicsImpl2::GetPostProcessEffectProperties(PostProcessEffectId effectId,
-                                                     PostProcessPass::type pass) const -> const PostProcessPassProperties&
+                                                     PostProcessPassFlag::type pass) const -> const PostProcessPassProperties&
 {
     return m_frontend.GetPostProcessSubsystem().GetProperties(effectId, pass);
 }
 
 void NcGraphicsImpl2::SetPostProcessEffectProperties(PostProcessEffectId effectId,
-                                                     PostProcessPass::type pass,
+                                                     PostProcessPassFlag::type pass,
                                                      const PostProcessPassProperties& properties)
 {
     m_frontend.GetPostProcessSubsystem().SetProperties(effectId, pass, properties);

--- a/source/ncengine/graphics2/NcGraphicsImpl2.h
+++ b/source/ncengine/graphics2/NcGraphicsImpl2.h
@@ -42,9 +42,9 @@ class NcGraphicsImpl2 : public NcGraphics
         auto IsPostProcessEffectEnabled(PostProcessEffectId effectId) const -> bool override;
         void SetPostProcessEffectEnabled(PostProcessEffectId effectId, bool enabled) override;
         auto GetPostProcessEffectProperties(PostProcessEffectId effectId,
-                                            PostProcessPass::type pass) const -> const PostProcessPassProperties& override;
+                                            PostProcessPassFlag::type pass) const -> const PostProcessPassProperties& override;
         void SetPostProcessEffectProperties(PostProcessEffectId effectId,
-                                            PostProcessPass::type pass,
+                                            PostProcessPassFlag::type pass,
                                             const PostProcessPassProperties& properties) override;
         void OnBuildTaskGraph(task::UpdateTasks& update, task::RenderTasks& render) override;
         void OnBeforeSceneLoad() override;

--- a/source/ncengine/graphics2/PostProcess.cpp
+++ b/source/ncengine/graphics2/PostProcess.cpp
@@ -6,20 +6,20 @@
 
 namespace nc
 {
-auto PassHasProperties(PostProcessPass::type pass) -> bool
+auto PassHasProperties(PostProcessPassFlag::type pass) -> bool
 {
-    return pass == PostProcessPass::Outline;
+    return pass == PostProcessPassFlag::Outline;
 }
 
-auto MakeDefaultPassProperties(PostProcessPass::type pass) -> PostProcessPassProperties
+auto MakeDefaultPassProperties(PostProcessPassFlag::type pass) -> PostProcessPassProperties
 {
     switch (pass)
     {
-        case PostProcessPass::Alpha:
-        case PostProcessPass::Depth:
-        case PostProcessPass::Normals:
+        case PostProcessPassFlag::Alpha:
+        case PostProcessPassFlag::Depth:
+        case PostProcessPassFlag::Normals:
             return PostProcessPassProperties{EmptyPassProperties{}};
-        case PostProcessPass::Outline:
+        case PostProcessPassFlag::Outline:
             return PostProcessPassProperties{OutlinePassProperties{}};
         default:
             // Explicitly enumerate above and fail here so tests can catch if an update to this gets missed.

--- a/source/ncengine/graphics2/diligent/pass/Pass.cpp
+++ b/source/ncengine/graphics2/diligent/pass/Pass.cpp
@@ -148,7 +148,7 @@ namespace nc::graphics
 {
 Pass::Pass(Diligent::IRenderDevice& device,
            const Diligent::GraphicsPipelineStateCreateInfo& createInfo,
-           MaterialPass::type passId)
+           MaterialPassFlag::type passId)
     : pso{},
       id{passId}
 {
@@ -218,7 +218,7 @@ auto MakeTestPass(Diligent::IRenderDevice& device,
         "Test PSO"
     );
 
-    return Pass(device, createInfo, MaterialPass::Toon);
+    return Pass(device, createInfo, MaterialPassFlag::Toon);
 }
 
 auto MakePasses(Diligent::IRenderDevice& device,

--- a/source/ncengine/graphics2/diligent/pass/Pass.h
+++ b/source/ncengine/graphics2/diligent/pass/Pass.h
@@ -17,7 +17,7 @@ class ShaderFactory;
 struct Pass
 {
     explicit Pass(Diligent::RefCntAutoPtr<Diligent::IPipelineState> state,
-                  MaterialPass::type passId)
+                  MaterialPassFlag::type passId)
         : pso{std::move(state)},
           id{passId}
     {
@@ -25,10 +25,10 @@ struct Pass
 
     explicit Pass(Diligent::IRenderDevice& device,
                   const Diligent::GraphicsPipelineStateCreateInfo& createInfo,
-                  MaterialPass::type passId);
+                  MaterialPassFlag::type passId);
 
     Diligent::RefCntAutoPtr<Diligent::IPipelineState> pso;
-    MaterialPass::type id;
+    MaterialPassFlag::type id;
 };
 
 auto MakeDefaultGraphicsPipelineCreateInfo(Diligent::ISwapChain& swapChain,

--- a/source/ncengine/graphics2/diligent/pass/PostProcessPass.cpp
+++ b/source/ncengine/graphics2/diligent/pass/PostProcessPass.cpp
@@ -7,11 +7,11 @@ namespace
 {
 auto MakeBuffer(Diligent::IDeviceContext& context,
                 Diligent::IRenderDevice& device,
-                nc::PostProcessPass::type passId) -> nc::graphics::DynamicUniformBuffer
+                nc::PostProcessPassFlag::type passId) -> nc::graphics::DynamicUniformBuffer
 {
     switch (passId)
     {
-        case nc::PostProcessPass::Outline:
+        case nc::PostProcessPassFlag::Outline:
         {
             return nc::graphics::DynamicUniformBuffer(
                 context,
@@ -27,7 +27,7 @@ auto MakeBuffer(Diligent::IDeviceContext& context,
 
 auto MakePassInstances(Diligent::IDeviceContext& context,
                        Diligent::IRenderDevice& device,
-                       nc::PostProcessPass::type passId) -> std::vector<nc::graphics::PostProcessPipelineInstance>
+                       nc::PostProcessPassFlag::type passId) -> std::vector<nc::graphics::PostProcessPipelineInstance>
 {
     const auto hasProperties = nc::PassHasProperties(passId);
     auto instances = std::vector<nc::graphics::PostProcessPipelineInstance>{};

--- a/source/ncengine/graphics2/diligent/pass/PostProcessPass.h
+++ b/source/ncengine/graphics2/diligent/pass/PostProcessPass.h
@@ -28,7 +28,7 @@ struct PostProcessPipeline
 {
     Diligent::RefCntAutoPtr<Diligent::IPipelineState> pso;
     std::vector<PostProcessPipelineInstance> instances;
-    PostProcessPass::type id = PostProcessPass::None;
+    PostProcessPassFlag::type id = PostProcessPassFlag::None;
     uint32_t renderTargetCount = 0u;
     uint32_t colorRenderTargetIndex = 0u;
     uint32_t depthRenderTargetIndex = 0u;

--- a/source/ncengine/graphics2/diligent/pass/PostProcessPassBackend.cpp
+++ b/source/ncengine/graphics2/diligent/pass/PostProcessPassBackend.cpp
@@ -54,7 +54,7 @@ void DisableInstance(PostProcessEffectId effectId,
 
 auto FindInstance(std::vector<PostProcessPipeline>& passes,
                   PostProcessEffectId effectId,
-                  PostProcessPass::type passId) -> PostProcessPipelineInstance&
+                  PostProcessPassFlag::type passId) -> PostProcessPipelineInstance&
 {
     auto pass = std::ranges::find(passes, passId, &PostProcessPipeline::id);
     if (pass != passes.end())

--- a/source/ncengine/graphics2/diligent/resource/PerFrameResourceSignature.cpp
+++ b/source/ncengine/graphics2/diligent/resource/PerFrameResourceSignature.cpp
@@ -147,7 +147,7 @@ PerFrameResourceSignature::PerFrameResourceSignature(Diligent::IDeviceContext& c
         std::vector<PostProcessDataVariable>{
             PostProcessDataVariable{
                 &GetVariable(outlinePassPropertiesDesc, m_srb),
-                PostProcessPass::Outline
+                PostProcessPassFlag::Outline
             }
         }
     );

--- a/source/ncengine/graphics2/diligent/resource/PostProcessPropertyBufferResource.cpp
+++ b/source/ncengine/graphics2/diligent/resource/PostProcessPropertyBufferResource.cpp
@@ -12,12 +12,12 @@ PostProcessPropertyBufferResource::PostProcessPropertyBufferResource(std::vector
 {
 }
 
-void PostProcessPropertyBufferResource::SetVariable(PostProcessPass::type passId, Diligent::IBuffer& buffer)
+void PostProcessPropertyBufferResource::SetVariable(PostProcessPassFlag::type passId, Diligent::IBuffer& buffer)
 {
     GetVariable(passId).Set(&buffer);
 }
 
-auto PostProcessPropertyBufferResource::GetVariable(PostProcessPass::type passId) -> Diligent::IShaderResourceVariable&
+auto PostProcessPropertyBufferResource::GetVariable(PostProcessPassFlag::type passId) -> Diligent::IShaderResourceVariable&
 {
     auto pos = std::ranges::find_if(
         m_variables,

--- a/source/ncengine/graphics2/diligent/resource/PostProcessPropertyBufferResource.h
+++ b/source/ncengine/graphics2/diligent/resource/PostProcessPropertyBufferResource.h
@@ -15,7 +15,7 @@ struct PostProcessState;
 struct PostProcessDataVariable
 {
     Diligent::IShaderResourceVariable* variable = nullptr;
-    PostProcessPass::type passId = PostProcessPass::None;
+    PostProcessPassFlag::type passId = PostProcessPassFlag::None;
 };
 
 // Set of uniform buffer variables for post process property types. The actual buffers are owned by pass instances.
@@ -24,8 +24,8 @@ class PostProcessPropertyBufferResource
     public:
         explicit PostProcessPropertyBufferResource(std::vector<PostProcessDataVariable> variables);
 
-        void SetVariable(PostProcessPass::type passId, Diligent::IBuffer& buffer);
-        auto GetVariable(PostProcessPass::type passId) -> Diligent::IShaderResourceVariable&;
+        void SetVariable(PostProcessPassFlag::type passId, Diligent::IBuffer& buffer);
+        auto GetVariable(PostProcessPassFlag::type passId) -> Diligent::IShaderResourceVariable&;
 
     private:
         std::vector<PostProcessDataVariable> m_variables;

--- a/source/ncengine/graphics2/frontend/subsystem/InstanceCache.h
+++ b/source/ncengine/graphics2/frontend/subsystem/InstanceCache.h
@@ -17,7 +17,7 @@ constexpr auto NullBatchIndex = std::numeric_limits<uint32_t>::max();
 // A batch is uniquely identified by a mesh and set of material passes.
 struct BatchKey
 {
-    MaterialPasses passes = NullBatchIndex;
+    MaterialPassFlags passes = NullBatchIndex;
     uint64_t meshId = std::numeric_limits<uint64_t>::max();
 
     friend auto operator==(const BatchKey& lhs, const BatchKey& rhs) -> bool
@@ -37,7 +37,7 @@ struct BatchRegion
 // A new batch waiting to be added to the instance buffer.
 struct StagedBatchRegion
 {
-    MaterialPasses passes = MaterialPasses{};
+    MaterialPassFlags passes = MaterialPassFlags{};
     asset::MeshView mesh = asset::MeshView{};
 };
 
@@ -73,17 +73,17 @@ class InstanceCacheStaging
     public:
         // API-Facing Functions
         void AddInstance(uint32_t entityId,
-                         MaterialPasses passes,
+                         MaterialPassFlags passes,
                          const asset::MeshView& mesh,
                          const T& instanceData);
 
         void RemoveInstance(uint32_t entityId,
-                            MaterialPasses passes,
+                            MaterialPassFlags passes,
                             uint64_t meshId);
 
         void UpdateInstance(uint32_t entityId,
-                            MaterialPasses oldPasses,
-                            MaterialPasses newPasses,
+                            MaterialPassFlags oldPasses,
+                            MaterialPassFlags newPasses,
                             uint64_t oldMeshId,
                             const asset::MeshView& newMesh,
                             const T& instanceData);
@@ -125,7 +125,7 @@ class InstanceCache
 
         // Generate draw call information for batches. The return value contains a collection of batches
         // to be drawn per material pass provided in the input 'passes'.
-        auto BuildBatches(std::span<const MaterialPass::type> passes) -> std::vector<std::vector<Batch>>;
+        auto BuildBatches(std::span<const MaterialPassFlag::type> passes) -> std::vector<std::vector<Batch>>;
 
         // Merge staging area into the buffer.
         // IMPORTANT: Staging area cannot be modified while this is running (game logic cannot be running).

--- a/source/ncengine/graphics2/frontend/subsystem/InstanceCache.inl
+++ b/source/ncengine/graphics2/frontend/subsystem/InstanceCache.inl
@@ -21,7 +21,7 @@ inline auto WalkBatch(const Batch& batch)
 
 template<class T>
 void InstanceCacheStaging<T>::AddInstance(uint32_t entityId,
-                                          MaterialPasses passes,
+                                          MaterialPassFlags passes,
                                           const asset::MeshView& mesh,
                                           const T& instanceData)
 {
@@ -49,7 +49,7 @@ void InstanceCacheStaging<T>::AddInstance(uint32_t entityId,
 
 template<class T>
 void InstanceCacheStaging<T>::RemoveInstance(uint32_t entityId,
-                                             MaterialPasses passes,
+                                             MaterialPassFlags passes,
                                              uint64_t meshId)
 {
     m_hasStagedState = true;
@@ -58,8 +58,8 @@ void InstanceCacheStaging<T>::RemoveInstance(uint32_t entityId,
 
 template<class T>
 void InstanceCacheStaging<T>::UpdateInstance(uint32_t entityId,
-                                             MaterialPasses oldPasses,
-                                             MaterialPasses newPasses,
+                                             MaterialPassFlags oldPasses,
+                                             MaterialPassFlags newPasses,
                                              uint64_t oldMeshId,
                                              const asset::MeshView& newMesh,
                                              const T& instanceData)
@@ -155,7 +155,7 @@ auto InstanceCache<T>::BuildState() -> BufferUpdateInfo<T>
 }
 
 template<class T>
-auto InstanceCache<T>::BuildBatches(std::span<const MaterialPass::type> passes) -> std::vector<std::vector<Batch>>
+auto InstanceCache<T>::BuildBatches(std::span<const MaterialPassFlag::type> passes) -> std::vector<std::vector<Batch>>
 {
     NC_PROFILE_SCOPE("InstanceCache::BuildBatches()", ProfileCategory::Rendering);
     auto out = std::vector<std::vector<Batch>>(passes.size());

--- a/source/ncengine/graphics2/frontend/subsystem/MeshSubsystem.cpp
+++ b/source/ncengine/graphics2/frontend/subsystem/MeshSubsystem.cpp
@@ -136,7 +136,7 @@ void MeshSubsystem::SetInstanceMesh(MeshInstanceContext& ctx,
 
 void MeshSubsystem::SetInstanceMaterial(const MeshInstanceContext& ctx,
                                         const MaterialInstance& material,
-                                        MaterialPasses oldPasses)
+                                        MaterialPassFlags oldPasses)
 {
     const auto meshService = asset::AssetService<asset::MeshView>::Get();
     const auto meshPath = std::string{meshService->GetPath(ctx.meshId)};

--- a/source/ncengine/graphics2/frontend/subsystem/MeshSubsystem.h
+++ b/source/ncengine/graphics2/frontend/subsystem/MeshSubsystem.h
@@ -37,7 +37,7 @@ class MeshSubsystem
 
         void SetInstanceMaterial(const MeshInstanceContext& ctx,
                                  const MaterialInstance& material,
-                                 MaterialPasses oldPasses);
+                                 MaterialPassFlags oldPasses);
 
         auto BuildState(ecs::ExplicitEcs<Transform> ecs) -> MeshRenderState;
         void OnBeforeSceneLoad();

--- a/source/ncengine/graphics2/frontend/subsystem/PostProcessState.h
+++ b/source/ncengine/graphics2/frontend/subsystem/PostProcessState.h
@@ -9,14 +9,14 @@ namespace nc::graphics
 struct PostProcessToggle
 {
     PostProcessEffectId effectId = NullPostProcessEffectId;
-    PostProcessEffectPasses passes = PostProcessPass::None;
+    PostProcessEffectPassFlags passes = PostProcessPassFlag::None;
     bool enabled = false;
 };
 
 struct PostProcessPropertyUpdate
 {
     PostProcessEffectId effectId = NullPostProcessEffectId;
-    PostProcessPass::type pass = PostProcessPass::None;
+    PostProcessPassFlag::type pass = PostProcessPassFlag::None;
     PostProcessPassProperties properties = EmptyPassProperties{};
 };
 

--- a/source/ncengine/graphics2/frontend/subsystem/PostProcessSubsystem.cpp
+++ b/source/ncengine/graphics2/frontend/subsystem/PostProcessSubsystem.cpp
@@ -8,7 +8,7 @@
 namespace
 {
 void VerifyPropertyQuery([[maybe_unused]] nc::PostProcessEffectId effectId,
-                         [[maybe_unused]] nc::PostProcessPass::type passId)
+                         [[maybe_unused]] nc::PostProcessPassFlag::type passId)
 {
     NC_ASSERT(
         nc::GetCombinedPostProcessEffectPassFlags(effectId) & passId,
@@ -27,7 +27,7 @@ auto BuildEffectStates() -> std::vector<nc::graphics::PostProcessEffectState>
     for (const auto effectId : nc::GetPostProcessEffectIds())
     {
         auto properties = std::vector<nc::PostProcessPassProperties>{};
-        auto passes = nc::PostProcessEffectPasses{};
+        auto passes = nc::PostProcessEffectPassFlags{};
         for (const auto pass : nc::GetPostProcessEffectPassFlags(effectId))
         {
             passes |= pass;
@@ -48,14 +48,14 @@ auto BuildEffectStates() -> std::vector<nc::graphics::PostProcessEffectState>
     return effects;
 }
 
-auto MatchPostProcessPass(nc::PostProcessPass::type pass,
+auto MatchPostProcessPass(nc::PostProcessPassFlag::type pass,
                           const nc::PostProcessPassProperties& properties) -> bool
 {
     return std::visit(
         [pass](const auto& unpacked) {
             using T = std::decay_t<decltype(unpacked)>;
             if constexpr (std::same_as<T, nc::OutlinePassProperties>)
-                return pass == nc::PostProcessPass::Outline;
+                return pass == nc::PostProcessPassFlag::Outline;
             else
                 return false;
         },
@@ -84,7 +84,7 @@ void PostProcessSubsystem::SetEnabled(PostProcessEffectId effectId, bool enabled
 }
 
 auto PostProcessSubsystem::GetProperties(PostProcessEffectId effectId,
-                                         PostProcessPass::type pass) const -> const PostProcessPassProperties&
+                                         PostProcessPassFlag::type pass) const -> const PostProcessPassProperties&
 {
     VerifyPropertyQuery(effectId, pass);
     for (const auto& properties : m_effects.at(effectId).properties)
@@ -99,7 +99,7 @@ auto PostProcessSubsystem::GetProperties(PostProcessEffectId effectId,
 }
 
 void PostProcessSubsystem::SetProperties(PostProcessEffectId effectId,
-                                         PostProcessPass::type pass,
+                                         PostProcessPassFlag::type pass,
                                          const PostProcessPassProperties& properties)
 {
     VerifyPropertyQuery(effectId, pass);

--- a/source/ncengine/graphics2/frontend/subsystem/PostProcessSubsystem.h
+++ b/source/ncengine/graphics2/frontend/subsystem/PostProcessSubsystem.h
@@ -11,7 +11,7 @@ namespace nc::graphics
 struct PostProcessEffectState
 {
     PostProcessEffectId effectId = NullPostProcessEffectId;
-    PostProcessEffectPasses passes = PostProcessPass::None;
+    PostProcessEffectPassFlags passes = PostProcessPassFlag::None;
     std::vector<PostProcessPassProperties> properties = {};
     bool enabled = false;
 };
@@ -24,9 +24,9 @@ class PostProcessSubsystem
         auto IsEnabled(PostProcessEffectId effectId) const -> bool;
         void SetEnabled(PostProcessEffectId effectId, bool enabled);
         auto GetProperties(PostProcessEffectId effectId,
-                           PostProcessPass::type pass) const -> const PostProcessPassProperties&;
+                           PostProcessPassFlag::type pass) const -> const PostProcessPassProperties&;
         void SetProperties(PostProcessEffectId effectId,
-                           PostProcessPass::type pass,
+                           PostProcessPassFlag::type pass,
                            const PostProcessPassProperties& properties);
 
         auto BuildState() -> PostProcessState;

--- a/source/ncengine/ui/editor/impl/ComponentWidgets.cpp
+++ b/source/ncengine/ui/editor/impl/ComponentWidgets.cpp
@@ -78,7 +78,7 @@ void MeshNodeWidget(nc::MeshBase& baseMesh, nc::asset::NcAsset& ncAsset)
     }
 }
 
-auto MaterialPassesWidget(nc::MaterialPasses& passes) -> bool
+auto MaterialPassFlagsWidget(nc::MaterialPassFlags& passes) -> bool
 {
     auto modified = false;
     const auto passInfo = std::views::zip(nc::GetMaterialPassNames(), nc::GetMaterialPassFlags());
@@ -158,7 +158,7 @@ auto MaterialNodeWidget(nc::MeshBase& baseMesh, nc::asset::NcAsset& ncAsset)
         ImGui::Separator();
         if (ImGui::TreeNodeEx("Passes"))
         {
-            passesModified = MaterialPassesWidget(passes);
+            passesModified = MaterialPassFlagsWidget(passes);
             ImGui::TreePop();
         }
 

--- a/source/ncengine/ui/editor/impl/windows/dialogs/PostProcessDialog.cpp
+++ b/source/ncengine/ui/editor/impl/windows/dialogs/PostProcessDialog.cpp
@@ -7,7 +7,7 @@
 namespace
 {
 void DrawPostProcessPassInfo(nc::PostProcessEffectId effectId,
-                             nc::PostProcessPass::type passId,
+                             nc::PostProcessPassFlag::type passId,
                              nc::graphics::NcGraphics* ncGraphics)
 {
     ImGui::Separator();
@@ -26,7 +26,7 @@ void DrawPostProcessPassInfo(nc::PostProcessEffectId effectId,
                     modified = nc::ui::DragFloat(copy.width, "width", 0.05f, 0.1f, 10.0f) || modified;
                     if (modified)
                     {
-                        ncGraphics->SetPostProcessEffectProperties(effectId, nc::PostProcessPass::Outline, copy);
+                        ncGraphics->SetPostProcessEffectProperties(effectId, nc::PostProcessPassFlag::Outline, copy);
                     }
                 }
             },

--- a/test/ncengine/graphics2/InstanceCache_tests.cpp
+++ b/test/ncengine/graphics2/InstanceCache_tests.cpp
@@ -30,21 +30,21 @@ constexpr auto g_mesh3 = nc::asset::MeshView{
 };
 
 constexpr auto g_allBatches = std::array{
-    nc::MaterialPass::Shadow,
-    nc::MaterialPass::Toon
+    nc::MaterialPassFlag::Shadow,
+    nc::MaterialPassFlag::Toon
 };
 
 struct TestObjectInfo
 {
     uint32_t transformIndex;
     nc::MaterialInstanceHandle materialIndex;
-    nc::MaterialPasses passes;
+    nc::MaterialPassFlags passes;
     nc::asset::MeshView mesh;
 };
 
 struct Batch1
 {
-    static constexpr auto passes = nc::MaterialPass::Toon;
+    static constexpr auto passes = nc::MaterialPassFlag::Toon;
     static constexpr auto& mesh = g_mesh1;
     static constexpr auto key = nc::graphics::BatchKey{passes, mesh.id};
     static constexpr auto objects = std::array{
@@ -58,7 +58,7 @@ struct Batch1
 
 struct Batch2
 {
-    static constexpr auto passes = nc::MaterialPass::Toon;
+    static constexpr auto passes = nc::MaterialPassFlag::Toon;
     static constexpr auto& mesh = g_mesh2;
     static constexpr auto key = nc::graphics::BatchKey{passes, mesh.id};
     static constexpr auto objects = std::array{
@@ -70,8 +70,8 @@ struct Batch2
 
 struct Batch3
 {
-    static constexpr auto passes = nc::MaterialPass::Shadow |
-                                   nc::MaterialPass::Toon;
+    static constexpr auto passes = nc::MaterialPassFlag::Shadow |
+                                   nc::MaterialPassFlag::Toon;
     static constexpr auto& mesh = g_mesh1;
     static constexpr auto key = nc::graphics::BatchKey{passes, mesh.id};
     static constexpr auto objects = std::array{

--- a/test/ncengine/graphics2/MaterialRegistry_tests.cpp
+++ b/test/ncengine/graphics2/MaterialRegistry_tests.cpp
@@ -8,7 +8,7 @@ TEST(MaterialRegistryTest, CreateInstance_constructsValidInstance)
 {
     const auto expectedDesc = nc::MaterialDesc{
         .name = "test",
-        .passes = nc::MaterialPass::Toon,
+        .passes = nc::MaterialPassFlag::Toon,
         .properties = nc::MaterialProperties{
             .diffuseTexture = nc::asset::TextureView{
                 .id = 42,

--- a/test/ncengine/graphics2/MeshSubsystem_tests.cpp
+++ b/test/ncengine/graphics2/MeshSubsystem_tests.cpp
@@ -13,7 +13,7 @@
 #include <ranges>
 
 const auto g_materialDesc = nc::MaterialDesc{
-    .passes = nc::MaterialPass::Toon
+    .passes = nc::MaterialPassFlag::Toon
 };
 
 constexpr auto g_meshView = nc::asset::MeshView{
@@ -25,7 +25,7 @@ DEFINE_ASSET_SERVICE_STUB(meshAssetManager, nc::asset::AssetType::Mesh, nc::asse
 namespace nc
 {
 MaterialInstance::MaterialInstance(const MaterialDesc&){}
-auto MaterialInstance::GetPasses()     const ->       MaterialPasses      { return g_materialDesc.passes;     }
+auto MaterialInstance::GetPasses()     const ->       MaterialPassFlags      { return g_materialDesc.passes;     }
 auto MaterialInstance::GetProperties() const -> const MaterialProperties& { return g_materialDesc.properties; }
 void MaterialInstance::Release() noexcept {}
 } // namespace nc

--- a/test/ncengine/graphics2/PostProcessSubsystem_tests.cpp
+++ b/test/ncengine/graphics2/PostProcessSubsystem_tests.cpp
@@ -54,7 +54,7 @@ TEST(PostProcessSubsystemTest, SetProperties_validCall_updatesState)
 {
     auto uut = nc::graphics::PostProcessSubsystem{};
     constexpr auto effect = nc::MoebiusEffectId;
-    constexpr auto pass = nc::PostProcessPass::Outline;
+    constexpr auto pass = nc::PostProcessPassFlag::Outline;
     ASSERT_TRUE(nc::PassHasProperties(pass));
 
     const auto expected = nc::OutlinePassProperties{
@@ -102,7 +102,7 @@ TEST(PostProcessSubsystemTest, BuildState_reportsEnabledAndDisabled)
     EXPECT_EQ(0, state.modifiedProperties.size());
     const auto& enableEvent = state.toggledEffects.at(0);
     EXPECT_EQ(nc::MoebiusEffectId, enableEvent.effectId);
-    EXPECT_EQ(nc::MoebiusEffectPasses, enableEvent.passes);
+    EXPECT_EQ(nc::MoebiusEffectPassFlags, enableEvent.passes);
     EXPECT_TRUE(enableEvent.enabled);
 
     // enable event cleared
@@ -117,7 +117,7 @@ TEST(PostProcessSubsystemTest, BuildState_reportsEnabledAndDisabled)
     EXPECT_EQ(0, state.modifiedProperties.size());
     const auto& disableEvent = state.toggledEffects.at(0);
     EXPECT_EQ(nc::MoebiusEffectId, disableEvent.effectId);
-    EXPECT_EQ(nc::MoebiusEffectPasses, disableEvent.passes);
+    EXPECT_EQ(nc::MoebiusEffectPassFlags, disableEvent.passes);
     EXPECT_FALSE(disableEvent.enabled);
 
     // disable event cleared
@@ -137,13 +137,13 @@ TEST(PostProcessSubsystemTest, BuildState_reportsPropertyModification)
 
     // reports property modification
     const auto expectedProperties = nc::OutlinePassProperties{nc::Vector3::Up(), 10.0f};
-    uut.SetProperties(nc::MoebiusEffectId, nc::PostProcessPass::Outline, expectedProperties);
+    uut.SetProperties(nc::MoebiusEffectId, nc::PostProcessPassFlag::Outline, expectedProperties);
     state = uut.BuildState();
     EXPECT_EQ(0, state.toggledEffects.size());
     EXPECT_EQ(1, state.modifiedProperties.size());
     const auto& modifyEvent = state.modifiedProperties.at(0);
     EXPECT_EQ(nc::MoebiusEffectId, modifyEvent.effectId);
-    EXPECT_EQ(nc::PostProcessPass::Outline, modifyEvent.pass);
+    EXPECT_EQ(nc::PostProcessPassFlag::Outline, modifyEvent.pass);
     const auto& actualProperties = std::get<nc::OutlinePassProperties>(modifyEvent.properties);
     EXPECT_EQ(expectedProperties.color, actualProperties.color);
     EXPECT_EQ(expectedProperties.width, actualProperties.width);

--- a/test/ncengine/graphics2/PostProcess_tests.cpp
+++ b/test/ncengine/graphics2/PostProcess_tests.cpp
@@ -21,7 +21,7 @@ TEST(PostProcessTest, MakeDefaultPassProperties_succeedsForAllPasses)
 
 TEST(PostProcessTest, MakeDefaultPassProperties_invalidPass_throws)
 {
-    EXPECT_THROW(nc::MakeDefaultPassProperties(nc::PostProcessPass::None), nc::NcError);
+    EXPECT_THROW(nc::MakeDefaultPassProperties(nc::PostProcessPassFlag::None), nc::NcError);
 }
 
 TEST(PostProcessTest, MakeDefaultPassProperties_ifPassHasProperties_returnsNonEmptyResult)


### PR DESCRIPTION
Renamed the pass types that represent pass flags from `XPass` and `XPasses` to `XPassFlag` and `XPassFlags`.