### PR TITLE
Add ByteArrayStream

### DIFF
--- a/source/ncjolt/ncjolt/ByteArrayStream.h
+++ b/source/ncjolt/ncjolt/ByteArrayStream.h
@@ -1,0 +1,93 @@
+#pragma once
+
+#include "Jolt/Jolt.h"
+#include "Jolt/Core/StreamIn.h"
+#include "Jolt/Core/StreamOut.h"
+
+#include <cstring>
+#include <vector>
+
+namespace nc::jolt
+{
+// Jolt I/O stream implementation backed by a std::vector
+class ByteArrayStream : public JPH::StreamIn,
+                        public JPH::StreamOut
+{
+    public:
+        explicit ByteArrayStream() = default;
+
+        explicit ByteArrayStream(std::vector<uint8_t> data)
+            : m_data{std::move(data)},
+              m_writePos{m_data.size()}
+        {
+        }
+
+        void ReadBytes(void* out, size_t numBytes) override
+        {
+            if (m_readPos + numBytes > m_data.size())
+            {
+                const auto availableBytes = m_data.size() - m_readPos;
+                if (availableBytes > 0)
+                {
+                    std::memcpy(out, m_data.data() + m_readPos, availableBytes);
+                }
+
+                std::memset(static_cast<uint8_t*>(out) + availableBytes, 0, numBytes - availableBytes);
+                m_readPos = m_data.size();
+                m_failed = true;
+                return;
+            }
+
+            std::memcpy(out, m_data.data() + m_readPos, numBytes);
+            m_readPos += numBytes;
+        }
+
+        void WriteBytes(const void* data, size_t numBytes) override
+        {
+            if (m_writePos + numBytes > m_data.size())
+            {
+                m_data.resize(m_writePos + numBytes);
+            }
+
+            std::memcpy(m_data.data() + m_writePos, data, numBytes);
+            m_writePos += numBytes;
+        }
+
+        auto IsEOF() const -> bool override
+        {
+            return m_failed && m_readPos >= m_data.size();
+        }
+
+        auto IsFailed() const -> bool override
+        {
+            return m_failed;
+        }
+
+        auto GetBuffer() const -> const std::vector<uint8_t>&
+        {
+            return m_data;
+        }
+
+        auto ExtractBuffer() -> std::vector<uint8_t>
+        {
+            m_writePos = 0;
+            m_readPos = 0;
+            m_failed = false;
+            return std::move(m_data);
+        }
+
+        void Reset() noexcept
+        {
+            m_data.clear();
+            m_writePos = 0;
+            m_readPos = 0;
+            m_failed = false;
+        }
+
+    private:
+        std::vector<uint8_t> m_data;
+        size_t m_writePos = 0;
+        size_t m_readPos = 0;
+        bool m_failed = false;
+};
+} // namespace nc::jolt

--- a/test/ncjolt/ByteArrayStream_unit_tests.cpp
+++ b/test/ncjolt/ByteArrayStream_unit_tests.cpp
@@ -1,0 +1,121 @@
+#include "gtest/gtest.h"
+#include "ncjolt/ByteArrayStream.h"
+
+#include <array>
+
+TEST(ByteArrayStreamTest, DefaultConstructor)
+{
+    auto uut = nc::jolt::ByteArrayStream{};
+
+    EXPECT_FALSE(uut.IsFailed());
+    EXPECT_FALSE(uut.IsEOF());
+}
+
+TEST(ByteArrayStreamTest, ConstructorWithVector)
+{
+    auto uut = nc::jolt::ByteArrayStream{ {1, 2, 3, 4, 5} };
+
+    const auto& actualBuffer = uut.GetBuffer();
+    EXPECT_FALSE(uut.IsFailed());
+    EXPECT_FALSE(uut.IsEOF());
+    EXPECT_EQ(actualBuffer[0], 1);
+    EXPECT_EQ(actualBuffer[1], 2);
+    EXPECT_EQ(actualBuffer[2], 3);
+    EXPECT_EQ(actualBuffer[3], 4);
+    EXPECT_EQ(actualBuffer[4], 5);
+}
+
+TEST(ByteArrayStreamTest, ReadBytes_goodCall_copiesData)
+{
+    auto uut = nc::jolt::ByteArrayStream{ {10, 20, 30} };
+    auto buffer = std::array<uint8_t, 3>{};
+    uut.ReadBytes(buffer.data(), 3);
+
+    EXPECT_EQ(buffer[0], 10);
+    EXPECT_EQ(buffer[1], 20);
+    EXPECT_EQ(buffer[2], 30);
+    EXPECT_FALSE(uut.IsEOF());
+    EXPECT_FALSE(uut.IsFailed());
+}
+
+TEST(ByteArrayStreamTest, ReadBytes_pastEnd_copiesFirstDataAndSetsEOF)
+{
+    auto uut = nc::jolt::ByteArrayStream{ {10, 20} };
+    auto buffer = std::array<uint8_t, 4>{};
+    uut.ReadBytes(buffer.data(), 4);
+
+    EXPECT_TRUE(uut.IsFailed());
+    EXPECT_TRUE(uut.IsEOF());
+    EXPECT_EQ(buffer[0], 10);
+    EXPECT_EQ(buffer[1], 20);
+    EXPECT_EQ(buffer[2], 0); // remaining bytes should not be set
+    EXPECT_EQ(buffer[3], 0);
+}
+
+TEST(ByteArrayStreamTest, ReadBytes_emptyStream_setsFailAndEOF)
+{
+    auto uut = nc::jolt::ByteArrayStream{};
+    auto buffer = std::array<uint8_t, 1>{};
+    uut.ReadBytes(buffer.data(), 1);
+
+    EXPECT_TRUE(uut.IsFailed());
+    EXPECT_TRUE(uut.IsEOF());
+}
+
+TEST(ByteArrayStreamTest, WriteBytes_goodCall_copiesData)
+{
+    auto uut = nc::jolt::ByteArrayStream{};
+    constexpr auto expected = std::array<uint8_t, 3>{100, 200, 255};
+    uut.WriteBytes(expected.data(), expected.size());
+
+    const auto& actual = uut.GetBuffer();
+    ASSERT_EQ(expected.size(), actual.size());
+    EXPECT_EQ(expected[0], actual[0]);
+    EXPECT_EQ(expected[1], actual[1]);
+    EXPECT_EQ(expected[2], actual[2]);
+}
+
+TEST(ByteArrayStreamTest, WriteAndRead_roundTrip_preservesData)
+{
+    auto uut = nc::jolt::ByteArrayStream{};
+    constexpr auto expected = std::array<uint8_t, 4>{5, 10, 15, 20};
+    uut.WriteBytes(expected.data(), 4);
+    auto actual = std::array<uint8_t, 4>{};
+    uut.ReadBytes(actual.data(), 4);
+
+    EXPECT_EQ(expected[0], actual[0]);
+    EXPECT_EQ(expected[1], actual[1]);
+    EXPECT_EQ(expected[2], actual[2]);
+    EXPECT_EQ(expected[3], actual[3]);
+    EXPECT_FALSE(uut.IsEOF());
+    EXPECT_FALSE(uut.IsFailed());
+}
+
+TEST(ByteArrayStreamTest, ExtractBuffer_hasExpectedData)
+{
+    const auto expected = std::vector<uint8_t>{10, 20, 30};
+    auto uut = nc::jolt::ByteArrayStream{expected};
+    const auto actual = uut.ExtractBuffer();
+
+    EXPECT_EQ(expected.size(), actual.size());
+    EXPECT_EQ(expected[0], actual[0]);
+    EXPECT_EQ(expected[1], actual[1]);
+    EXPECT_EQ(expected[2], actual[2]);
+    EXPECT_FALSE(uut.IsFailed());
+    EXPECT_FALSE(uut.IsEOF());
+    EXPECT_EQ(uut.GetBuffer().size(), 0);
+}
+
+TEST(ByteArrayStreamTest, EOFBehavior)
+{
+    auto uut = nc::jolt::ByteArrayStream{ {42} };
+    auto buffer = std::array<uint8_t, 1>{};
+    uut.ReadBytes(buffer.data(), 1);
+
+    EXPECT_EQ(buffer[0], 42);
+    EXPECT_FALSE(uut.IsEOF());
+    EXPECT_FALSE(uut.IsFailed());
+
+    uut.ReadBytes(buffer.data(), 1);
+    EXPECT_TRUE(uut.IsFailed());
+}

--- a/test/ncjolt/CMakeLists.txt
+++ b/test/ncjolt/CMakeLists.txt
@@ -1,3 +1,27 @@
+### ByteArrayStream Tests ###
+add_executable(ByteArrayStream_unit_tests
+    ByteArrayStream_unit_tests.cpp
+)
+
+target_include_directories(ByteArrayStream_unit_tests
+    PRIVATE
+        ${NC_INCLUDE_DIR}
+        ${NC_SOURCE_DIR}
+)
+
+target_compile_options(ByteArrayStream_unit_tests
+    PUBLIC
+        ${NC_COMPILER_FLAGS}
+)
+
+target_link_libraries(ByteArrayStream_unit_tests
+    PRIVATE
+        NcJolt
+        gtest_main
+)
+
+add_test(ByteArrayStream_unit_tests ByteArrayStream_unit_tests)
+
 ### PhysicsAllocator Tests ###
 add_executable(PhysicsAllocator_unit_tests
     PhysicsAllocator_unit_tests.cpp


### PR DESCRIPTION
Binary serialization in jolt needs to go through `JPH::StreamIn`/`JPH::StreamOut` objects. Implementing these in terms of `std::vector` so we can easily plop the blobs into the nc-convert workflow.

PR into feature branch, so manual build [here](https://github.com/NcStudios/NcEngine/actions/runs/12718974890).