### PR TITLE
MSAA

### DIFF
--- a/source/ncengine/graphics2/NcGraphicsImpl2.cpp
+++ b/source/ncengine/graphics2/NcGraphicsImpl2.cpp
@@ -192,38 +192,38 @@ NcGraphicsImpl2::NcGraphicsImpl2(const config::GraphicsSettings& graphicsSetting
                     .name = "Toon",
                     .type = PassType::Material,
                     .shaderPaths = ShaderPaths{"Toon.psh", "Toon.vsh"},
-                    .colorSink = MainColor,
-                    .depthSink = MainDepth
+                    .colorSink = MainColorMsaa,
+                    .depthSink = MainDepthMsaa
                 },
                 PassDesc{
                     .id = MaterialPassFlag::Toon,
                     .name = "ToonSkinned",
                     .type = PassType::SkinnedMaterial,
                     .shaderPaths = ShaderPaths{"Toon.psh", "ToonSkinned.vsh"},
-                    .colorSink = MainColor,
-                    .depthSink = MainDepth
+                    .colorSink = MainColorMsaa,
+                    .depthSink = MainDepthMsaa
                 },
                 PassDesc{
                     .id = MaterialPassFlag::Normals,
                     .name = "Normals",
                     .type = PassType::Material,
                     .shaderPaths = ShaderPaths{"Normals.psh", "Toon.vsh"},
-                    .colorSink = NormalsColor
+                    .colorSink = NormalsColorMsaa
                 },
                 PassDesc{
                     .id = MaterialPassFlag::Normals,
                     .name = "NormalsSkinned",
                     .type = PassType::SkinnedMaterial,
                     .shaderPaths = ShaderPaths{"Normals.psh", "ToonSkinned.vsh"},
-                    .colorSink = NormalsColor
+                    .colorSink = NormalsColorMsaa
                 },
                 PassDesc{
                     .id = MiscPassFlag::Wireframe,
                     .name = "Wireframe",
                     .type = PassType::Wireframe,
                     .shaderPaths = ShaderPaths{"Wireframe.psh", "Wireframe.vsh"},
-                    .colorSink = MainColor,
-                    .depthSink = MainDepth
+                    .colorSink = MainColorMsaa,
+                    .depthSink = MainDepthMsaa
                 },
                 PassDesc{
                     .id = PostProcessPassFlag::Wave,
@@ -252,7 +252,8 @@ NcGraphicsImpl2::NcGraphicsImpl2(const config::GraphicsSettings& graphicsSetting
             m_engine.GetSwapChain(),
             m_engine.GetShaderFactory(),
             m_shaderBindings,
-            m_passManifest
+            m_passManifest,
+            graphicsSettings.antialiasing
           },
           m_frontend{
             m_engine.GetContext(),
@@ -272,7 +273,8 @@ NcGraphicsImpl2::NcGraphicsImpl2(const config::GraphicsSettings& graphicsSetting
             modules.Get<asset::NcAsset>()->OnBoneUpdate()
           },
           m_onResizeConnection{window.OnResize().Connect(this, &NcGraphicsImpl2::OnResize)},
-          m_resizeNeeded{false}
+          m_resizeNeeded{false},
+          m_numSamples{graphicsSettings.antialiasing} /* @todo: Check for device support */
 {
 }
 
@@ -433,7 +435,7 @@ void NcGraphicsImpl2::Run()
 
 void NcGraphicsImpl2::OnResize(const Vector2& dimensions, bool isMinimized)
 {
-    (void)isMinimized;
+    if (isMinimized) return;
     m_engine.GetSwapChain().Resize(static_cast<uint32_t>(dimensions.x), static_cast<uint32_t>(dimensions.y));
     m_resizeNeeded = true;
     m_dimensions = dimensions;
@@ -442,8 +444,8 @@ void NcGraphicsImpl2::OnResize(const Vector2& dimensions, bool isMinimized)
 void NcGraphicsImpl2::Resize()
 {
     m_engine.GetSwapChain().Resize(static_cast<uint32_t>(m_dimensions.x), static_cast<uint32_t>(m_dimensions.y));
-    m_shaderBindings.GetPerPassSignature().GetPostProcessColorSinkBufferResource().Resize(m_engine.GetDevice(), static_cast<uint32_t>(m_dimensions.x), static_cast<uint32_t>(m_dimensions.y));
-    m_shaderBindings.GetPerPassSignature().GetPostProcessDepthSinkBufferResource().Resize(m_engine.GetDevice(), static_cast<uint32_t>(m_dimensions.x), static_cast<uint32_t>(m_dimensions.y));
+    m_shaderBindings.GetPerPassSignature().GetPostProcessColorSinkBufferResource().Resize(m_engine.GetDevice(), static_cast<uint32_t>(m_dimensions.x), static_cast<uint32_t>(m_dimensions.y), m_numSamples);
+    m_shaderBindings.GetPerPassSignature().GetPostProcessDepthSinkBufferResource().Resize(m_engine.GetDevice(), static_cast<uint32_t>(m_dimensions.x), static_cast<uint32_t>(m_dimensions.y), m_numSamples);
     m_resizeNeeded = false;
 }
 } // namespace nc::graphics

--- a/source/ncengine/graphics2/NcGraphicsImpl2.cpp
+++ b/source/ncengine/graphics2/NcGraphicsImpl2.cpp
@@ -276,6 +276,7 @@ NcGraphicsImpl2::NcGraphicsImpl2(const config::GraphicsSettings& graphicsSetting
           m_onResizeConnection{window.OnResize().Connect(this, &NcGraphicsImpl2::OnResize)},
           m_resizeNeeded{false},
           m_numSamples{m_engine.GetDeviceCapability().msaaSampleCount}
+{
 }
 
 NcGraphicsImpl2::~NcGraphicsImpl2()

--- a/source/ncengine/graphics2/NcGraphicsImpl2.cpp
+++ b/source/ncengine/graphics2/NcGraphicsImpl2.cpp
@@ -160,6 +160,7 @@ NcGraphicsImpl2::NcGraphicsImpl2(const config::GraphicsSettings& graphicsSetting
         : m_world{world},
           m_engine{
             MakeEngineCreateInfo(graphicsSettings.useValidationLayers),
+            DeviceCapability{.msaaSampleCount = graphicsSettings.antialiasing},
             window.GetWindowHandle(),
             shadersPath,
             ::LogCallback
@@ -253,7 +254,7 @@ NcGraphicsImpl2::NcGraphicsImpl2(const config::GraphicsSettings& graphicsSetting
             m_engine.GetShaderFactory(),
             m_shaderBindings,
             m_passManifest,
-            graphicsSettings.antialiasing
+            m_engine.GetDeviceCapability().msaaSampleCount
           },
           m_frontend{
             m_engine.GetContext(),
@@ -274,8 +275,7 @@ NcGraphicsImpl2::NcGraphicsImpl2(const config::GraphicsSettings& graphicsSetting
           },
           m_onResizeConnection{window.OnResize().Connect(this, &NcGraphicsImpl2::OnResize)},
           m_resizeNeeded{false},
-          m_numSamples{graphicsSettings.antialiasing} /* @todo: Check for device support */
-{
+          m_numSamples{m_engine.GetDeviceCapability().msaaSampleCount}
 }
 
 NcGraphicsImpl2::~NcGraphicsImpl2()

--- a/source/ncengine/graphics2/NcGraphicsImpl2.h
+++ b/source/ncengine/graphics2/NcGraphicsImpl2.h
@@ -63,6 +63,7 @@ class NcGraphicsImpl2 : public NcGraphics
         Connection m_onResizeConnection;
         Vector2 m_dimensions;
         bool m_resizeNeeded;
+        uint32_t m_numSamples;
 };
 } // namespace graphics
 } // namespace nc

--- a/source/ncengine/graphics2/diligent/DiligentEngine.cpp
+++ b/source/ncengine/graphics2/diligent/DiligentEngine.cpp
@@ -11,11 +11,48 @@ void EnsureContextFlushed(Diligent::IDeviceContext* context)
     if (context)
         context->Flush();
 }
+
+auto QueryDeviceCapability(Diligent::IRenderDevice* device, Diligent::ISwapChain* swapChain, const nc::graphics::DeviceCapability& requestedCaps)
+{
+    auto supportedDeviceCaps = nc::graphics::DeviceCapability{};
+
+    // Supported MSAA sample count
+    const auto& colorFormat = device->GetTextureFormatInfoExt(swapChain->GetDesc().ColorBufferFormat);
+    const auto& depthFormat = device->GetTextureFormatInfoExt(swapChain->GetDesc().DepthBufferFormat);
+
+    auto requestedMsaaCount = requestedCaps.msaaSampleCount;
+    auto supportedMsaaCount = colorFormat.SampleCounts & depthFormat.SampleCounts;
+
+    // We only support a max of 8 samples because of texture formats used.
+    if (requestedMsaaCount > 7 && supportedMsaaCount & Diligent::SAMPLE_COUNT_8)
+    {
+        supportedDeviceCaps.msaaSampleCount = 8;
+    }
+    else if (requestedMsaaCount > 3 && supportedMsaaCount & Diligent::SAMPLE_COUNT_4)
+    {
+        supportedDeviceCaps.msaaSampleCount = 4;
+    }
+    else if (requestedMsaaCount > 1 && supportedMsaaCount & Diligent::SAMPLE_COUNT_2)
+    {
+        supportedDeviceCaps.msaaSampleCount = 2;
+    }
+    else
+    {
+        if (requestedMsaaCount > 1)
+        {
+            NC_LOG_TRACE("Multisampling not supported on this device.");
+        }
+        supportedDeviceCaps.msaaSampleCount = 1;
+    }
+
+    return supportedDeviceCaps;
+}
 } // anonymous namespace
 
 namespace nc::graphics
 {
 DiligentEngine::DiligentEngine(const Diligent::EngineCreateInfo& engineCreateInfo,
+                               DeviceCapability requestedCaps,
                                GLFWwindow* windowHandle,
                                std::string_view shadersPath,
                                Diligent::DebugMessageCallbackType logCallback)
@@ -48,6 +85,8 @@ DiligentEngine::DiligentEngine(const Diligent::EngineCreateInfo& engineCreateInf
         EnsureContextFlushed(m_pImmediateContext);
         throw nc::NcError("Failed to create swapchain.");
     }
+
+    m_deviceCapability = QueryDeviceCapability(m_pDevice, m_pSwapChain, requestedCaps);
 
     m_shaderFactory = MakeShaderFactory(*pFactoryVk, *m_pDevice, shadersPath);
     NC_LOG_TRACE("Successfully initialized rendering engine.");

--- a/source/ncengine/graphics2/diligent/DiligentEngine.h
+++ b/source/ncengine/graphics2/diligent/DiligentEngine.h
@@ -14,24 +14,32 @@ struct GLFWwindow;
 
 namespace nc::graphics
 {
+struct DeviceCapability
+{
+    uint32_t msaaSampleCount = 1u;
+};
+
 class DiligentEngine
 {
     public:
         DiligentEngine(const Diligent::EngineCreateInfo& engineCreateInfo,
+                       DeviceCapability requestedCaps,
                        GLFWwindow* windowHandle,
                        std::string_view shadersPath,
                        Diligent::DebugMessageCallbackType logCallback = nullptr);
         ~DiligentEngine() noexcept;
 
-        auto GetDevice()        -> Diligent::IRenderDevice&  { return *m_pDevice; }
-        auto GetContext()       -> Diligent::IDeviceContext& { return *m_pImmediateContext; }
-        auto GetSwapChain()     -> Diligent::ISwapChain&     { return *m_pSwapChain; }
-        auto GetShaderFactory() -> ShaderFactory&            { return *m_shaderFactory; }
+        auto GetDevice()           -> Diligent::IRenderDevice&  { return *m_pDevice; }
+        auto GetContext()          -> Diligent::IDeviceContext& { return *m_pImmediateContext; }
+        auto GetSwapChain()        -> Diligent::ISwapChain&     { return *m_pSwapChain; }
+        auto GetShaderFactory()    -> ShaderFactory&            { return *m_shaderFactory; }
+        auto GetDeviceCapability() -> const DeviceCapability&   { return m_deviceCapability; }
 
     private:
         Diligent::RefCntAutoPtr<Diligent::IRenderDevice>  m_pDevice;
         Diligent::RefCntAutoPtr<Diligent::IDeviceContext> m_pImmediateContext;
         Diligent::RefCntAutoPtr<Diligent::ISwapChain>     m_pSwapChain;
         std::unique_ptr<ShaderFactory>                    m_shaderFactory;
+        DeviceCapability                                  m_deviceCapability;
 };
 } // namespace nc::graphics

--- a/source/ncengine/graphics2/diligent/pass/MaterialPass.cpp
+++ b/source/ncengine/graphics2/diligent/pass/MaterialPass.cpp
@@ -15,7 +15,8 @@ using namespace nc::graphics;
 auto MakeMaterialPass(Diligent::IRenderDevice& device,
                       ShaderFactory& shaderFactory,
                       ShaderBindings& shaderBindings,
-                      const PassDesc& passDesc) -> MaterialPass
+                      const PassDesc& passDesc,
+                      uint32_t numSamples) -> MaterialPass
 {
     auto pixelShaderSource = shaderFactory.ReadShaderFile(passDesc.shaderPaths.pixelShaderPath);
     auto pixelShader = shaderFactory.MakeShaderFromSource(
@@ -56,6 +57,7 @@ auto MakeMaterialPass(Diligent::IRenderDevice& device,
     ci.GraphicsPipeline.DepthStencilDesc.DepthEnable = passDesc.depthSink == NoTarget ? False : True;
     ci.GraphicsPipeline.InputLayout.LayoutElements   = layoutElements.data();
     ci.GraphicsPipeline.InputLayout.NumElements      = static_cast<uint32_t>(layoutElements.size());
+    ci.GraphicsPipeline.SmplDesc.Count               = static_cast<uint8_t>(numSamples);
 
     return MaterialPass(device, ci, passDesc.id, passDesc.colorSink, passDesc.depthSink);
 }
@@ -80,14 +82,15 @@ MaterialPass::MaterialPass(Diligent::IRenderDevice& device,
 auto MakeMaterialPasses(Diligent::IRenderDevice& device,
                         ShaderFactory& shaderFactory,
                         ShaderBindings& shaderBindings,
-                        std::span<const PassDesc> passManifest) -> std::vector<MaterialPass>
+                        std::span<const PassDesc> passManifest,
+                        uint32_t numSamples) -> std::vector<MaterialPass>
 {
     auto materialPasses = std::vector<MaterialPass>{};
     materialPasses.reserve(passManifest.size());
 
     for (auto& passDesc : passManifest)
     {
-        materialPasses.emplace_back(MakeMaterialPass(device, shaderFactory, shaderBindings, passDesc));
+        materialPasses.emplace_back(MakeMaterialPass(device, shaderFactory, shaderBindings, passDesc, numSamples));
     }
 
     return materialPasses;

--- a/source/ncengine/graphics2/diligent/pass/MaterialPass.h
+++ b/source/ncengine/graphics2/diligent/pass/MaterialPass.h
@@ -46,5 +46,6 @@ struct MaterialPass
 auto MakeMaterialPasses(Diligent::IRenderDevice& device,
                         ShaderFactory& shaderFactory,
                         ShaderBindings& shaderBindings,
-                        std::span<const PassDesc> passManifest)-> std::vector<MaterialPass>;
+                        std::span<const PassDesc> passManifest,
+                        uint32_t numSamples = 1u)-> std::vector<MaterialPass>;
 } // namespace nc::graphics

--- a/source/ncengine/graphics2/diligent/pass/PassBackend.cpp
+++ b/source/ncengine/graphics2/diligent/pass/PassBackend.cpp
@@ -101,14 +101,23 @@ PassBackend::PassBackend(Diligent::IRenderDevice& device,
                          Diligent::ISwapChain& swapChain,
                          ShaderFactory& shaderFactory,
                          ShaderBindings& shaderBindings,
-                         const PassManifest& passManifest)
+                         const PassManifest& passManifest,
+                         uint32_t numSamples)
+    : m_numSamples{numSamples},
+      m_colorSinkCountMsaa{0u},
+      m_depthSinkCountMsaa{0u}
 {
+    // Sink target buffers
+    auto& postProcessColorSinks = shaderBindings.GetPerPassSignature().GetPostProcessColorSinkBufferResource();
+    auto& postProcessDepthSinks = shaderBindings.GetPerPassSignature().GetPostProcessDepthSinkBufferResource();
+
     m_staticMaterialPasses = MakeMaterialPasses
     (
         device,
         shaderFactory,
         shaderBindings,
-        passManifest.StaticMaterialPassDescs()
+        passManifest.StaticMaterialPassDescs(),
+        m_numSamples
     );
 
     m_skinnedMaterialPasses = MakeMaterialPasses
@@ -116,7 +125,8 @@ PassBackend::PassBackend(Diligent::IRenderDevice& device,
         device,
         shaderFactory,
         shaderBindings,
-        passManifest.SkinnedMaterialPassDescs()
+        passManifest.SkinnedMaterialPassDescs(),
+        m_numSamples
     );
 
     m_wireframePass = std::make_unique<WireframePass>
@@ -124,7 +134,8 @@ PassBackend::PassBackend(Diligent::IRenderDevice& device,
         device,
         shaderFactory,
         shaderBindings,
-        passManifest.WireframePassDesc()
+        passManifest.WireframePassDesc(),
+        m_numSamples
     );
 
     m_postProcessPasses = MakePostProcessPasses
@@ -153,11 +164,16 @@ PassBackend::PassBackend(Diligent::IRenderDevice& device,
     m_finalPass = std::make_unique<PostProcessPass>(MakePostProcessPass(device, swapChain, shaderFactory, shaderBindings, finalPass));
 
     // Make all the off screen render targets that will be used by the passes
-    auto& postProcessColorSinks = shaderBindings.GetPerPassSignature().GetPostProcessColorSinkBufferResource();
     postProcessColorSinks.Add(device, passManifest.ColorSinkCount(), swapChain.GetDesc().Width, swapChain.GetDesc().Height);
-
-    auto& postProcessDepthSinks = shaderBindings.GetPerPassSignature().GetPostProcessDepthSinkBufferResource();
     postProcessDepthSinks.Add(device, passManifest.DepthSinkCount(), swapChain.GetDesc().Width, swapChain.GetDesc().Height);
+
+    if (m_numSamples > 1)
+    {
+        m_colorSinkCountMsaa = passManifest.ColorSinkCountMsaa();
+        m_depthSinkCountMsaa = passManifest.DepthSinkCountMsaa();
+        postProcessColorSinks.Add(device, m_colorSinkCountMsaa, swapChain.GetDesc().Width, swapChain.GetDesc().Height, m_numSamples);
+        postProcessDepthSinks.Add(device, m_depthSinkCountMsaa, swapChain.GetDesc().Width, swapChain.GetDesc().Height, m_numSamples);
+    }
 }
 
 void PassBackend::Update(const PostProcessState& postProcessState)
@@ -199,17 +215,14 @@ void PassBackend::RenderMaterial(Diligent::IDeviceContext& context,
         skinnedPassBatches
     );
 
+    auto& colorSinkBuffer = perPassResourceSignature.GetPostProcessColorSinkBufferResource();
+    auto& depthSinkBuffer = perPassResourceSignature.GetPostProcessDepthSinkBufferResource();
+
     for (auto [staticPass, skinnedPass, staticBatches, skinnedBatches] : passView)
     {
         // PassManifest verifies static/skinned pass pairs specify the same render targets, so we can just choose from either here.
-        BindRenderTarget(context, swapChain,
-                         perPassResourceSignature.GetPostProcessColorSinkBufferResource(),
-                         perPassResourceSignature.GetPostProcessDepthSinkBufferResource(),
-                         staticPass.colorRTIndex, staticPass.depthRTIndex);
-        ClearRenderTarget(context, swapChain,
-                          perPassResourceSignature.GetPostProcessColorSinkBufferResource(),
-                          perPassResourceSignature.GetPostProcessDepthSinkBufferResource(),
-                          staticPass.colorRTIndex, staticPass.depthRTIndex);
+        BindRenderTarget(context, swapChain, colorSinkBuffer, depthSinkBuffer, staticPass.colorRTIndex, staticPass.depthRTIndex, m_numSamples > 1);
+        ClearRenderTarget(context, swapChain, colorSinkBuffer, depthSinkBuffer, staticPass.colorRTIndex, staticPass.depthRTIndex, m_numSamples > 1);
 
         context.SetPipelineState(staticPass.pso);
         DrawIndexed(context, staticBatches);
@@ -229,10 +242,10 @@ void PassBackend::RenderWireframe(Diligent::IDeviceContext& context,
         return;
     }
 
-    BindRenderTarget(context, swapChain,
-                     perPassResourceSignature.GetPostProcessColorSinkBufferResource(),
-                     perPassResourceSignature.GetPostProcessDepthSinkBufferResource(),
-                     m_wireframePass->colorRTIndex, m_wireframePass->depthRTIndex);
+    auto& colorSinkBuffer = perPassResourceSignature.GetPostProcessColorSinkBufferResource();
+    auto& depthSinkBuffer = perPassResourceSignature.GetPostProcessDepthSinkBufferResource();
+
+    BindRenderTarget(context, swapChain, colorSinkBuffer, depthSinkBuffer, m_wireframePass->colorRTIndex, m_wireframePass->depthRTIndex, m_numSamples > 1);
     context.SetPipelineState(m_wireframePass->pso);
 
     for (const auto& [data, mesh] : state.wireframeData)
@@ -260,22 +273,32 @@ void PassBackend::RenderPostProcess(Diligent::IDeviceContext& context,
     NC_PROFILE_SCOPE("PassBackend::RenderPostProcess()", ProfileCategory::Rendering);
     constexpr auto drawAttribs = Diligent::DrawAttribs{4, Diligent::DRAW_FLAG_VERIFY_ALL};
     auto& propertyBuffer = perFrameResourceSignature.GetPostProcessPropertyBuffer();
+    auto& colorSinkBuffer = perPassResourceSignature.GetPostProcessColorSinkBufferResource();
+    auto& depthSinkBuffer = perPassResourceSignature.GetPostProcessDepthSinkBufferResource();
+    auto& sinkIndexBuffer = perPassResourceSignature.GetPostProcessSinkIndexBufferResource();
+
+    // If MSAA samples are set to be greater than 1 in the config, all PassType::Material, PassType::SkinnedMaterial and PassType::Misc passes are multisampled.
+    // These need to be resolved before used by the post process passes.
+    if (m_numSamples > 1)
+    {
+        for (auto i = 0u; i < m_colorSinkCountMsaa; i++)
+        {
+            Diligent::ResolveTextureSubresourceAttribs resolveAttribs;
+            resolveAttribs.SrcTextureTransitionMode = Diligent::RESOURCE_STATE_TRANSITION_MODE_TRANSITION;
+            resolveAttribs.DstTextureTransitionMode = Diligent::RESOURCE_STATE_TRANSITION_MODE_TRANSITION;
+            context.ResolveTextureSubresource(colorSinkBuffer.GetMsaaTexture(i), colorSinkBuffer.GetTexture(i), resolveAttribs);
+        }
+    }
 
     for (auto& pass : m_postProcessPasses)
     {
         if (!pass.anyEnabled) continue;
 
-        BindRenderTarget(context, swapChain,
-                         perPassResourceSignature.GetPostProcessColorSinkBufferResource(),
-                         perPassResourceSignature.GetPostProcessDepthSinkBufferResource(),
-                         pass.passDesc.colorSink, pass.passDesc.depthSink);
-        ClearRenderTarget(context, swapChain,
-                          perPassResourceSignature.GetPostProcessColorSinkBufferResource(),
-                          perPassResourceSignature.GetPostProcessDepthSinkBufferResource(),
-                          pass.passDesc.colorSink, pass.passDesc.depthSink);
+        BindRenderTarget(context, swapChain, colorSinkBuffer, depthSinkBuffer, pass.passDesc.colorSink, pass.passDesc.depthSink, false);
+        ClearRenderTarget(context, swapChain, colorSinkBuffer, depthSinkBuffer, pass.passDesc.colorSink, pass.passDesc.depthSink, false);
 
         context.SetPipelineState(pass.pso);
-        perPassResourceSignature.GetPostProcessSinkIndexBufferResource().Update(context, pass.passDesc.colorSources, pass.passDesc.depthSources);
+        sinkIndexBuffer.Update(context, pass.passDesc.colorSources, pass.passDesc.depthSources);
 
         for (auto& instance : pass.instances)
         {
@@ -290,17 +313,11 @@ void PassBackend::RenderPostProcess(Diligent::IDeviceContext& context,
     }
 
     // Render final post process pass
-    BindRenderTarget(context, swapChain,
-                     perPassResourceSignature.GetPostProcessColorSinkBufferResource(),
-                     perPassResourceSignature.GetPostProcessDepthSinkBufferResource(),
-                     m_finalPass->passDesc.colorSink,  m_finalPass->passDesc.depthSink);
-    ClearRenderTarget(context, swapChain,
-                      perPassResourceSignature.GetPostProcessColorSinkBufferResource(),
-                      perPassResourceSignature.GetPostProcessDepthSinkBufferResource(),
-                      m_finalPass->passDesc.colorSink, m_finalPass->passDesc.depthSink);
+    BindRenderTarget(context, swapChain, colorSinkBuffer, depthSinkBuffer, m_finalPass->passDesc.colorSink, m_finalPass->passDesc.depthSink, false);
+    ClearRenderTarget(context, swapChain, colorSinkBuffer, depthSinkBuffer, m_finalPass->passDesc.colorSink, m_finalPass->passDesc.depthSink, false);
 
     context.SetPipelineState(m_finalPass->pso);
-    perPassResourceSignature.GetPostProcessSinkIndexBufferResource().Update(context, SingleSource(FinalColorTarget()), NoTargets());
+    sinkIndexBuffer.Update(context, SingleSource(FinalColorTarget()), NoTargets());
     context.Draw(drawAttribs);
     context.TransitionShaderResources(&perPassResourceSignature.GetResourceBinding());
 }

--- a/source/ncengine/graphics2/diligent/pass/PassBackend.h
+++ b/source/ncengine/graphics2/diligent/pass/PassBackend.h
@@ -25,7 +25,8 @@ class PassBackend
                              Diligent::ISwapChain& swapChain,
                              ShaderFactory& shaderFactory,
                              ShaderBindings& shaderBindings,
-                             const PassManifest& passManifest);
+                             const PassManifest& passManifest,
+                             uint32_t numSamples = 1u);
 
         void Update(const PostProcessState& postProcessState);
 
@@ -53,5 +54,8 @@ class PassBackend
         std::unique_ptr<WireframePass> m_wireframePass;
         std::vector<PostProcessPass> m_postProcessPasses;
         std::unique_ptr<PostProcessPass> m_finalPass;
+        uint32_t m_numSamples;
+        uint32_t m_colorSinkCountMsaa;
+        uint32_t m_depthSinkCountMsaa;
 };
 } // namespace nc::graphics

--- a/source/ncengine/graphics2/diligent/pass/PassManifest.cpp
+++ b/source/ncengine/graphics2/diligent/pass/PassManifest.cpp
@@ -82,32 +82,20 @@ void PassManifest::RegisterPass(PassDesc desc)
         throw nc::NcError("The pass was already registered");
     }
 
-    if (desc.colorSink != NoTarget && desc.colorSink != SwapChainColorRTIndex)
-        m_colorSinkCount = std::max(m_colorSinkCount, desc.colorSink + 1);
-    if (desc.depthSink != NoTarget && desc.depthSink != SwapChainDepthRTIndex)
-        m_depthSinkCount = std::max(m_depthSinkCount, desc.depthSink + 1);
+    SetMaxIndices(desc.colorSink, desc.depthSink, false);
 
     switch (desc.type)
     {
         case PassType::Material:
-            if (desc.colorSink != NoTarget && desc.colorSink != SwapChainColorRTIndex)
-                m_colorSinkCountMsaa = std::max(m_colorSinkCountMsaa, desc.colorSink + 1);
-            if (desc.depthSink != NoTarget && desc.depthSink != SwapChainDepthRTIndex)
-                m_depthSinkCountMsaa = std::max(m_depthSinkCountMsaa, desc.depthSink + 1);
+            SetMaxIndices(desc.colorSink, desc.depthSink, true);
             m_staticMaterialPassDescs.emplace_back(std::move(desc));
             break;
         case PassType::SkinnedMaterial:
-            if (desc.colorSink != NoTarget && desc.colorSink != SwapChainColorRTIndex)
-                m_colorSinkCountMsaa = std::max(m_colorSinkCountMsaa, desc.colorSink + 1);
-            if (desc.depthSink != NoTarget && desc.depthSink != SwapChainDepthRTIndex)
-                m_depthSinkCountMsaa = std::max(m_depthSinkCountMsaa, desc.depthSink + 1);
+            SetMaxIndices(desc.colorSink, desc.depthSink, true);
             m_skinnedMaterialPassDescs.emplace_back(std::move(desc));
             break;
         case PassType::Wireframe:
-            if (desc.colorSink != NoTarget && desc.colorSink != SwapChainColorRTIndex)
-                m_colorSinkCountMsaa = std::max(m_colorSinkCountMsaa, desc.colorSink + 1);
-            if (desc.depthSink != NoTarget && desc.depthSink != SwapChainDepthRTIndex)
-                m_depthSinkCountMsaa = std::max(m_depthSinkCountMsaa, desc.depthSink + 1);
+            SetMaxIndices(desc.colorSink, desc.depthSink, true);
             m_wireframePassDesc = std::move(desc);
             break;
         case PassType::PostProcess:
@@ -131,5 +119,20 @@ void PassManifest::Clear()
     m_colorSinkCount = 0u;
     m_depthSinkCountMsaa = 0u;
     m_depthSinkCount = 0u;
+}
+
+void PassManifest::SetMaxIndices(uint32_t colorRT, uint32_t depthRT, bool isMsaa)
+{
+    auto& colorToModify = isMsaa ? m_colorSinkCountMsaa : m_colorSinkCount;
+    auto& depthToModify = isMsaa ? m_depthSinkCountMsaa : m_depthSinkCount;
+
+    if (colorRT != NoTarget && colorRT != SwapChainColorRTIndex)
+    {
+        colorToModify = std::max(colorToModify, colorRT + 1);
+    }
+    if (depthRT != NoTarget && depthRT != SwapChainDepthRTIndex)
+    {
+        depthToModify = std::max(depthToModify, depthRT + 1);
+    }
 }
 } // namespace nc::graphics

--- a/source/ncengine/graphics2/diligent/pass/PassManifest.cpp
+++ b/source/ncengine/graphics2/diligent/pass/PassManifest.cpp
@@ -32,10 +32,10 @@ PassManifest::PassManifest(std::vector<PassDesc> passes,
                            std::span<const MaterialPassFlag::type> implementedMaterialPasses,
                            std::span<const PostProcessPassFlag::type> implementedPPPasses,
                            std::span<const MiscPassFlag::type> implementedMiscPasses)
-    : m_colorSinkCount{0u},
-      m_colorSinkCountMsaa{0u},
-      m_depthSinkCount{0u},
-      m_depthSinkCountMsaa{0u}
+    : m_colorSinkCountMsaa{0u},
+      m_colorSinkCount{0u},
+      m_depthSinkCountMsaa{0u},
+      m_depthSinkCount{0u}
 {
     auto registerMatches = [this](const auto& descs, const auto& passFlags, auto matchType)
     {

--- a/source/ncengine/graphics2/diligent/pass/PassManifest.cpp
+++ b/source/ncengine/graphics2/diligent/pass/PassManifest.cpp
@@ -33,7 +33,9 @@ PassManifest::PassManifest(std::vector<PassDesc> passes,
                            std::span<const PostProcessPassFlag::type> implementedPPPasses,
                            std::span<const MiscPassFlag::type> implementedMiscPasses)
     : m_colorSinkCount{0u},
-      m_depthSinkCount{0u}
+      m_colorSinkCountMsaa{0u},
+      m_depthSinkCount{0u},
+      m_depthSinkCountMsaa{0u}
 {
     auto registerMatches = [this](const auto& descs, const auto& passFlags, auto matchType)
     {
@@ -80,15 +82,32 @@ void PassManifest::RegisterPass(PassDesc desc)
         throw nc::NcError("The pass was already registered");
     }
 
+    if (desc.colorSink != NoTarget && desc.colorSink != SwapChainColorRTIndex)
+        m_colorSinkCount = std::max(m_colorSinkCount, desc.colorSink + 1);
+    if (desc.depthSink != NoTarget && desc.depthSink != SwapChainDepthRTIndex)
+        m_depthSinkCount = std::max(m_depthSinkCount, desc.depthSink + 1);
+
     switch (desc.type)
     {
         case PassType::Material:
+            if (desc.colorSink != NoTarget && desc.colorSink != SwapChainColorRTIndex)
+                m_colorSinkCountMsaa = std::max(m_colorSinkCountMsaa, desc.colorSink + 1);
+            if (desc.depthSink != NoTarget && desc.depthSink != SwapChainDepthRTIndex)
+                m_depthSinkCountMsaa = std::max(m_depthSinkCountMsaa, desc.depthSink + 1);
             m_staticMaterialPassDescs.emplace_back(std::move(desc));
             break;
         case PassType::SkinnedMaterial:
+            if (desc.colorSink != NoTarget && desc.colorSink != SwapChainColorRTIndex)
+                m_colorSinkCountMsaa = std::max(m_colorSinkCountMsaa, desc.colorSink + 1);
+            if (desc.depthSink != NoTarget && desc.depthSink != SwapChainDepthRTIndex)
+                m_depthSinkCountMsaa = std::max(m_depthSinkCountMsaa, desc.depthSink + 1);
             m_skinnedMaterialPassDescs.emplace_back(std::move(desc));
             break;
         case PassType::Wireframe:
+            if (desc.colorSink != NoTarget && desc.colorSink != SwapChainColorRTIndex)
+                m_colorSinkCountMsaa = std::max(m_colorSinkCountMsaa, desc.colorSink + 1);
+            if (desc.depthSink != NoTarget && desc.depthSink != SwapChainDepthRTIndex)
+                m_depthSinkCountMsaa = std::max(m_depthSinkCountMsaa, desc.depthSink + 1);
             m_wireframePassDesc = std::move(desc);
             break;
         case PassType::PostProcess:
@@ -96,15 +115,6 @@ void PassManifest::RegisterPass(PassDesc desc)
             break;
         case PassType::None:
             throw nc::NcError("Pass type not implemented.");
-    }
-
-    if (desc.colorSink != NoTarget && desc.colorSink != SwapChainColorRTIndex)
-    {
-        m_colorSinkCount = std::max(m_colorSinkCount, desc.colorSink + 1);
-    }
-    if (desc.depthSink != NoTarget && desc.depthSink != SwapChainDepthRTIndex)
-    {
-        m_depthSinkCount = std::max(m_depthSinkCount, desc.depthSink + 1);
     }
 }
 
@@ -117,5 +127,9 @@ void PassManifest::Clear()
     m_postProcessPassDescs.clear();
     m_postProcessPassDescs.shrink_to_fit();
     m_wireframePassDesc = PassDesc{};
+    m_colorSinkCountMsaa = 0u;
+    m_colorSinkCount = 0u;
+    m_depthSinkCountMsaa = 0u;
+    m_depthSinkCount = 0u;
 }
 } // namespace nc::graphics

--- a/source/ncengine/graphics2/diligent/pass/PassManifest.h
+++ b/source/ncengine/graphics2/diligent/pass/PassManifest.h
@@ -22,7 +22,9 @@ class PassManifest
         auto SkinnedMaterialPassDescs() const -> std::span<const PassDesc> { return m_skinnedMaterialPassDescs; }
         auto PostProcessPassDescs() const -> std::span<const PassDesc> { return m_postProcessPassDescs; }
         auto WireframePassDesc() const -> const PassDesc& { return m_wireframePassDesc; }
+        auto ColorSinkCountMsaa() const -> uint32_t { return m_colorSinkCountMsaa; }
         auto ColorSinkCount() const -> uint32_t { return m_colorSinkCount; }
+        auto DepthSinkCountMsaa() const -> uint32_t  { return m_depthSinkCountMsaa; }
         auto DepthSinkCount() const -> uint32_t  { return m_depthSinkCount; }
         void Clear();
 
@@ -32,7 +34,9 @@ class PassManifest
         std::vector<PassDesc> m_skinnedMaterialPassDescs;
         std::vector<PassDesc> m_postProcessPassDescs;
         PassDesc m_wireframePassDesc;
+        uint32_t m_colorSinkCountMsaa;
         uint32_t m_colorSinkCount;
+        uint32_t m_depthSinkCountMsaa;
         uint32_t m_depthSinkCount;
 };
 } // namespace nc::graphics

--- a/source/ncengine/graphics2/diligent/pass/PassManifest.h
+++ b/source/ncengine/graphics2/diligent/pass/PassManifest.h
@@ -29,6 +29,7 @@ class PassManifest
         void Clear();
 
     private:
+        void SetMaxIndices(uint32_t colorRT, uint32_t depthRT, bool isMsaa);
         std::vector<size_t> m_ids;
         std::vector<PassDesc> m_staticMaterialPassDescs;
         std::vector<PassDesc> m_skinnedMaterialPassDescs;

--- a/source/ncengine/graphics2/diligent/pass/PassTypes.h
+++ b/source/ncengine/graphics2/diligent/pass/PassTypes.h
@@ -14,11 +14,22 @@ constexpr auto SwapChainColorRTIndex = std::numeric_limits<uint32_t>::max();
 constexpr auto SwapChainDepthRTIndex = std::numeric_limits<uint32_t>::max();
 constexpr auto OffScreenColorRTFormat = Diligent::TEX_FORMAT_RGBA8_UNORM;
 constexpr auto OffScreenDepthRTFormat = Diligent::TEX_FORMAT_D32_FLOAT;
+
+/* MSAA Color Target Indices */
+constexpr auto MainColorMsaa = 0u;
+constexpr auto NormalsColorMsaa = 1u;
+
+/* Color Target Indices */
 constexpr auto MainColor = 0u;
-constexpr auto MainDepth = 0u;
 constexpr auto NormalsColor = 1u;
 constexpr auto PPWaveColor = 2u;
 constexpr auto PPOutlineColor = 3u;
+
+/* MSAA Depth Target Indices */
+constexpr auto MainDepthMsaa = 0u;
+
+/* Depth Target Indices */
+constexpr auto MainDepth = 0u;
 
 struct ShaderPaths
 {

--- a/source/ncengine/graphics2/diligent/pass/PassUtilities.cpp
+++ b/source/ncengine/graphics2/diligent/pass/PassUtilities.cpp
@@ -47,7 +47,8 @@ void ClearRenderTarget(Diligent::IDeviceContext& context,
                        nc::graphics::PostProcessColorSinkBufferResource& postProcessColorSinkBufferResource,
                        nc::graphics::PostProcessDepthSinkBufferResource& postProcessDepthSinkBufferResource,
                        uint32_t colorRenderTargetIndex,
-                       uint32_t depthRenderTargetIndex)
+                       uint32_t depthRenderTargetIndex,
+                       bool isMsaa)
 {
     Diligent::ITextureView* pRTV = nullptr;
     Diligent::ITextureView* pDSV = nullptr;
@@ -60,7 +61,8 @@ void ClearRenderTarget(Diligent::IDeviceContext& context,
         }
         else
         {
-            pRTV = static_cast<Diligent::ITextureView*>(postProcessColorSinkBufferResource.GetColorRenderTarget(colorRenderTargetIndex));
+            pRTV = isMsaa ? static_cast<Diligent::ITextureView*>(postProcessColorSinkBufferResource.GetMsaaSrv(colorRenderTargetIndex)) :
+                            static_cast<Diligent::ITextureView*>(postProcessColorSinkBufferResource.GetSrv(colorRenderTargetIndex));
         }
     }
 
@@ -72,7 +74,8 @@ void ClearRenderTarget(Diligent::IDeviceContext& context,
         }
         else
         {
-            pDSV = static_cast<Diligent::ITextureView*>(postProcessDepthSinkBufferResource.GetDepthRenderTarget(depthRenderTargetIndex));
+            pDSV = isMsaa ? static_cast<Diligent::ITextureView*>(postProcessDepthSinkBufferResource.GetMsaaDSV(depthRenderTargetIndex)) :
+                            static_cast<Diligent::ITextureView*>(postProcessDepthSinkBufferResource.GetDSV(depthRenderTargetIndex));
         }
     }
 
@@ -94,7 +97,8 @@ void BindRenderTarget(Diligent::IDeviceContext& context,
                       nc::graphics::PostProcessColorSinkBufferResource& postProcessColorSinkBufferResource,
                       nc::graphics::PostProcessDepthSinkBufferResource& postProcessDepthSinkBufferResource,
                       uint32_t colorRenderTargetIndex,
-                      uint32_t depthRenderTargetIndex)
+                      uint32_t depthRenderTargetIndex,
+                      bool isMsaa)
 {
     Diligent::ITextureView* pRTV = nullptr;
     Diligent::ITextureView* pDSV = nullptr;
@@ -107,7 +111,8 @@ void BindRenderTarget(Diligent::IDeviceContext& context,
         }
         else
         {
-            pRTV = static_cast<Diligent::ITextureView*>(postProcessColorSinkBufferResource.GetColorRenderTarget(colorRenderTargetIndex));
+            pRTV = isMsaa ? static_cast<Diligent::ITextureView*>(postProcessColorSinkBufferResource.GetMsaaSrv(colorRenderTargetIndex)) :
+                            static_cast<Diligent::ITextureView*>(postProcessColorSinkBufferResource.GetSrv(colorRenderTargetIndex));
         }
     }
 
@@ -119,7 +124,8 @@ void BindRenderTarget(Diligent::IDeviceContext& context,
         }
         else
         {
-            pDSV = static_cast<Diligent::ITextureView*>(postProcessDepthSinkBufferResource.GetDepthRenderTarget(depthRenderTargetIndex));
+            pDSV = isMsaa ? static_cast<Diligent::ITextureView*>(postProcessDepthSinkBufferResource.GetMsaaDSV(depthRenderTargetIndex)) :
+                            static_cast<Diligent::ITextureView*>(postProcessDepthSinkBufferResource.GetDSV(depthRenderTargetIndex));
         }
     }
 

--- a/source/ncengine/graphics2/diligent/pass/PassUtilities.h
+++ b/source/ncengine/graphics2/diligent/pass/PassUtilities.h
@@ -27,11 +27,13 @@ void ClearRenderTarget(Diligent::IDeviceContext& context,
                        nc::graphics::PostProcessColorSinkBufferResource& postProcessSinkBufferResource,
                        nc::graphics::PostProcessDepthSinkBufferResource& postProcessDepthSinkBufferResource,
                        uint32_t colorRenderTargetIndex,
-                       uint32_t depthRenderTargetIndex);
+                       uint32_t depthRenderTargetIndex,
+                       bool isMsaa);
 void BindRenderTarget(Diligent::IDeviceContext& context,
                       Diligent::ISwapChain& swapChain,
                       nc::graphics::PostProcessColorSinkBufferResource& postProcessColorSinkBufferResource,
                       nc::graphics::PostProcessDepthSinkBufferResource& postProcessDepthSinkBufferResource,
                       uint32_t colorRenderTargetIndex,
-                      uint32_t depthRenderTargetIndex);
+                      uint32_t depthRenderTargetIndex,
+                      bool isMsaa);
 } // namespace nc::graphics

--- a/source/ncengine/graphics2/diligent/pass/WireframePass.cpp
+++ b/source/ncengine/graphics2/diligent/pass/WireframePass.cpp
@@ -15,7 +15,8 @@ namespace
 auto MakePso(Diligent::IRenderDevice& device,
              nc::graphics::ShaderFactory& shaderFactory,
              Diligent::IPipelineResourceSignature& perFrameResourceSignature,
-             const nc::graphics::PassDesc& passDesc)
+             const nc::graphics::PassDesc& passDesc,
+             uint32_t numSamples)
 {
     using namespace Diligent;
 
@@ -58,6 +59,7 @@ auto MakePso(Diligent::IRenderDevice& device,
     ci.GraphicsPipeline.InputLayout.LayoutElements   = layoutElements.data();
     ci.GraphicsPipeline.InputLayout.NumElements      = static_cast<uint32_t>(layoutElements.size());
     ci.GraphicsPipeline.RasterizerDesc.FillMode      = FILL_MODE_WIREFRAME;
+    ci.GraphicsPipeline.SmplDesc.Count               = static_cast<uint8_t>(numSamples);
 
     auto pso = RefCntAutoPtr<IPipelineState>{};
     device.CreateGraphicsPipelineState(ci, &pso);
@@ -75,8 +77,9 @@ namespace nc::graphics
 WireframePass::WireframePass(Diligent::IRenderDevice& device,
                              ShaderFactory& shaderFactory,
                              ShaderBindings& shaderBindings,
-                             const PassDesc& passDesc)
-    : pso{MakePso(device, shaderFactory, shaderBindings.GetPerFrameSignature().GetResourceSignature(), passDesc)},
+                             const PassDesc& passDesc,
+                             uint32_t numSamples)
+    : pso{MakePso(device, shaderFactory, shaderBindings.GetPerFrameSignature().GetResourceSignature(), passDesc, numSamples)},
       buffer{&shaderBindings.GetPerFrameSignature().GetWireframeBuffer()},
       colorRTIndex{passDesc.colorSink},
       depthRTIndex{passDesc.depthSink}

--- a/source/ncengine/graphics2/diligent/pass/WireframePass.h
+++ b/source/ncengine/graphics2/diligent/pass/WireframePass.h
@@ -18,7 +18,8 @@ struct WireframePass
     explicit WireframePass(Diligent::IRenderDevice& device,
                             ShaderFactory& shaderFactory,
                             ShaderBindings& shaderBindings,
-                            const PassDesc& passDesc);
+                            const PassDesc& passDesc,
+                            uint32_t numSamples = 1u);
     Diligent::RefCntAutoPtr<Diligent::IPipelineState> pso;
     WireframeBufferResource* buffer;
     uint32_t colorRTIndex;

--- a/source/ncengine/graphics2/diligent/resource/PostProcessColorSinkBufferResource.cpp
+++ b/source/ncengine/graphics2/diligent/resource/PostProcessColorSinkBufferResource.cpp
@@ -17,9 +17,10 @@ auto PostProcessColorSinkBufferResource::MakeSamplerDesc(std::string_view variab
 }
 
 auto PostProcessColorSinkBufferResource::Add(Diligent::IRenderDevice& device,
-                                    uint32_t numColorRenderTargets,
-                                    uint32_t renderTargetWidth,
-                                    uint32_t renderTargetHeight) -> std::vector<uint32_t>
+                                             uint32_t numColorRenderTargets,
+                                             uint32_t renderTargetWidth,
+                                             uint32_t renderTargetHeight,
+                                             uint32_t numSamples) -> std::vector<uint32_t>
 {
     using namespace Diligent;
 
@@ -31,14 +32,26 @@ auto PostProcessColorSinkBufferResource::Add(Diligent::IRenderDevice& device,
         return addedIndices;
     }
 
-    if (numColorRenderTargets + m_colorRenderTargets.size() > m_maxTextures)
+    if (numSamples > 1)
     {
-        throw NcError{"Max texture count exceeded"};
+        if (numColorRenderTargets + m_colorRenderTargetsMsaa.size() > m_maxTextures)
+        {
+            throw NcError{"Max texture count exceeded"};
+        }
+        m_colorRenderTargetsMsaa.reserve(m_colorRenderTargetsMsaa.size() + numColorRenderTargets);
+        m_colorRenderTargetViewsRTMsaa.reserve(m_colorRenderTargetViewsRTMsaa.size() + numColorRenderTargets);
+        m_colorRenderTargetViewsSRMsaa.reserve(m_colorRenderTargetViewsSRMsaa.size() + numColorRenderTargets);
     }
-
-    m_colorRenderTargets.reserve(m_colorRenderTargets.size() + numColorRenderTargets);
-    m_colorRenderTargetViewsRT.reserve(m_colorRenderTargetViewsRT.size() + numColorRenderTargets);
-    m_colorRenderTargetViewsSR.reserve(m_colorRenderTargetViewsSR.size() + numColorRenderTargets);
+    else
+    {
+        if (numColorRenderTargets + m_colorRenderTargets.size() > m_maxTextures)
+        {
+            throw NcError{"Max texture count exceeded"};
+        }
+        m_colorRenderTargets.reserve(m_colorRenderTargets.size() + numColorRenderTargets);
+        m_colorRenderTargetViewsRT.reserve(m_colorRenderTargetViewsRT.size() + numColorRenderTargets);
+        m_colorRenderTargetViewsSR.reserve(m_colorRenderTargetViewsSR.size() + numColorRenderTargets);
+    }
 
     for (auto i = 0u; i < numColorRenderTargets; i++)
     {
@@ -56,6 +69,7 @@ auto PostProcessColorSinkBufferResource::Add(Diligent::IRenderDevice& device,
         colorRenderTargetDesc.ClearValue.Color[1] = 0.350f;
         colorRenderTargetDesc.ClearValue.Color[2] = 0.350f;
         colorRenderTargetDesc.ClearValue.Color[3] = 1.0f;
+        colorRenderTargetDesc.SampleCount = numSamples;
 
         RefCntAutoPtr<ITexture> pColorRenderTarget;
         device.CreateTexture(colorRenderTargetDesc, nullptr, &pColorRenderTarget);
@@ -64,23 +78,46 @@ auto PostProcessColorSinkBufferResource::Add(Diligent::IRenderDevice& device,
             throw NcError("Failed to create texture");
         }
 
-        addedIndices.push_back(static_cast<uint32_t>(m_colorRenderTargets.size()));
-        m_colorRenderTargets.push_back(std::move(pColorRenderTarget));
-        m_colorRenderTargetViewsRT.push_back(m_colorRenderTargets.back()->GetDefaultView(TEXTURE_VIEW_RENDER_TARGET));
-        m_colorRenderTargetViewsSR.push_back(m_colorRenderTargets.back()->GetDefaultView(TEXTURE_VIEW_SHADER_RESOURCE));
+        if (numSamples > 1)
+        {
+            addedIndices.push_back(static_cast<uint32_t>(m_colorRenderTargetsMsaa.size()));
+            m_colorRenderTargetsMsaa.push_back(std::move(pColorRenderTarget));
+            m_colorRenderTargetViewsRTMsaa.push_back(m_colorRenderTargetsMsaa.back()->GetDefaultView(TEXTURE_VIEW_RENDER_TARGET));
+            m_colorRenderTargetViewsSRMsaa.push_back(m_colorRenderTargetsMsaa.back()->GetDefaultView(TEXTURE_VIEW_SHADER_RESOURCE));
+        }
+        else
+        {
+            addedIndices.push_back(static_cast<uint32_t>(m_colorRenderTargets.size()));
+            m_colorRenderTargets.push_back(std::move(pColorRenderTarget));
+            m_colorRenderTargetViewsRT.push_back(m_colorRenderTargets.back()->GetDefaultView(TEXTURE_VIEW_RENDER_TARGET));
+            m_colorRenderTargetViewsSR.push_back(m_colorRenderTargets.back()->GetDefaultView(TEXTURE_VIEW_SHADER_RESOURCE));
+        }
     }
 
-    SetArrayRegion(m_colorRenderTargetViewsSR, 0u, m_colorRenderTargetViewsSR.size());
+    if (numSamples > 1)
+    {
+        SetArrayRegion(m_colorRenderTargetViewsSRMsaa, m_colorRenderTargetViewsSR.size(), m_colorRenderTargetViewsSRMsaa.size());
+    }
+    else
+    {
+        SetArrayRegion(m_colorRenderTargetViewsSR, 0u, m_colorRenderTargetViewsSR.size());
+    }
     return addedIndices;
 }
 
 void PostProcessColorSinkBufferResource::Resize(Diligent::IRenderDevice& device,
                                        uint32_t renderTargetWidth,
-                                       uint32_t renderTargetHeight)
+                                       uint32_t renderTargetHeight,
+                                       uint32_t numSamples)
 {
     auto numColorRenderTargets = static_cast<uint32_t>(m_colorRenderTargets.size());
+    auto numColorRenderTargetsMsaa = static_cast<uint32_t>(m_colorRenderTargetsMsaa.size());
     Clear();
-    Add(device, numColorRenderTargets, renderTargetWidth, renderTargetHeight);
+    Add(device, numColorRenderTargets, renderTargetWidth, renderTargetHeight, 1);
+    if (numSamples > 1)
+    {
+        Add(device, numColorRenderTargetsMsaa, renderTargetWidth, renderTargetHeight, numSamples);
+    }
 }
 
 void PostProcessColorSinkBufferResource::Clear()
@@ -91,12 +128,19 @@ void PostProcessColorSinkBufferResource::Clear()
     m_colorRenderTargetViewsRT.shrink_to_fit();
     m_colorRenderTargetViewsSR.clear();
     m_colorRenderTargetViewsSR.shrink_to_fit();
+
+    m_colorRenderTargetsMsaa.clear();
+    m_colorRenderTargetsMsaa.shrink_to_fit();
+    m_colorRenderTargetViewsRTMsaa.clear();
+    m_colorRenderTargetViewsRTMsaa.shrink_to_fit();
+    m_colorRenderTargetViewsSRMsaa.clear();
+    m_colorRenderTargetViewsSRMsaa.shrink_to_fit();
 }
 
 void PostProcessColorSinkBufferResource::SetArrayRegion(const std::vector<Diligent::IDeviceObject*>& views, size_t offset, size_t count)
 {
     m_variable->SetArray(
-        views.data() + offset,
+        views.data(),
         static_cast<uint32_t>(offset),
         static_cast<uint32_t>(count),
         Diligent::SET_SHADER_RESOURCE_FLAG_ALLOW_OVERWRITE

--- a/source/ncengine/graphics2/diligent/resource/PostProcessColorSinkBufferResource.cpp
+++ b/source/ncengine/graphics2/diligent/resource/PostProcessColorSinkBufferResource.cpp
@@ -1,9 +1,9 @@
 #include "PostProcessColorSinkBufferResource.h"
+
 #include "ncengine/asset/AssetData.h"
 
 #include "TextureLoader.h"
 #include "ncutility/NcError.h"
-#include "fmt/format.h"
 
 namespace nc::graphics
 {
@@ -40,7 +40,6 @@ auto PostProcessColorSinkBufferResource::Add(Diligent::IRenderDevice& device,
         }
         m_colorRenderTargetsMsaa.reserve(m_colorRenderTargetsMsaa.size() + numColorRenderTargets);
         m_colorRenderTargetViewsRTMsaa.reserve(m_colorRenderTargetViewsRTMsaa.size() + numColorRenderTargets);
-        m_colorRenderTargetViewsSRMsaa.reserve(m_colorRenderTargetViewsSRMsaa.size() + numColorRenderTargets);
     }
     else
     {
@@ -83,7 +82,6 @@ auto PostProcessColorSinkBufferResource::Add(Diligent::IRenderDevice& device,
             addedIndices.push_back(static_cast<uint32_t>(m_colorRenderTargetsMsaa.size()));
             m_colorRenderTargetsMsaa.push_back(std::move(pColorRenderTarget));
             m_colorRenderTargetViewsRTMsaa.push_back(m_colorRenderTargetsMsaa.back()->GetDefaultView(TEXTURE_VIEW_RENDER_TARGET));
-            m_colorRenderTargetViewsSRMsaa.push_back(m_colorRenderTargetsMsaa.back()->GetDefaultView(TEXTURE_VIEW_SHADER_RESOURCE));
         }
         else
         {
@@ -94,14 +92,7 @@ auto PostProcessColorSinkBufferResource::Add(Diligent::IRenderDevice& device,
         }
     }
 
-    if (numSamples > 1)
-    {
-        SetArrayRegion(m_colorRenderTargetViewsSRMsaa, m_colorRenderTargetViewsSR.size(), m_colorRenderTargetViewsSRMsaa.size());
-    }
-    else
-    {
-        SetArrayRegion(m_colorRenderTargetViewsSR, 0u, m_colorRenderTargetViewsSR.size());
-    }
+    SetArrayRegion(m_colorRenderTargetViewsSR, 0u, m_colorRenderTargetViewsSR.size());
     return addedIndices;
 }
 
@@ -123,18 +114,11 @@ void PostProcessColorSinkBufferResource::Resize(Diligent::IRenderDevice& device,
 void PostProcessColorSinkBufferResource::Clear()
 {
     m_colorRenderTargets.clear();
-    m_colorRenderTargets.shrink_to_fit();
     m_colorRenderTargetViewsRT.clear();
-    m_colorRenderTargetViewsRT.shrink_to_fit();
     m_colorRenderTargetViewsSR.clear();
-    m_colorRenderTargetViewsSR.shrink_to_fit();
 
     m_colorRenderTargetsMsaa.clear();
-    m_colorRenderTargetsMsaa.shrink_to_fit();
     m_colorRenderTargetViewsRTMsaa.clear();
-    m_colorRenderTargetViewsRTMsaa.shrink_to_fit();
-    m_colorRenderTargetViewsSRMsaa.clear();
-    m_colorRenderTargetViewsSRMsaa.shrink_to_fit();
 }
 
 void PostProcessColorSinkBufferResource::SetArrayRegion(const std::vector<Diligent::IDeviceObject*>& views, size_t offset, size_t count)

--- a/source/ncengine/graphics2/diligent/resource/PostProcessColorSinkBufferResource.h
+++ b/source/ncengine/graphics2/diligent/resource/PostProcessColorSinkBufferResource.h
@@ -22,19 +22,27 @@ class PostProcessColorSinkBufferResource
         auto Add(Diligent::IRenderDevice& device,
                  uint32_t numColorRenderTargets,
                  uint32_t renderTargetWidth,
-                 uint32_t renderTargetHeight) -> std::vector<uint32_t>;
+                 uint32_t renderTargetHeight,
+                 uint32_t numSamples = 1u) -> std::vector<uint32_t>;
 
         void Resize(Diligent::IRenderDevice& device,
                     uint32_t renderTargetWidth,
-                    uint32_t renderTargetHeight);
+                    uint32_t renderTargetHeight,
+                    uint32_t numSamples = 1u);
 
         void Clear();
-        auto GetColorRenderTarget(uint32_t index) -> Diligent::IDeviceObject* { return m_colorRenderTargetViewsRT.at(index); }
+        auto GetMsaaSrv(uint32_t index) -> Diligent::IDeviceObject* { return m_colorRenderTargetViewsRTMsaa.at(index); }
+        auto GetSrv(uint32_t index) -> Diligent::IDeviceObject* { return m_colorRenderTargetViewsRT.at(index); }
+        auto GetMsaaTexture(uint32_t index) -> Diligent::ITexture* { return m_colorRenderTargetsMsaa.at(index); }
+        auto GetTexture(uint32_t index) -> Diligent::ITexture* { return m_colorRenderTargets.at(index); }
 
     private:
         std::vector<Diligent::RefCntAutoPtr<Diligent::ITexture>> m_colorRenderTargets;
         std::vector<Diligent::IDeviceObject*> m_colorRenderTargetViewsSR; // Shader resource
         std::vector<Diligent::IDeviceObject*> m_colorRenderTargetViewsRT; // Render target
+        std::vector<Diligent::RefCntAutoPtr<Diligent::ITexture>> m_colorRenderTargetsMsaa;
+        std::vector<Diligent::IDeviceObject*> m_colorRenderTargetViewsSRMsaa; // Shader resource
+        std::vector<Diligent::IDeviceObject*> m_colorRenderTargetViewsRTMsaa; // Render target
         Diligent::IShaderResourceVariable* m_variable;
         uint32_t m_maxTextures;
 

--- a/source/ncengine/graphics2/diligent/resource/PostProcessColorSinkBufferResource.h
+++ b/source/ncengine/graphics2/diligent/resource/PostProcessColorSinkBufferResource.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #include "Common/interface/RefCntAutoPtr.hpp"
-#include "Graphics/GraphicsEngine/interface/RenderDevice.h"
 #include "Graphics/GraphicsEngine/interface/DeviceContext.h"
+#include "Graphics/GraphicsEngine/interface/RenderDevice.h"
 
 #include <vector>
 
@@ -41,7 +41,6 @@ class PostProcessColorSinkBufferResource
         std::vector<Diligent::IDeviceObject*> m_colorRenderTargetViewsSR; // Shader resource
         std::vector<Diligent::IDeviceObject*> m_colorRenderTargetViewsRT; // Render target
         std::vector<Diligent::RefCntAutoPtr<Diligent::ITexture>> m_colorRenderTargetsMsaa;
-        std::vector<Diligent::IDeviceObject*> m_colorRenderTargetViewsSRMsaa; // Shader resource
         std::vector<Diligent::IDeviceObject*> m_colorRenderTargetViewsRTMsaa; // Render target
         Diligent::IShaderResourceVariable* m_variable;
         uint32_t m_maxTextures;

--- a/source/ncengine/graphics2/diligent/resource/PostProcessDepthSinkBufferResource.cpp
+++ b/source/ncengine/graphics2/diligent/resource/PostProcessDepthSinkBufferResource.cpp
@@ -10,7 +10,8 @@ namespace nc::graphics
 auto PostProcessDepthSinkBufferResource::Add(Diligent::IRenderDevice& device,
                                              uint32_t numDepthRenderTargets,
                                              uint32_t renderTargetWidth,
-                                             uint32_t renderTargetHeight) -> std::vector<uint32_t>
+                                             uint32_t renderTargetHeight,
+                                             uint32_t numSamples) -> std::vector<uint32_t>
 {
     using namespace Diligent;
 
@@ -27,9 +28,26 @@ auto PostProcessDepthSinkBufferResource::Add(Diligent::IRenderDevice& device,
         throw NcError{"Max texture count exceeded"};
     }
 
-    m_depthRenderTargets.reserve(m_depthRenderTargets.size() + numDepthRenderTargets);
-    m_depthRenderTargetViewsRT.reserve(m_depthRenderTargetViewsRT.size() + numDepthRenderTargets);
-    m_depthRenderTargetViewsSR.reserve(m_depthRenderTargetViewsSR.size() + numDepthRenderTargets);
+    if (numSamples > 1)
+    {
+        if (numDepthRenderTargets + m_depthRenderTargetsMsaa.size() > m_maxTextures)
+        {
+            throw NcError{"Max texture count exceeded"};
+        }
+        m_depthRenderTargetsMsaa.reserve(m_depthRenderTargetsMsaa.size() + numDepthRenderTargets);
+        m_depthRenderTargetViewsRTMsaa.reserve(m_depthRenderTargetViewsRTMsaa.size() + numDepthRenderTargets);
+        m_depthRenderTargetViewsSRMsaa.reserve(m_depthRenderTargetViewsSRMsaa.size() + numDepthRenderTargets);
+    }
+    else
+    {
+        if (numDepthRenderTargets + m_depthRenderTargets.size() > m_maxTextures)
+        {
+            throw NcError{"Max texture count exceeded"};
+        }
+        m_depthRenderTargets.reserve(m_depthRenderTargets.size() + numDepthRenderTargets);
+        m_depthRenderTargetViewsRT.reserve(m_depthRenderTargetViewsRT.size() + numDepthRenderTargets);
+        m_depthRenderTargetViewsSR.reserve(m_depthRenderTargetViewsSR.size() + numDepthRenderTargets);
+    }
 
     for (auto i = 0u; i < numDepthRenderTargets; i++)
     {
@@ -45,6 +63,7 @@ auto PostProcessDepthSinkBufferResource::Add(Diligent::IRenderDevice& device,
         depthRenderTargetDesc.ClearValue.Format = depthRenderTargetDesc.Format;
         depthRenderTargetDesc.ClearValue.DepthStencil.Depth = 1;
         depthRenderTargetDesc.ClearValue.DepthStencil.Stencil = 0;
+        depthRenderTargetDesc.SampleCount = numSamples;
 
         RefCntAutoPtr<ITexture> pDepthRenderTarget;
         device.CreateTexture(depthRenderTargetDesc, nullptr, &pDepthRenderTarget);
@@ -53,23 +72,46 @@ auto PostProcessDepthSinkBufferResource::Add(Diligent::IRenderDevice& device,
             throw NcError("Failed to create texture");
         }
 
-        addedIndices.push_back(static_cast<uint32_t>(m_depthRenderTargets.size()));
-        m_depthRenderTargets.push_back(std::move(pDepthRenderTarget));
-        m_depthRenderTargetViewsRT.push_back(m_depthRenderTargets.back()->GetDefaultView(TEXTURE_VIEW_DEPTH_STENCIL));
-        m_depthRenderTargetViewsSR.push_back(m_depthRenderTargets.back()->GetDefaultView(TEXTURE_VIEW_SHADER_RESOURCE));
+         if (numSamples > 1)
+        {
+            addedIndices.push_back(static_cast<uint32_t>(m_depthRenderTargetsMsaa.size()));
+            m_depthRenderTargetsMsaa.push_back(std::move(pDepthRenderTarget));
+            m_depthRenderTargetViewsRTMsaa.push_back(m_depthRenderTargetsMsaa.back()->GetDefaultView(TEXTURE_VIEW_DEPTH_STENCIL));
+            m_depthRenderTargetViewsSRMsaa.push_back(m_depthRenderTargetsMsaa.back()->GetDefaultView(TEXTURE_VIEW_SHADER_RESOURCE));
+        }
+        else
+        {
+            addedIndices.push_back(static_cast<uint32_t>(m_depthRenderTargets.size()));
+            m_depthRenderTargets.push_back(std::move(pDepthRenderTarget));
+            m_depthRenderTargetViewsRT.push_back(m_depthRenderTargets.back()->GetDefaultView(TEXTURE_VIEW_DEPTH_STENCIL));
+            m_depthRenderTargetViewsSR.push_back(m_depthRenderTargets.back()->GetDefaultView(TEXTURE_VIEW_SHADER_RESOURCE));
+        }
     }
 
-    SetArrayRegion(m_depthRenderTargetViewsSR, 0u, m_depthRenderTargetViewsSR.size());
+    if (numSamples > 1)
+    {
+        SetArrayRegion(m_depthRenderTargetViewsSRMsaa, m_depthRenderTargetViewsSR.size(), m_depthRenderTargetViewsSRMsaa.size());
+    }
+    else
+    {
+        SetArrayRegion(m_depthRenderTargetViewsSR, 0u, m_depthRenderTargetViewsSR.size());
+    }
     return addedIndices;
 }
 
 void PostProcessDepthSinkBufferResource::Resize(Diligent::IRenderDevice& device,
                                        uint32_t renderTargetWidth,
-                                       uint32_t renderTargetHeight)
+                                       uint32_t renderTargetHeight,
+                                       uint32_t numSamples)
 {
     auto numDepthRenderTargets = static_cast<uint32_t>(m_depthRenderTargets.size());
+    auto numDepthRenderTargetsMsaa = static_cast<uint32_t>(m_depthRenderTargetsMsaa.size());
     Clear();
-    Add(device, numDepthRenderTargets, renderTargetWidth, renderTargetHeight);
+    Add(device, numDepthRenderTargets, renderTargetWidth, renderTargetHeight, 1);
+    if (numSamples > 1)
+    {
+        Add(device, numDepthRenderTargetsMsaa, renderTargetWidth, renderTargetHeight, numSamples);
+    }
 }
 
 void PostProcessDepthSinkBufferResource::Clear()
@@ -80,12 +122,18 @@ void PostProcessDepthSinkBufferResource::Clear()
     m_depthRenderTargetViewsRT.shrink_to_fit();
     m_depthRenderTargetViewsSR.clear();
     m_depthRenderTargetViewsSR.shrink_to_fit();
+
+    m_depthRenderTargetsMsaa.shrink_to_fit();
+    m_depthRenderTargetViewsRTMsaa.clear();
+    m_depthRenderTargetViewsRTMsaa.shrink_to_fit();
+    m_depthRenderTargetViewsSRMsaa.clear();
+    m_depthRenderTargetViewsSRMsaa.shrink_to_fit();
 }
 
 void PostProcessDepthSinkBufferResource::SetArrayRegion(const std::vector<Diligent::IDeviceObject*>& views, size_t offset, size_t count)
 {
     m_variable->SetArray(
-        views.data() + offset,
+        views.data(),
         static_cast<uint32_t>(offset),
         static_cast<uint32_t>(count),
         Diligent::SET_SHADER_RESOURCE_FLAG_ALLOW_OVERWRITE

--- a/source/ncengine/graphics2/diligent/resource/PostProcessDepthSinkBufferResource.cpp
+++ b/source/ncengine/graphics2/diligent/resource/PostProcessDepthSinkBufferResource.cpp
@@ -3,7 +3,6 @@
 
 #include "TextureLoader.h"
 #include "ncutility/NcError.h"
-#include "fmt/format.h"
 
 namespace nc::graphics
 {
@@ -36,7 +35,6 @@ auto PostProcessDepthSinkBufferResource::Add(Diligent::IRenderDevice& device,
         }
         m_depthRenderTargetsMsaa.reserve(m_depthRenderTargetsMsaa.size() + numDepthRenderTargets);
         m_depthRenderTargetViewsRTMsaa.reserve(m_depthRenderTargetViewsRTMsaa.size() + numDepthRenderTargets);
-        m_depthRenderTargetViewsSRMsaa.reserve(m_depthRenderTargetViewsSRMsaa.size() + numDepthRenderTargets);
     }
     else
     {
@@ -77,7 +75,6 @@ auto PostProcessDepthSinkBufferResource::Add(Diligent::IRenderDevice& device,
             addedIndices.push_back(static_cast<uint32_t>(m_depthRenderTargetsMsaa.size()));
             m_depthRenderTargetsMsaa.push_back(std::move(pDepthRenderTarget));
             m_depthRenderTargetViewsRTMsaa.push_back(m_depthRenderTargetsMsaa.back()->GetDefaultView(TEXTURE_VIEW_DEPTH_STENCIL));
-            m_depthRenderTargetViewsSRMsaa.push_back(m_depthRenderTargetsMsaa.back()->GetDefaultView(TEXTURE_VIEW_SHADER_RESOURCE));
         }
         else
         {
@@ -88,14 +85,7 @@ auto PostProcessDepthSinkBufferResource::Add(Diligent::IRenderDevice& device,
         }
     }
 
-    if (numSamples > 1)
-    {
-        SetArrayRegion(m_depthRenderTargetViewsSRMsaa, m_depthRenderTargetViewsSR.size(), m_depthRenderTargetViewsSRMsaa.size());
-    }
-    else
-    {
-        SetArrayRegion(m_depthRenderTargetViewsSR, 0u, m_depthRenderTargetViewsSR.size());
-    }
+    SetArrayRegion(m_depthRenderTargetViewsSR, 0u, m_depthRenderTargetViewsSR.size());
     return addedIndices;
 }
 
@@ -117,17 +107,11 @@ void PostProcessDepthSinkBufferResource::Resize(Diligent::IRenderDevice& device,
 void PostProcessDepthSinkBufferResource::Clear()
 {
     m_depthRenderTargets.clear();
-    m_depthRenderTargets.shrink_to_fit();
     m_depthRenderTargetViewsRT.clear();
-    m_depthRenderTargetViewsRT.shrink_to_fit();
     m_depthRenderTargetViewsSR.clear();
-    m_depthRenderTargetViewsSR.shrink_to_fit();
 
-    m_depthRenderTargetsMsaa.shrink_to_fit();
+    m_depthRenderTargetsMsaa.clear();
     m_depthRenderTargetViewsRTMsaa.clear();
-    m_depthRenderTargetViewsRTMsaa.shrink_to_fit();
-    m_depthRenderTargetViewsSRMsaa.clear();
-    m_depthRenderTargetViewsSRMsaa.shrink_to_fit();
 }
 
 void PostProcessDepthSinkBufferResource::SetArrayRegion(const std::vector<Diligent::IDeviceObject*>& views, size_t offset, size_t count)

--- a/source/ncengine/graphics2/diligent/resource/PostProcessDepthSinkBufferResource.h
+++ b/source/ncengine/graphics2/diligent/resource/PostProcessDepthSinkBufferResource.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #include "Common/interface/RefCntAutoPtr.hpp"
-#include "Graphics/GraphicsEngine/interface/RenderDevice.h"
 #include "Graphics/GraphicsEngine/interface/DeviceContext.h"
+#include "Graphics/GraphicsEngine/interface/RenderDevice.h"
 
 #include <vector>
 
@@ -39,7 +39,6 @@ class PostProcessDepthSinkBufferResource
         std::vector<Diligent::IDeviceObject*> m_depthRenderTargetViewsSR; // Shader Resource
         std::vector<Diligent::IDeviceObject*> m_depthRenderTargetViewsRT; // Render target
         std::vector<Diligent::RefCntAutoPtr<Diligent::ITexture>> m_depthRenderTargetsMsaa;
-        std::vector<Diligent::IDeviceObject*> m_depthRenderTargetViewsSRMsaa; // Shader Resource
         std::vector<Diligent::IDeviceObject*> m_depthRenderTargetViewsRTMsaa; // Render target
         Diligent::IShaderResourceVariable* m_variable;
         uint32_t m_maxTextures;

--- a/source/ncengine/graphics2/diligent/resource/PostProcessDepthSinkBufferResource.h
+++ b/source/ncengine/graphics2/diligent/resource/PostProcessDepthSinkBufferResource.h
@@ -20,19 +20,27 @@ class PostProcessDepthSinkBufferResource
         auto Add(Diligent::IRenderDevice& device,
                  uint32_t numDepthRenderTargets,
                  uint32_t renderTargetWidth,
-                 uint32_t renderTargetHeight) -> std::vector<uint32_t>;
+                 uint32_t renderTargetHeight,
+                 uint32_t numSamples = 1u) -> std::vector<uint32_t>;
 
         void Resize(Diligent::IRenderDevice& device,
                     uint32_t renderTargetWidth,
-                    uint32_t renderTargetHeight);
+                    uint32_t renderTargetHeight,
+                    uint32_t numSamples = 1u);
 
         void Clear();
-        auto GetDepthRenderTarget(uint32_t index) -> Diligent::IDeviceObject* { return m_depthRenderTargetViewsRT.at(index); }
+        auto GetMsaaDSV(uint32_t index) -> Diligent::IDeviceObject* { return m_depthRenderTargetViewsRTMsaa.at(index); }
+        auto GetDSV(uint32_t index) -> Diligent::IDeviceObject* { return m_depthRenderTargetViewsRT.at(index); }
+        auto GetMsaaTexture(uint32_t index) -> Diligent::ITexture* { return m_depthRenderTargetsMsaa.at(index); }
+        auto GetTexture(uint32_t index) -> Diligent::ITexture* { return m_depthRenderTargets.at(index); }
 
     private:
         std::vector<Diligent::RefCntAutoPtr<Diligent::ITexture>> m_depthRenderTargets;
         std::vector<Diligent::IDeviceObject*> m_depthRenderTargetViewsSR; // Shader Resource
         std::vector<Diligent::IDeviceObject*> m_depthRenderTargetViewsRT; // Render target
+        std::vector<Diligent::RefCntAutoPtr<Diligent::ITexture>> m_depthRenderTargetsMsaa;
+        std::vector<Diligent::IDeviceObject*> m_depthRenderTargetViewsSRMsaa; // Shader Resource
+        std::vector<Diligent::IDeviceObject*> m_depthRenderTargetViewsRTMsaa; // Render target
         Diligent::IShaderResourceVariable* m_variable;
         uint32_t m_maxTextures;
 

--- a/source/ncengine/graphics2/diligent/resource/ShaderBindings.h
+++ b/source/ncengine/graphics2/diligent/resource/ShaderBindings.h
@@ -41,14 +41,14 @@ class ShaderBindings
                 TextureBufferResourceDesc{"TextureBufferData",             Diligent::SHADER_TYPE::SHADER_TYPE_PIXEL,  maxTextures},
                 UniformBufferResourceDesc{"EnvironmentBufferData",         Diligent::SHADER_TYPE::SHADER_TYPE_VS_PS},
                 UniformBufferResourceDesc{"WireframeBufferData",           Diligent::SHADER_TYPE::SHADER_TYPE_VS_PS},
-                UniformBufferResourceDesc{"OutlinePassBufferData",          Diligent::SHADER_TYPE::SHADER_TYPE_PIXEL}
+                UniformBufferResourceDesc{"OutlinePassBufferData",         Diligent::SHADER_TYPE::SHADER_TYPE_PIXEL}
               },
               m_perPassSignature{
                 device, context,
                 "PerPassResourceSignature",
                 1,
-                TextureBufferResourceDesc{"PostProcessColorSinkBufferData", Diligent::SHADER_TYPE::SHADER_TYPE_PIXEL, 50},
-                TextureBufferResourceDesc{"PostProcessDepthSinkBufferData", Diligent::SHADER_TYPE::SHADER_TYPE_PIXEL, 50},
+                TextureBufferResourceDesc{"PostProcessColorSinkBufferData", Diligent::SHADER_TYPE::SHADER_TYPE_PIXEL, 20},
+                TextureBufferResourceDesc{"PostProcessDepthSinkBufferData", Diligent::SHADER_TYPE::SHADER_TYPE_PIXEL, 20},
                 UniformBufferResourceDesc{"PostProcessSinkIndexBufferData", Diligent::SHADER_TYPE::SHADER_TYPE_PIXEL}
             }
         {

--- a/source/ncengine/graphics2/diligent/resource/ShaderBindings.h
+++ b/source/ncengine/graphics2/diligent/resource/ShaderBindings.h
@@ -47,8 +47,8 @@ class ShaderBindings
                 device, context,
                 "PerPassResourceSignature",
                 1,
-                TextureBufferResourceDesc{"PostProcessColorSinkBufferData", Diligent::SHADER_TYPE::SHADER_TYPE_PIXEL, 10},
-                TextureBufferResourceDesc{"PostProcessDepthSinkBufferData", Diligent::SHADER_TYPE::SHADER_TYPE_PIXEL, 10},
+                TextureBufferResourceDesc{"PostProcessColorSinkBufferData", Diligent::SHADER_TYPE::SHADER_TYPE_PIXEL, 50},
+                TextureBufferResourceDesc{"PostProcessDepthSinkBufferData", Diligent::SHADER_TYPE::SHADER_TYPE_PIXEL, 50},
                 UniformBufferResourceDesc{"PostProcessSinkIndexBufferData", Diligent::SHADER_TYPE::SHADER_TYPE_PIXEL}
             }
         {

--- a/test/integration_test/ncengine/graphics2/DiligentEngineFixture.inl
+++ b/test/integration_test/ncengine/graphics2/DiligentEngineFixture.inl
@@ -21,6 +21,7 @@ class DiligentEngineFixture : public testing::Test
             engineCI.Features.BindlessResources = Diligent::DEVICE_FEATURE_STATE_ENABLED;
             engine = std::make_unique<nc::graphics::DiligentEngine>(
                 engineCI,
+                nc::graphics::DeviceCapability{},
                 window->GetWindowHandle(),
                 "",
                 &DiligentEngineFixture::LogCallback


### PR DESCRIPTION
Added MSAA support.

We cap the count of samples requested by `antialising` in the config to whatever the device supports via a new struct and helper in `DiligentEngine`.

All the passes that aren't post process are multisampled. The post process render call then resolves all of these multisampled render targets down to single sampled targets before using the new single sampled targets for rendering.

The single sampled and multisampled targets share the same indices which makes it much cleaner when creating `PassDesc` in the `PassManifest` interface.
Depth targets don't need to be resolved. (I don't know why). 

Tested with an `antialising` value of 8, 1, 16, and 912 (in the >8 cases, we cap at 8). 