### PR TITLE
Fix Constraint Bugs

### DIFF
--- a/source/ncengine/ui/editor/impl/ComponentWidgets.cpp
+++ b/source/ncengine/ui/editor/impl/ComponentWidgets.cpp
@@ -491,6 +491,13 @@ void ConstraintWidget(nc::Constraint& constraint, nc::RigidBody& body, nc::ecs::
         if (ImGui::Button(buttonText))
         {
             body.RemoveConstraint(constraint.GetId());
+            // Constraint dangles now - need to clean up and get out.
+            if (isConstraintOpen)
+            {
+                ImGui::TreePop();
+            }
+
+            return;
         }
     }
 

--- a/source/ncengine/ui/editor/impl/windows/SceneGraph.cpp
+++ b/source/ncengine/ui/editor/impl/windows/SceneGraph.cpp
@@ -100,7 +100,7 @@ auto SceneGraph::PassFilter(Tag& tag) -> bool
 
 void SceneGraph::Graph(EditorContext& ctx, CreateEntityDialog& createEntity)
 {
-    for(auto entity : ctx.world.GetAll<Entity>())
+    for(auto entity : std::views::reverse(ctx.world.GetAll<Entity>()))
     {
         auto& hierarchy = ctx.world.Get<Hierarchy>(entity);
         auto& tag = ctx.world.Get<Tag>(entity);

--- a/test/ncengine/physics/jolt/ConstraintManager_unit_tests.cpp
+++ b/test/ncengine/physics/jolt/ConstraintManager_unit_tests.cpp
@@ -170,17 +170,16 @@ TEST_F(ConstraintManagerTest, UpdateConstraint_disabled_preservesDisabledState)
     auto body1 = CreateBody();
     auto body2 = CreateBody();
     auto& constraint = uut.AddConstraint(initialInfo, g_entity1, *body1, g_entity2, *body2);
-    const auto handle = uut.GetConstraintHandle(constraint.GetId());
 
     uut.EnableConstraint(constraint, false);
     constraint.GetInfo() = updatedInfo;
     uut.UpdateConstraint(constraint);
     EXPECT_FALSE(constraint.IsEnabled());
-    EXPECT_FALSE(handle->GetEnabled());
+    EXPECT_FALSE(uut.GetConstraintHandle(constraint.GetId())->GetEnabled());
 
     uut.UpdateConstraintTarget(constraint, nc::Entity::Null(), &JPH::Body::sFixedToWorld);
     EXPECT_FALSE(constraint.IsEnabled());
-    EXPECT_FALSE(handle->GetEnabled());
+    EXPECT_FALSE(uut.GetConstraintHandle(constraint.GetId())->GetEnabled());
 }
 
 TEST_F(ConstraintManagerTest, UpdateConstraintTarget_attachedToOtherBody_attachToNewBody_updatesMapping)


### PR DESCRIPTION
Fixing two use-after-free cases with constraints + potential container invalidation when removing an entity through the editor.