### PR TITLE
Add Entity User Data

### DIFF
--- a/include/ncengine/ecs/Ecs.h
+++ b/include/ncengine/ecs/Ecs.h
@@ -37,7 +37,7 @@ class EcsInterface
             requires PolicyType::template HasAccess<Entity, Transform, Tag, Hierarchy>
         auto Emplace(EntityInfo info = {}) -> Entity
         {
-            const auto handle = m_policy.template GetPool<Entity>().Add(info.layer, info.flags);
+            const auto handle = m_policy.template GetPool<Entity>().Add(info.layer, info.flags, info.userData);
             if (info.parent.Valid())
             {
                 auto& parentTransform = Get<Transform>(info.parent);

--- a/include/ncengine/ecs/Entity.h
+++ b/include/ncengine/ecs/Entity.h
@@ -1,74 +1,101 @@
+/**
+ * @file Entity.h
+ * @copyright Jaremie Romer and McCallister Romer 2025
+ */
 #pragma once
 
 #include "ncmath/Vector.h"
 #include "ncmath/Quaternion.h"
 
-#include <concepts>
 #include <cstdint>
 #include <limits>
 #include <string>
 
 namespace nc
 {
-/** Identifies an object in the registry. */
+/** @brief Identifies an object in the registry. */
 class Entity
 {
     public:
         using index_type = uint32_t;
         using layer_type = uint8_t;
         using flags_type = uint8_t;
+        using user_data_type = uint8_t;
 
+        /** @brief Index used for an invalid Entity. */
         static constexpr index_type NullIndex = std::numeric_limits<index_type>::max();
 
+        /** @brief Flags for configuring internal Entity behavior. */
         struct Flags
         {
-            static constexpr Entity::flags_type None                     = 0b00000000; // Default behavior
-            static constexpr Entity::flags_type Static                   = 0b00000001; // The Entitiy's Transform will not be moved after construction
-            static constexpr Entity::flags_type Persistent               = 0b00000010; // Entity persists across scene load/unload
-            static constexpr Entity::flags_type NoCollisionNotifications = 0b00000100; // Do not send Collision/Trigger events involving the Entity
-            static constexpr Entity::flags_type NoSerialize              = 0b00001000; // Exclude the Entity and its children from scene serialization
-            static constexpr Entity::flags_type Internal                 = 0b00010000; // Entity was created by the engine/editor
+            static constexpr Entity::flags_type None                     = 0b00000000; ///< Default behavior
+            static constexpr Entity::flags_type Static                   = 0b00000001; ///< The Entitiy's Transform will not be moved after construction
+            static constexpr Entity::flags_type Persistent               = 0b00000010; ///< Entity persists across scene load/unload
+            static constexpr Entity::flags_type NoCollisionNotifications = 0b00000100; ///< Do not send Collision/Trigger events involving the Entity
+            static constexpr Entity::flags_type NoSerialize              = 0b00001000; ///< Exclude the Entity and its children from scene serialization
+            static constexpr Entity::flags_type Internal                 = 0b00010000; ///< Entity was created by the engine/editor
         };
 
+        /** @brief Construct a null Entity. */
         constexpr Entity() noexcept
-            : m_index{NullIndex}, m_layer{0}, m_flags{Flags::None}
+            : m_index{NullIndex},
+              m_layer{0},
+              m_flags{Flags::None},
+              m_userData{0}
         {
         }
 
-        explicit constexpr Entity(index_type index, layer_type layer, flags_type flags) noexcept
-            : m_index{index}, m_layer{layer}, m_flags{flags}
+        /** @brief Construct an Entity. */
+        explicit constexpr Entity(index_type index,
+                                  layer_type layer = 0,
+                                  flags_type flags = Flags::None,
+                                  user_data_type userData = 0) noexcept
+            : m_index{index},
+              m_layer{layer},
+              m_flags{flags},
+              m_userData{userData}
         {
         }
 
+        /** @brief Construct a null Entity. */
+        static constexpr auto Null() noexcept { return Entity{}; }
+
+        /** @brief Reconstruct an Entity from a hashed value. */
         static constexpr auto FromHash(uint64_t hash) noexcept -> Entity
         {
-            const auto index = static_cast<Entity::index_type>((hash >> 16) & 0xFFFFFFFF);
-            const auto layer = static_cast<Entity::layer_type>((hash >> 8) & 0xFF);
-            const auto flags = static_cast<Entity::flags_type>(hash & 0xFF);
-            return Entity{index, layer, flags};
+            const auto index = static_cast<Entity::index_type>((hash >> 24) & 0xFFFFFFFF);
+            const auto layer = static_cast<Entity::layer_type>((hash >> 16) & 0xFF);
+            const auto flags = static_cast<Entity::flags_type>((hash >> 8) & 0xFF);
+            const auto userData = static_cast<Entity::user_data_type>(hash & 0xFF);
+            return Entity{index, layer, flags, userData};
         }
 
-        static constexpr auto Null() noexcept { return Entity{}; }
-        constexpr auto Valid() const noexcept { return m_index != NullIndex; }
-        constexpr auto Index() const noexcept { return m_index; }
-        constexpr auto Layer() const noexcept { return m_layer; }
-        constexpr auto Flags() const noexcept { return m_flags; }
-        constexpr auto IsStatic() const noexcept -> bool { return m_flags & Flags::Static; }
-        constexpr auto IsPersistent() const noexcept -> bool { return m_flags & Flags::Persistent; }
-        constexpr auto ReceivesCollisionEvents() const noexcept -> bool { return !(m_flags & Flags::NoCollisionNotifications); }
-        constexpr auto IsSerializable() const noexcept -> bool { return !(m_flags & Flags::NoSerialize); }
-        constexpr auto IsInternal() const noexcept -> bool { return m_flags & Flags::Internal; }
+        /** @name Entity Properties */
+        constexpr auto Valid()                   const noexcept -> bool           { return m_index != NullIndex; }
+        constexpr auto Index()                   const noexcept -> index_type     { return m_index; }
+        constexpr auto Layer()                   const noexcept -> layer_type     { return m_layer; }
+        constexpr auto Flags()                   const noexcept -> flags_type     { return m_flags; }
+        constexpr auto UserData()                const noexcept -> user_data_type { return m_userData; }
+        constexpr auto IsStatic()                const noexcept -> bool           { return m_flags & Flags::Static; }
+        constexpr auto IsPersistent()            const noexcept -> bool           { return m_flags & Flags::Persistent; }
+        constexpr auto ReceivesCollisionEvents() const noexcept -> bool           { return !(m_flags & Flags::NoCollisionNotifications); }
+        constexpr auto IsSerializable()          const noexcept -> bool           { return !(m_flags & Flags::NoSerialize); }
+        constexpr auto IsInternal()              const noexcept -> bool           { return m_flags & Flags::Internal; }
+
+        /** @name Operators */
         explicit constexpr operator index_type() const noexcept { return m_index; }
         friend bool constexpr operator==(const Entity& a, const Entity& b) { return a.Index() == b.Index(); }
         friend bool constexpr operator!=(const Entity& a, const Entity& b) { return !(a == b); }
 
+        /** @brief Entity Hasher */
         struct Hash
         {
             constexpr auto operator()(const Entity& entity) const noexcept
             {
-                return static_cast<uint64_t>(entity.Index()) << 16
-                     | static_cast<uint64_t>(entity.Layer()) << 8
-                     | static_cast<uint64_t>(entity.Flags());
+                return static_cast<uint64_t>(entity.Index()) << 24
+                     | static_cast<uint64_t>(entity.Layer()) << 16
+                     | static_cast<uint64_t>(entity.Flags()) << 8
+                     | static_cast<uint64_t>(entity.UserData());
             }
         };
 
@@ -76,27 +103,19 @@ class Entity
         index_type m_index;
         layer_type m_layer;
         flags_type m_flags;
+        user_data_type m_userData;
 };
 
-/** Concepts to enforce exact matches to Entity member types. */
-template<class T>
-concept explicit_index_type = std::same_as<T, Entity::index_type>;
-
-template<class T>
-concept explicit_layer_type = std::same_as<T, Entity::layer_type>;
-
-/** Initialization data for Entities.
- *  - Rotation must be a normalized quaternion.
- *  - Scale must not be zero in any dimension.
- *  - Layer must be in the range [1, 64]. */
+/** @brief Initialization data for Entities. */
 struct EntityInfo
 {
-    Vector3 position = Vector3::Zero();
-    Quaternion rotation = Quaternion::Identity();
-    Vector3 scale = Vector3::One();
-    Entity parent = Entity::Null();
-    std::string tag = "Entity";
-    Entity::layer_type layer = 1u;
-    Entity::flags_type flags = Entity::Flags::None;
+    Vector3 position = Vector3::Zero();              ///< initial Transform position
+    Quaternion rotation = Quaternion::Identity();    ///< initial Transform rotation (must be normalized)
+    Vector3 scale = Vector3::One();                  ///< initial Transform scale (must be non-zero in all dimensions)
+    Entity parent = Entity::Null();                  ///< optional Entity to parent under
+    std::string tag = "Entity";                      ///< initial Tag value
+    Entity::layer_type layer = 1u;                   ///< the layer the Entity belongs to
+    Entity::flags_type flags = Entity::Flags::None;  ///< enabled flags
+    Entity::user_data_type userData = 0u;            ///< custom data for client-side use
 };
 } // namespace nc

--- a/include/ncengine/ecs/EntityPool.h
+++ b/include/ncengine/ecs/EntityPool.h
@@ -29,9 +29,11 @@ class EntityPool : public StableAddress
             : m_entities{maxEntities / 4u, maxEntities} {}
 
         /** @brief Add an entity. */
-        auto Add(Entity::layer_type layer, Entity::flags_type flags) -> Entity
+        auto Add(Entity::layer_type layer,
+                 Entity::flags_type flags,
+                 Entity::user_data_type userData) -> Entity
         {
-            const auto handle = m_handleManager.GenerateNewHandle(layer, flags);
+            const auto handle = m_handleManager.GenerateNewHandle(layer, flags, userData);
             m_entities.emplace(handle.Index(), handle);
             if(handle.IsPersistent())
                 m_persistent.push_back(handle);

--- a/include/ncengine/ecs/detail/HandleManager.h
+++ b/include/ncengine/ecs/detail/HandleManager.h
@@ -18,14 +18,20 @@ class HandleManager
         {
         }
 
-        Entity GenerateNewHandle(Entity::layer_type layer, Entity::flags_type flags)
+        Entity GenerateNewHandle(Entity::layer_type layer,
+                                 Entity::flags_type flags,
+                                 Entity::user_data_type userData)
         {
-            if(m_freeHandles.empty())
-                return Entity{m_nextIndex++, layer, flags};
+            const auto index = [this](){
+                if (m_freeHandles.empty())
+                    return m_nextIndex++;
 
-            auto index = m_freeHandles.back();
-            m_freeHandles.pop_back();
-            return Entity{index, layer, flags};
+                const auto recycled = m_freeHandles.back();
+                m_freeHandles.pop_back();
+                return recycled;
+            }();
+
+            return Entity{index, layer, flags, userData};
         }
 
         void ReclaimHandle(Entity handle)

--- a/source/ncengine/serialize/EntitySerializationUtility.cpp
+++ b/source/ncengine/serialize/EntitySerializationUtility.cpp
@@ -37,7 +37,8 @@ auto ReconstructEntityInfo(nc::Entity entity,
         .parent = hierarchy.parent,
         .tag = tag.value,
         .layer = entity.Layer(),
-        .flags = entity.Flags()
+        .flags = entity.Flags(),
+        .userData = entity.UserData()
     };
 }
 } // anonymous namespace
@@ -82,7 +83,7 @@ auto BuildEntityToFragmentIdMap(std::span<const Entity> entities) -> EntityToFra
 void RemapEntity(Entity& entity, const EntityToFragmentIdMap& map)
 {
     if (entity != Entity::Null())
-        entity = Entity{map.at(entity), uint8_t{}, uint8_t{}};
+        entity = Entity{map.at(entity)};
 }
 
 void RemapEntity(Entity& entity, const FragmentIdToEntityMap& map)
@@ -106,5 +107,4 @@ auto BuildFragmentEntityInfos(std::span<const Entity> entities,
 
     return out;
 }
-
 } // namespace nc

--- a/source/ncengine/ui/editor/impl/windows/Inspector.cpp
+++ b/source/ncengine/ui/editor/impl/windows/Inspector.cpp
@@ -34,8 +34,9 @@ void Inspector::Draw(EditorContext& ctx, CreateEntityDialog& createEntity)
 
         ElementHeader("Entity");
         DragAndDropSource<Entity>(&entity);
-        ImGui::Text("Index: %d", entity.Index());
-        ImGui::Text("Layer: %d", entity.Layer());
+        ImGui::Text("Index:    %d", entity.Index());
+        ImGui::Text("Layer:    %d", entity.Layer());
+        ImGui::Text("UserData: %d", entity.UserData());
         if (ImGui::TreeNodeEx("Flags"))
         {
             ImGui::BeginDisabled(true);

--- a/source/ncengine/ui/editor/impl/windows/dialogs/CreateEntityDialog.cpp
+++ b/source/ncengine/ui/editor/impl/windows/dialogs/CreateEntityDialog.cpp
@@ -8,6 +8,7 @@ void CreateEntityDialog::Draw(const ImVec2& dimensions, Entity& selectedEntity)
     {
         ui::InputText(m_tag, "tag");
         ui::InputU8(m_layer, "layer");
+        ui::InputU8(m_userData, "userData");
         ImGui::Checkbox("static", &m_staticFlag);
         ImGui::Checkbox("persistent", &m_persistentFlag);
         ImGui::Checkbox("noCollisionNotifications", &m_noCollisionFlag);
@@ -25,7 +26,8 @@ void CreateEntityDialog::Draw(const ImVec2& dimensions, Entity& selectedEntity)
                 .parent = selectedEntity,
                 .tag = m_tag,
                 .layer = m_layer,
-                .flags = BuildFlags()
+                .flags = BuildFlags(),
+                .userData = m_userData
             });
 
             ClosePopup();

--- a/source/ncengine/ui/editor/impl/windows/dialogs/CreateEntityDialog.h
+++ b/source/ncengine/ui/editor/impl/windows/dialogs/CreateEntityDialog.h
@@ -28,6 +28,7 @@ class CreateEntityDialog : public ModalDialog
         bool m_persistentFlag = false;
         bool m_noCollisionFlag = false;
         bool m_noSerializeFlag = false;
+        uint8_t m_userData = 0;
         Vector3 m_position;
         Vector3 m_rotation;
         Vector3 m_scale = Vector3::One();

--- a/test/ncengine/ecs/ComponentRegistry_unit_tests.cpp
+++ b/test/ncengine/ecs/ComponentRegistry_unit_tests.cpp
@@ -113,8 +113,8 @@ TEST(ComponentRegistryTests, CommitPendingChanges_updatesState)
     uut.RegisterType<S1>(10);
     auto& entities = uut.GetPool<nc::Entity>();
     auto& components = uut.GetPool<S1>();
-    const auto a = entities.Add(0, 0);
-    const auto b = entities.Add(0, 0);
+    const auto a = entities.Add(0, 0, 0);
+    const auto b = entities.Add(0, 0, 0);
     components.Emplace(a);
     components.Emplace(b);
     entities.Remove(b);
@@ -123,7 +123,7 @@ TEST(ComponentRegistryTests, CommitPendingChanges_updatesState)
     EXPECT_TRUE(components.Contains(a));
     EXPECT_FALSE(entities.Contains(b));
     EXPECT_FALSE(components.Contains(b));
-    const auto next = entities.Add(0, 0);
+    const auto next = entities.Add(0, 0, 0);
     EXPECT_EQ(next, b);
 }
 
@@ -133,9 +133,9 @@ TEST(ComponentRegistryTests, ClearSceneData)
     uut.RegisterType<S1>(10);
     auto& entities = uut.GetPool<nc::Entity>();
     auto& components = uut.GetPool<S1>();
-    const auto a = entities.Add(0, 0);
-    const auto b = entities.Add(0, nc::Entity::Flags::Persistent);
-    const auto c = entities.Add(0, 0);
+    const auto a = entities.Add(0, 0, 0);
+    const auto b = entities.Add(0, nc::Entity::Flags::Persistent, 0);
+    const auto c = entities.Add(0, 0, 0);
     components.Emplace(a);
     components.Emplace(b);
     components.Emplace(c);
@@ -157,9 +157,9 @@ TEST(ComponentRegistryTests, Clear)
     uut.RegisterType<S1>(10);
     auto& entities = uut.GetPool<nc::Entity>();
     auto& components = uut.GetPool<S1>();
-    const auto a = entities.Add(0, 0);
-    const auto b = entities.Add(0, nc::Entity::Flags::Persistent);
-    const auto c = entities.Add(0, 0);
+    const auto a = entities.Add(0, 0, 0);
+    const auto b = entities.Add(0, nc::Entity::Flags::Persistent, 0);
+    const auto c = entities.Add(0, 0, 0);
     components.Emplace(a);
     components.Emplace(b);
     components.Emplace(c);

--- a/test/ncengine/ecs/Entity_unit_tests.cpp
+++ b/test/ncengine/ecs/Entity_unit_tests.cpp
@@ -63,6 +63,14 @@ TEST(Entity_unit_tests, Flags_ExtractsFlags)
     EXPECT_EQ(actual, expected);
 }
 
+TEST(Entity_unit_tests, UserData_ExtractsUserData)
+{
+    Entity::user_data_type expected = 2u;
+    auto handle = Entity{0u, 1u, 0u, expected};
+    Entity::user_data_type actual = handle.UserData();
+    EXPECT_EQ(actual, expected);
+}
+
 TEST(Entity_unit_tests, IsStatic_FlagSet_ReturnsTrue)
 {
     auto flags = Entity::Flags::Static;
@@ -121,25 +129,31 @@ TEST(Entity_unit_tests, IsInternal_FlagNotSet_ReturnsFalse)
 
 TEST(Entity_unit_tests, Hash_AllValues_ReturnsExpectedHash)
 {
-    constexpr auto handle = Entity{uint32_t{0x01234567}, uint8_t{0x89}, uint8_t{0xAB}};
+    constexpr auto handle = Entity{uint32_t{0x01234567}, uint8_t{0x89}, uint8_t{0xAB}, uint8_t{0xCD}};
     constexpr auto uut = Entity::Hash();
     constexpr auto actual = uut(handle);
-    constexpr auto expected = size_t{0x00000123456789AB}; // top 4 bytes empty | index | layer | flags
+    constexpr auto expected = size_t{0x000123456789ABCD}; // top byte empty | index | layer | flags | userData
     EXPECT_EQ(expected, actual);
 }
 
-TEST(Entity_unit_tests, FromHash_NoFlags_ReconstructsEntity)
+TEST(Entity_unit_tests, FromHash_NoValues_ReconstructsEntity)
 {
-    constexpr auto expectedEntity = Entity{42u, 0u, 0u};
+    constexpr auto expectedEntity = Entity{42u, 0u, 0u, 0u};
     constexpr auto hash = Entity::Hash{}(expectedEntity);
     constexpr auto actualEntity = Entity::FromHash(hash);
-    EXPECT_EQ(expectedEntity, actualEntity);
+    EXPECT_EQ(expectedEntity.Index(), actualEntity.Index());
+    EXPECT_EQ(expectedEntity.Layer(), actualEntity.Layer());
+    EXPECT_EQ(expectedEntity.Flags(), actualEntity.Flags());
+    EXPECT_EQ(expectedEntity.UserData(), actualEntity.UserData());
 }
 
 TEST(Entity_unit_tests, FromHash_AllValues_ReconstructsEntity)
 {
-    constexpr auto expectedEntity = Entity{128u, 7u, nc::Entity::Flags::Static | nc::Entity::Flags::NoSerialize};
+    constexpr auto expectedEntity = Entity{128u, 7u, nc::Entity::Flags::Static | nc::Entity::Flags::NoSerialize, 2u};
     constexpr auto hash = Entity::Hash{}(expectedEntity);
     constexpr auto actualEntity = Entity::FromHash(hash);
-    EXPECT_EQ(expectedEntity, actualEntity);
+    EXPECT_EQ(expectedEntity.Index(), actualEntity.Index());
+    EXPECT_EQ(expectedEntity.Layer(), actualEntity.Layer());
+    EXPECT_EQ(expectedEntity.Flags(), actualEntity.Flags());
+    EXPECT_EQ(expectedEntity.UserData(), actualEntity.UserData());
 }

--- a/test/ncengine/serialize/ComponentSerialization_integration_tests.cpp
+++ b/test/ncengine/serialize/ComponentSerialization_integration_tests.cpp
@@ -96,7 +96,7 @@ auto RigidBody::GetConstraints() const -> std::span<const Constraint>
 auto g_registry = nc::ecs::ComponentRegistry{10ull};
 auto g_ecs = nc::ecs::Ecs{g_registry};
 constexpr auto g_entity = nc::Entity{42u, nc::Entity::layer_type{}, nc::Entity::Flags::None};
-constexpr auto g_staticEntity = nc::Entity{42u, nc::Entity::layer_type{}, nc::Entity::Flags::Static};
+constexpr auto g_staticEntity = nc::Entity{43u, nc::Entity::layer_type{}, nc::Entity::Flags::Static};
 auto g_entityToFragmentIdMap = nc::EntityToFragmentIdMap
 {
     {g_entity, 0u},

--- a/test/ncengine/serialize/SceneSerialization_unit_tests.cpp
+++ b/test/ncengine/serialize/SceneSerialization_unit_tests.cpp
@@ -237,7 +237,10 @@ TEST_F(SceneSerializationTests, RoundTrip_hasEntities_correctlyRestoresEntityVal
             .layer = nc::Entity::layer_type{2},
             .flags = nc::Entity::Flags::Static
         },
-        {.flags = nc::Entity::Flags::NoCollisionNotifications}
+        {
+            .flags = nc::Entity::Flags::NoCollisionNotifications,
+            .userData = 3u
+        }
     };
 
     const auto unexpectedInfos = std::vector<nc::EntityInfo>
@@ -266,6 +269,7 @@ TEST_F(SceneSerializationTests, RoundTrip_hasEntities_correctlyRestoresEntityVal
     {
         EXPECT_EQ(expected.layer, actualEntity.Layer());
         EXPECT_EQ(expected.flags, actualEntity.Flags());
+        EXPECT_EQ(expected.userData, actualEntity.UserData());
 
         const auto& actualTransform = ecs.Get<nc::Transform>(actualEntity);
         EXPECT_EQ(expected.position, actualTransform.LocalPosition());


### PR DESCRIPTION
Exposing one of the padding bytes in `Entity` as user data. I added this in a feature branch for project pineapple to encode chunk ids into entities. For Rustbelt, I'm thinking if we use the layer to encode object type (terrain, vehicle, attachment...), we may want this to store some small + immutable network state, like player id.