### PR TITLE
Renamed resource types

### DIFF
--- a/resources/shaders/Normals.psh
+++ b/resources/shaders/Normals.psh
@@ -5,10 +5,10 @@
 
 #include "Lighting.fxh"
 
-Texture2D     TextureBufferData[];
-SamplerState  TextureBufferData_sampler; // By convention, texture samplers must use the '_sampler' suffix
+Texture2D     Textures[];
+SamplerState  Textures_sampler; // By convention, texture samplers must use the '_sampler' suffix
 
-cbuffer EnvironmentBufferData
+cbuffer EnvironmentProperties
 {
     float4x4 cameraViewProjection;
     float4x4 cameraInvProjection;
@@ -30,7 +30,7 @@ struct MaterialData
     float padding3;
 };
 
-StructuredBuffer<MaterialData> MaterialBufferData : register(t1);
+StructuredBuffer<MaterialData> Materials : register(t1);
 
 struct PSInput 
 { 
@@ -49,9 +49,9 @@ struct PSOutput
 void main(in  PSInput  PSIn, out PSOutput PSOut)
 {
     float4 Color;
-    uint normalIndex = MaterialBufferData[PSIn.MaterialIndex].normalIndex;
-    Color = TextureBufferData[normalIndex].Sample(TextureBufferData_sampler, PSIn.UV);
+    uint normalIndex = Materials[PSIn.MaterialIndex].normalIndex;
+    Color = Textures[normalIndex].Sample(Textures_sampler, PSIn.UV);
     float3 viewDir = normalize(cameraPosition - PSIn.WorldPos);
-    float3 adjustedNormals = PSIn.Normal * MaterialBufferData[PSIn.MaterialIndex].normalIntensity;
+    float3 adjustedNormals = PSIn.Normal * Materials[PSIn.MaterialIndex].normalIntensity;
     PSOut.Color = float4(adjustedNormals, 1-dot(PSIn.Normal, -viewDir));
 }

--- a/resources/shaders/PPEnd.psh
+++ b/resources/shaders/PPEnd.psh
@@ -3,11 +3,11 @@
 #   define NonUniformResourceIndex(x) x
 #endif
 
-Texture2D     PostProcessColorSinkBufferData[];
-Texture2D     PostProcessDepthSinkBufferData[];
-SamplerState  PostProcessColorSinkBufferData_sampler; // By convention, texture samplers must use the '_sampler' suffix
+Texture2D     ColorSinks[];
+Texture2D     DepthSinks[];
+SamplerState  ColorSinks_sampler; // By convention, texture samplers must use the '_sampler' suffix
 
-cbuffer PostProcessSinkIndexBufferData
+cbuffer SinkIndices
 {
     uint colorRT1;
     uint colorRT2;
@@ -32,5 +32,5 @@ struct PSOutput
 
 void main(in PSInput PSIn, out PSOutput PSOut)
 {
-    PSOut.Color = PostProcessColorSinkBufferData[colorRT1].Sample(PostProcessColorSinkBufferData_sampler, PSIn.UV);;
+    PSOut.Color = ColorSinks[colorRT1].Sample(ColorSinks_sampler, PSIn.UV);;
 }

--- a/resources/shaders/PPFxaa.psh
+++ b/resources/shaders/PPFxaa.psh
@@ -1,10 +1,10 @@
 // Much credit to Timothy Lottes and Simon Rodriguez https://blog.simonrodriguez.fr/articles/2016/07/implementing_fxaa.html
 
-Texture2D     PostProcessColorSinkBufferData[];
-Texture2D     PostProcessDepthSinkBufferData[];
-SamplerState  PostProcessColorSinkBufferData_sampler; // By convention, texture samplers must use the '_sampler' suffix
+Texture2D     ColorSinks[];
+Texture2D     DepthSinks[];
+SamplerState  ColorSinks_sampler; // By convention, texture samplers must use the '_sampler' suffix
 
-cbuffer EnvironmentBufferData
+cbuffer EnvironmentProperties
 {
     float4x4 cameraViewProjection;
     float4x4 cameraInvProjection;
@@ -14,7 +14,7 @@ cbuffer EnvironmentBufferData
     float farClip;
 };
 
-cbuffer PostProcessSinkIndexBufferData
+cbuffer SinkIndices
 {
     uint colorRT1;
     uint colorRT2;
@@ -49,8 +49,8 @@ static float SubpixelQuality = 0.75f;
 void main(in PSInput PSIn, out PSOutput PSOut)
 {
     // Alias the resource names
-    SamplerState smplr = PostProcessColorSinkBufferData_sampler;
-    Texture2D colorTex = PostProcessColorSinkBufferData[colorRT1];
+    SamplerState smplr = ColorSinks_sampler;
+    Texture2D colorTex = ColorSinks[colorRT1];
     float4 sceneColor = colorTex.Sample(smplr, PSIn.UV);
 
     // Get screen dimensions

--- a/resources/shaders/PPOutline.psh
+++ b/resources/shaders/PPOutline.psh
@@ -1,10 +1,10 @@
 // Much credit given to: https://roystan.net/articles/outline-shader/
 
-Texture2D     PostProcessColorSinkBufferData[];
-Texture2D     PostProcessDepthSinkBufferData[];
-SamplerState  PostProcessColorSinkBufferData_sampler; // By convention, texture samplers must use the '_sampler' suffix
+Texture2D     ColorSinks[];
+Texture2D     DepthSinks[];
+SamplerState  ColorSinks_sampler; // By convention, texture samplers must use the '_sampler' suffix
 
-cbuffer EnvironmentBufferData
+cbuffer EnvironmentProperties
 {
     float4x4 cameraViewProjection;
     float4x4 cameraInvProjection;
@@ -14,7 +14,7 @@ cbuffer EnvironmentBufferData
     float farClip;
 };
 
-cbuffer PostProcessSinkIndexBufferData
+cbuffer SinkIndices
 {
     uint colorRT1;
     uint colorRT2;
@@ -26,7 +26,7 @@ cbuffer PostProcessSinkIndexBufferData
     uint depthRT4;
 };
 
-cbuffer OutlinePassBufferData
+cbuffer OutlinePassProperties
 {
     float3 outlineColor;
     float outlineWidth;
@@ -101,10 +101,10 @@ float OutlineNormals(Texture2D normalsTex, SamplerState smplr, float2 LLUV, floa
 void main(in PSInput PSIn, out PSOutput PSOut)
 {
     // Alias the resource names
-    SamplerState smplr = PostProcessColorSinkBufferData_sampler;
-    Texture2D depthTex = PostProcessDepthSinkBufferData[depthRT1];
-    Texture2D colorTex = PostProcessColorSinkBufferData[colorRT1];
-    Texture2D normalTex = PostProcessColorSinkBufferData[colorRT2];
+    SamplerState smplr = ColorSinks_sampler;
+    Texture2D depthTex = DepthSinks[depthRT1];
+    Texture2D colorTex = ColorSinks[colorRT1];
+    Texture2D normalTex = ColorSinks[colorRT2];
 
     // Get screen dimensions
     uint screenWidth, screenHeight;

--- a/resources/shaders/PPWave.psh
+++ b/resources/shaders/PPWave.psh
@@ -3,11 +3,11 @@
 #   define NonUniformResourceIndex(x) x
 #endif
 
-Texture2D     PostProcessColorSinkBufferData[];
-Texture2D     PostProcessDepthSinkBufferData[];
-SamplerState  PostProcessColorSinkBufferData_sampler; // By convention, texture samplers must use the '_sampler' suffix
+Texture2D     ColorSinks[];
+Texture2D     DepthSinks[];
+SamplerState  ColorSinks_sampler; // By convention, texture samplers must use the '_sampler' suffix
 
-cbuffer PostProcessSinkIndexBufferData
+cbuffer SinkIndices
 {
     uint colorRT1;
     uint colorRT2;
@@ -33,7 +33,7 @@ struct PSOutput
 void main(in PSInput PSIn, out PSOutput PSOut)
 {
     float2 DistortedUV = PSIn.UV + float2(sin(PSIn.UV.y * 100) * 0.1 * sin(PSIn.UV.x * 100.0) * 0.05);
-    float4 Color = PostProcessColorSinkBufferData[colorRT1].Sample(PostProcessColorSinkBufferData_sampler, DistortedUV);
+    float4 Color = ColorSinks[colorRT1].Sample(ColorSinks_sampler, DistortedUV);
 
     PSOut.Color = Color;
 }

--- a/resources/shaders/Particle.psh
+++ b/resources/shaders/Particle.psh
@@ -10,10 +10,10 @@ struct PSOutput
     float4 Color : SV_TARGET;
 };
 
-Texture2D     TextureBufferData[];
-SamplerState  TextureBufferData_sampler;
+Texture2D     Textures[];
+SamplerState  Textures_sampler;
 
 void main(in PSInput PSIn, out PSOutput PSOut)
 {
-    PSOut.Color = TextureBufferData[PSIn.TextureIndex].Sample(TextureBufferData_sampler, PSIn.UV);
+    PSOut.Color = Textures[PSIn.TextureIndex].Sample(Textures_sampler, PSIn.UV);
 }

--- a/resources/shaders/Particle.vsh
+++ b/resources/shaders/Particle.vsh
@@ -12,7 +12,7 @@ struct PSOutput
     uint   TextureIndex;
 };
 
-cbuffer EnvironmentBufferData
+cbuffer EnvironmentProperties
 {
     float4x4 cameraViewProjection;
     float4x4 cameraInvProjection;
@@ -28,11 +28,11 @@ struct ParticleData
     uint textureIndex;
 };
 
-StructuredBuffer<ParticleData> ParticleBufferData;
+StructuredBuffer<ParticleData> Particles;
 
 void main(in VSInput VSIn, uint InstanceID : SV_InstanceID, out PSOutput PSOut)
 {
-    ParticleData particle = ParticleBufferData[InstanceID];
+    ParticleData particle = Particles[InstanceID];
     float4 TransformedPos = mul(float4(VSIn.Pos, 1.0), particle.model);
     PSOut.Pos = mul(TransformedPos, cameraViewProjection);
     PSOut.UV = VSIn.UV;

--- a/resources/shaders/Toon.psh
+++ b/resources/shaders/Toon.psh
@@ -5,10 +5,10 @@
 
 #include "Lighting.fxh"
 
-Texture2D     TextureBufferData[];
-SamplerState  TextureBufferData_sampler; // By convention, texture samplers must use the '_sampler' suffix
+Texture2D     Textures[];
+SamplerState  Textures_sampler; // By convention, texture samplers must use the '_sampler' suffix
 
-cbuffer EnvironmentBufferData
+cbuffer EnvironmentProperties
 {
     float4x4 cameraViewProjection;
     float4x4 cameraInvProjection;
@@ -30,8 +30,8 @@ struct MaterialData
     float padding3;
 };
 
-StructuredBuffer<MaterialData> MaterialBufferData : register(t1);
-StructuredBuffer<LightData> LightBufferData : register(t2);
+StructuredBuffer<MaterialData> Materials : register(t1);
+StructuredBuffer<LightData> Lights : register(t2);
 
 struct PSInput 
 { 
@@ -67,14 +67,14 @@ float LightBand(float lightAmount)
 void main(in  PSInput  PSIn, out PSOutput PSOut)
 {
     float4 Color;
-    uint TexIndex = MaterialBufferData[PSIn.MaterialIndex].diffuseTexture;
-    Color = TextureBufferData[TexIndex].Sample(TextureBufferData_sampler, PSIn.UV);
+    uint TexIndex = Materials[PSIn.MaterialIndex].diffuseTexture;
+    Color = Textures[TexIndex].Sample(Textures_sampler, PSIn.UV);
     float alpha = Color.a;
     float3 finalColor = {0.0f, 0.0f, 0.0f};
 
     for (int i = 0; i < lightCount; i++)
     {
-        LightInfluence influence = LightRadiance(LightBufferData[i], PSIn.WorldPos, cameraPosition, PSIn.Normal);
+        LightInfluence influence = LightRadiance(Lights[i], PSIn.WorldPos, cameraPosition, PSIn.Normal);
         finalColor += influence.color * LightBand(influence.specularAmt + influence.diffuseAmt);
     }
 

--- a/resources/shaders/Toon.vsh
+++ b/resources/shaders/Toon.vsh
@@ -20,7 +20,7 @@ struct TransformData
     float4x4 model;
 };
 
-StructuredBuffer<TransformData> TransformBufferData;
+StructuredBuffer<TransformData> Transforms;
 
 struct StaticMeshInstanceData
 {
@@ -28,9 +28,9 @@ struct StaticMeshInstanceData
     uint materialIndex;
 };
 
-StructuredBuffer<StaticMeshInstanceData> StaticInstanceBufferData;
+StructuredBuffer<StaticMeshInstanceData> StaticInstances;
 
-cbuffer EnvironmentBufferData
+cbuffer EnvironmentProperties
 {
     float4x4 cameraViewProjection;
     float4x4 cameraInvProjection;
@@ -41,12 +41,12 @@ cbuffer EnvironmentBufferData
 };
 void main(in  VSInput VSIn, uint InstanceID : SV_InstanceID,  out PSInput PSIn)
 {
-    uint transformIndex = StaticInstanceBufferData[InstanceID].transformIndex;
-    uint materialIndex = StaticInstanceBufferData[InstanceID].materialIndex;
-    float4 TransformedPos = mul(float4(VSIn.Pos, 1.0), TransformBufferData[transformIndex].model);
+    uint transformIndex = StaticInstances[InstanceID].transformIndex;
+    uint materialIndex = StaticInstances[InstanceID].materialIndex;
+    float4 TransformedPos = mul(float4(VSIn.Pos, 1.0), Transforms[transformIndex].model);
     PSIn.Pos = mul(TransformedPos, cameraViewProjection);
     PSIn.UV  = VSIn.UV;
-    PSIn.Normal = normalize(mul(TransformBufferData[transformIndex].model, VSIn.Normal)); // @TODO #805, compute inverse model matrix CPU-side
+    PSIn.Normal = normalize(mul(Transforms[transformIndex].model, VSIn.Normal)); // @TODO #805, compute inverse model matrix CPU-side
     PSIn.WorldPos = TransformedPos.xyz;
     PSIn.MaterialIndex = materialIndex;
 }

--- a/resources/shaders/ToonSkinned.vsh
+++ b/resources/shaders/ToonSkinned.vsh
@@ -23,7 +23,7 @@ struct TransformData
     float4x4 modelMatrix;
 };
 
-StructuredBuffer<TransformData> TransformBufferData;
+StructuredBuffer<TransformData> Transforms;
 
 // todo: #802 Define this at compile time
 #define ENABLE_SKINNING 1
@@ -37,17 +37,17 @@ struct SkinnedMeshInstanceData
     uint boneIndex;
 };
 
-StructuredBuffer<SkinnedMeshInstanceData> SkinnedInstanceBufferData;
+StructuredBuffer<SkinnedMeshInstanceData> SkinnedInstances;
 
 #define INSTANCE_DATA SkinnedMeshInstanceData
-#define INSTANCE_BUFFER SkinnedInstanceBufferData
+#define INSTANCE_BUFFER SkinnedInstances
 
 struct BoneData
 {
     float4x4 animatedBoneMatrix;
 };
 
-StructuredBuffer<BoneData> BoneBufferData;
+StructuredBuffer<BoneData> Bones;
 
 bool IsValidBoneIndex(uint boneIndex)
 {
@@ -70,7 +70,7 @@ float4x4 CombineBoneMatrices(uint base, uint4 boneOffsets, float4 boneWeights)
     {
         if (boneWeights[i] > 0.0f)
         {
-            boneTransform += BoneBufferData[base + boneOffsets[i]].animatedBoneMatrix * boneWeights[i];
+            boneTransform += Bones[base + boneOffsets[i]].animatedBoneMatrix * boneWeights[i];
         }
     }
 
@@ -85,14 +85,14 @@ struct StaticMeshInstanceData
     uint materialIndex;
 };
 
-StructuredBuffer<StaticMeshInstanceData> StaticInstanceBufferData;
+StructuredBuffer<StaticMeshInstanceData> StaticInstances;
 
 #define INSTANCE_DATA StaticMeshInstanceData
-#define INSTANCE_BUFFER StaticInstanceBufferData
+#define INSTANCE_BUFFER StaticInstances
 
 #endif // ENABLE_SKINNING
 
-cbuffer EnvironmentBufferData
+cbuffer EnvironmentProperties
 {
     float4x4 cameraViewProjection;
     float4x4 cameraInvProjection;
@@ -121,10 +121,10 @@ void main(in VSInput VSIn, uint InstanceID : SV_InstanceID, out PSInput PSIn)
 #endif // ENABLE_SKINNING
 
     uint transformIndex = instance.transformIndex;
-    float4 worldPos = mul(pos, TransformBufferData[transformIndex].modelMatrix);
+    float4 worldPos = mul(pos, Transforms[transformIndex].modelMatrix);
     PSIn.Pos = mul(worldPos, cameraViewProjection);
     PSIn.UV = VSIn.UV;
-    PSIn.Normal = normalize(mul(TransformBufferData[transformIndex].modelMatrix, normal)); // @TODO #805, compute inverse model matrix CPU-side
+    PSIn.Normal = normalize(mul(Transforms[transformIndex].modelMatrix, normal)); // @TODO #805, compute inverse model matrix CPU-side
     PSIn.WorldPos = worldPos.xyz;
     PSIn.MaterialIndex = instance.materialIndex;
 }

--- a/resources/shaders/Wireframe.psh
+++ b/resources/shaders/Wireframe.psh
@@ -1,4 +1,4 @@
-cbuffer Wireframes
+cbuffer WireframeProperties
 {
     float4x4 wireframeModelMatrix;
     float4 wireframeColor;

--- a/resources/shaders/Wireframe.psh
+++ b/resources/shaders/Wireframe.psh
@@ -1,4 +1,4 @@
-cbuffer WireframeBufferData
+cbuffer Wireframes
 {
     float4x4 wireframeModelMatrix;
     float4 wireframeColor;

--- a/resources/shaders/Wireframe.vsh
+++ b/resources/shaders/Wireframe.vsh
@@ -8,7 +8,7 @@ struct PSInput
     float4 Pos : SV_POSITION;
 };
 
-cbuffer EnvironmentBufferData
+cbuffer EnvironmentProperties
 {
     float4x4 cameraViewProjection;
     float4x4 cameraInvProjection;
@@ -16,7 +16,7 @@ cbuffer EnvironmentBufferData
     uint lightCount;
 };
 
-cbuffer WireframeBufferData
+cbuffer Wireframes
 {
     float4x4 wireframeModelMatrix;
     float4 wireframeColor;

--- a/resources/shaders/Wireframe.vsh
+++ b/resources/shaders/Wireframe.vsh
@@ -16,7 +16,7 @@ cbuffer EnvironmentProperties
     uint lightCount;
 };
 
-cbuffer Wireframes
+cbuffer WireframeProperties
 {
     float4x4 wireframeModelMatrix;
     float4 wireframeColor;

--- a/source/ncengine/graphics2/diligent/pass/PassBackend.cpp
+++ b/source/ncengine/graphics2/diligent/pass/PassBackend.cpp
@@ -108,8 +108,8 @@ PassBackend::PassBackend(Diligent::IRenderDevice& device,
       m_depthSinkCountMsaa{0u}
 {
     // Sink target buffers
-    auto& postProcessColorSinks = shaderBindings.GetPerPassSignature().GetColorSinkBufferResource();
-    auto& postProcessDepthSinks = shaderBindings.GetPerPassSignature().GetDepthSinkBufferResource();
+    auto& ColorSinks = shaderBindings.GetPerPassSignature().GetColorSinkBufferResource();
+    auto& depthSinks = shaderBindings.GetPerPassSignature().GetDepthSinkBufferResource();
 
     m_staticMaterialPasses = MakeMaterialPasses
     (
@@ -173,15 +173,15 @@ PassBackend::PassBackend(Diligent::IRenderDevice& device,
     m_finalPass = std::make_unique<PostProcessPass>(MakePostProcessPass(device, swapChain, shaderFactory, shaderBindings, finalPass));
 
     // Make all the off screen render targets that will be used by the passes
-    postProcessColorSinks.Add(device, passManifest.ColorSinkCount(), swapChain.GetDesc().Width, swapChain.GetDesc().Height);
-    postProcessDepthSinks.Add(device, passManifest.DepthSinkCount(), swapChain.GetDesc().Width, swapChain.GetDesc().Height);
+    ColorSinks.Add(device, passManifest.ColorSinkCount(), swapChain.GetDesc().Width, swapChain.GetDesc().Height);
+    depthSinks.Add(device, passManifest.DepthSinkCount(), swapChain.GetDesc().Width, swapChain.GetDesc().Height);
 
     if (m_numSamples > 1)
     {
         m_colorSinkCountMsaa = passManifest.ColorSinkCountMsaa();
         m_depthSinkCountMsaa = passManifest.DepthSinkCountMsaa();
-        postProcessColorSinks.Add(device, m_colorSinkCountMsaa, swapChain.GetDesc().Width, swapChain.GetDesc().Height, m_numSamples);
-        postProcessDepthSinks.Add(device, m_depthSinkCountMsaa, swapChain.GetDesc().Width, swapChain.GetDesc().Height, m_numSamples);
+        ColorSinks.Add(device, m_colorSinkCountMsaa, swapChain.GetDesc().Width, swapChain.GetDesc().Height, m_numSamples);
+        depthSinks.Add(device, m_depthSinkCountMsaa, swapChain.GetDesc().Width, swapChain.GetDesc().Height, m_numSamples);
     }
 }
 

--- a/source/ncengine/graphics2/diligent/resource/PerFrameResourceSignature.cpp
+++ b/source/ncengine/graphics2/diligent/resource/PerFrameResourceSignature.cpp
@@ -14,17 +14,17 @@ PerFrameResourceSignature::PerFrameResourceSignature(Diligent::IDeviceContext& c
                                                      Diligent::IRenderDevice& device,
                                                      std::string_view signatureName,
                                                      uint8_t bindingIndex,
-                                                     const StructuredBufferResourceDesc& transformResourceDesc,
-                                                     const StructuredBufferResourceDesc& staticMeshInstanceResourceDesc,
-                                                     const StructuredBufferResourceDesc& skinnedMeshInstanceResourceDesc,
-                                                     const StructuredBufferResourceDesc& lightResourceDesc,
-                                                     const StructuredBufferResourceDesc& materialResourceDesc,
-                                                     const StructuredBufferResourceDesc& boneResourceDesc,
-                                                     const StructuredBufferResourceDesc& particleResourceDesc,
-                                                     const TextureBufferResourceDesc& textureResourceDesc,
-                                                     const UniformBufferResourceDesc& environmentResourceDesc,
-                                                     const UniformBufferResourceDesc& wireframeResourceDesc,
-                                                     const UniformBufferResourceDesc& outlinePassPropertiesDesc)
+                                                     const StructuredBufferDesc& transformResourceDesc,
+                                                     const StructuredBufferDesc& staticMeshInstanceResourceDesc,
+                                                     const StructuredBufferDesc& skinnedMeshInstanceResourceDesc,
+                                                     const StructuredBufferDesc& lightResourceDesc,
+                                                     const StructuredBufferDesc& materialResourceDesc,
+                                                     const StructuredBufferDesc& boneResourceDesc,
+                                                     const StructuredBufferDesc& particleResourceDesc,
+                                                     const TextureBufferDesc& textureResourceDesc,
+                                                     const UniformBufferDesc& environmentResourceDesc,
+                                                     const UniformBufferDesc& wireframeResourceDesc,
+                                                     const UniformBufferDesc& outlinePassPropertiesDesc)
 {
     const auto resources = std::array{
         ToPipelineResourceDesc(transformResourceDesc),

--- a/source/ncengine/graphics2/diligent/resource/PerFrameResourceSignature.h
+++ b/source/ncengine/graphics2/diligent/resource/PerFrameResourceSignature.h
@@ -25,17 +25,17 @@ class PerFrameResourceSignature
                                            Diligent::IRenderDevice& device,
                                            std::string_view signatureName,
                                            uint8_t bindingIndex,
-                                           const StructuredBufferResourceDesc& transformResourceDesc,
-                                           const StructuredBufferResourceDesc& staticMeshInstanceResourceDesc,
-                                           const StructuredBufferResourceDesc& skinnedMeshInstanceResourceDesc,
-                                           const StructuredBufferResourceDesc& lightResourceDesc,
-                                           const StructuredBufferResourceDesc& materialResourceDesc,
-                                           const StructuredBufferResourceDesc& boneResourceDesc,
-                                           const StructuredBufferResourceDesc& particleResourceDesc,
-                                           const TextureBufferResourceDesc& textureResourceDesc,
-                                           const UniformBufferResourceDesc& environmentResourceDesc,
-                                           const UniformBufferResourceDesc& wireframeResourceDesc,
-                                           const UniformBufferResourceDesc& outlinePassPropertiesDesc);
+                                           const StructuredBufferDesc& transformResourceDesc,
+                                           const StructuredBufferDesc& staticMeshInstanceResourceDesc,
+                                           const StructuredBufferDesc& skinnedMeshInstanceResourceDesc,
+                                           const StructuredBufferDesc& lightResourceDesc,
+                                           const StructuredBufferDesc& materialResourceDesc,
+                                           const StructuredBufferDesc& boneResourceDesc,
+                                           const StructuredBufferDesc& particleResourceDesc,
+                                           const TextureBufferDesc& textureResourceDesc,
+                                           const UniformBufferDesc& environmentResourceDesc,
+                                           const UniformBufferDesc& wireframeResourceDesc,
+                                           const UniformBufferDesc& outlinePassPropertiesDesc);
         ~PerFrameResourceSignature() noexcept;
 
         void Commit(Diligent::IDeviceContext& context) { context.CommitShaderResources(m_srb, Diligent::RESOURCE_STATE_TRANSITION_MODE_VERIFY); }

--- a/source/ncengine/graphics2/diligent/resource/PerPassResourceSignature.cpp
+++ b/source/ncengine/graphics2/diligent/resource/PerPassResourceSignature.cpp
@@ -12,9 +12,9 @@ PerPassResourceSignature::PerPassResourceSignature(Diligent::IRenderDevice& devi
                                                    Diligent::IDeviceContext& context,
                                                    std::string_view signatureName,
                                                    uint8_t bindingIndex,
-                                                   const TextureBufferResourceDesc& colorSinkResourceDesc,
-                                                   const TextureBufferResourceDesc& depthSinkResourceDesc,
-                                                   const UniformBufferResourceDesc& sinkIndexResourceDesc)
+                                                   const TextureBufferDesc& colorSinkResourceDesc,
+                                                   const TextureBufferDesc& depthSinkResourceDesc,
+                                                   const UniformBufferDesc& sinkIndexResourceDesc)
 {
     const auto resources = std::array{
         ToPipelineResourceDesc(colorSinkResourceDesc),

--- a/source/ncengine/graphics2/diligent/resource/PerPassResourceSignature.h
+++ b/source/ncengine/graphics2/diligent/resource/PerPassResourceSignature.h
@@ -21,9 +21,9 @@ class PerPassResourceSignature
                                           Diligent::IDeviceContext& context,
                                           std::string_view signatureName,
                                           uint8_t bindingIndex,
-                                          const TextureBufferResourceDesc& colorRTResourceDesc,
-                                          const TextureBufferResourceDesc& depthRTResourceDesc,
-                                          const UniformBufferResourceDesc& sinkIndexDesc);
+                                          const TextureBufferDesc& colorRTResourceDesc,
+                                          const TextureBufferDesc& depthRTResourceDesc,
+                                          const UniformBufferDesc& sinkIndexDesc);
 
         ~PerPassResourceSignature() noexcept;
 

--- a/source/ncengine/graphics2/diligent/resource/ResourceTypes.cpp
+++ b/source/ncengine/graphics2/diligent/resource/ResourceTypes.cpp
@@ -23,7 +23,7 @@ auto ToCommonShaderType(Diligent::SHADER_TYPE shaderType) -> Diligent::SHADER_TY
 
 namespace nc::graphics
 {
-auto ToPipelineResourceDesc(const UniformBufferResourceDesc& resourceDesc) -> Diligent::PipelineResourceDesc
+auto ToPipelineResourceDesc(const UniformBufferDesc& resourceDesc) -> Diligent::PipelineResourceDesc
 {
     return Diligent::PipelineResourceDesc
     {
@@ -34,7 +34,7 @@ auto ToPipelineResourceDesc(const UniformBufferResourceDesc& resourceDesc) -> Di
     };
 }
 
-auto ToPipelineResourceDesc(const StructuredBufferResourceDesc& resourceDesc) -> Diligent::PipelineResourceDesc
+auto ToPipelineResourceDesc(const StructuredBufferDesc& resourceDesc) -> Diligent::PipelineResourceDesc
 {
     return Diligent::PipelineResourceDesc
     {
@@ -47,7 +47,7 @@ auto ToPipelineResourceDesc(const StructuredBufferResourceDesc& resourceDesc) ->
     };
 }
 
-auto ToPipelineResourceDesc(const TextureBufferResourceDesc& resourceDesc) -> Diligent::PipelineResourceDesc
+auto ToPipelineResourceDesc(const TextureBufferDesc& resourceDesc) -> Diligent::PipelineResourceDesc
 {
     return Diligent::PipelineResourceDesc{
         resourceDesc.shaderType,

--- a/source/ncengine/graphics2/diligent/resource/ResourceTypes.h
+++ b/source/ncengine/graphics2/diligent/resource/ResourceTypes.h
@@ -7,30 +7,30 @@
 
 namespace nc::graphics
 {
-struct StructuredBufferResourceDesc
+struct StructuredBufferDesc
 {
-    std::string resourceKey = "UninitializedStructuredBufferResourceDesc";
+    std::string resourceKey = "UninitializedStructuredBufferDesc";
     Diligent::SHADER_TYPE shaderType = Diligent::SHADER_TYPE_UNKNOWN;
     uint32_t maxElementCount = 1u;
     uint32_t initialElementCount = 1u;
 };
 
-struct TextureBufferResourceDesc
+struct TextureBufferDesc
 {
-    std::string resourceKey = "UninitializedTextureBufferResourceDesc";
+    std::string resourceKey = "UninitializedTextureBufferDesc";
     Diligent::SHADER_TYPE shaderType = Diligent::SHADER_TYPE_UNKNOWN;
     uint32_t maxElementCount = 1u;
 };
 
-struct UniformBufferResourceDesc
+struct UniformBufferDesc
 {
-    std::string resourceKey = "UninitializedUniformBufferResourceDesc";
+    std::string resourceKey = "UninitializedUniformBufferDesc";
     Diligent::SHADER_TYPE shaderType = Diligent::SHADER_TYPE_UNKNOWN;
 };
 
-auto ToPipelineResourceDesc(const UniformBufferResourceDesc& resourceDesc) -> Diligent::PipelineResourceDesc;
-auto ToPipelineResourceDesc(const TextureBufferResourceDesc& resourceDesc) -> Diligent::PipelineResourceDesc;
-auto ToPipelineResourceDesc(const StructuredBufferResourceDesc& resourceDesc) -> Diligent::PipelineResourceDesc;
+auto ToPipelineResourceDesc(const UniformBufferDesc& resourceDesc) -> Diligent::PipelineResourceDesc;
+auto ToPipelineResourceDesc(const TextureBufferDesc& resourceDesc) -> Diligent::PipelineResourceDesc;
+auto ToPipelineResourceDesc(const StructuredBufferDesc& resourceDesc) -> Diligent::PipelineResourceDesc;
 
 auto GetVariable(Diligent::SHADER_TYPE shaderType, const char* name, Diligent::IShaderResourceBinding* srb) -> Diligent::IShaderResourceVariable&;
 

--- a/source/ncengine/graphics2/diligent/resource/ShaderBindings.h
+++ b/source/ncengine/graphics2/diligent/resource/ShaderBindings.h
@@ -33,7 +33,7 @@ class ShaderBindings
                 StructuredBufferDesc{"Particles",          Diligent::SHADER_TYPE_VS_PS,  memorySettings.maxParticles,         memorySettings.maxParticles / 4},
                 TextureBufferDesc{"Textures",              Diligent::SHADER_TYPE_PIXEL,  memorySettings.maxTextures},
                 UniformBufferDesc{"EnvironmentProperties", Diligent::SHADER_TYPE_VS_PS},
-                UniformBufferDesc{"Wireframes",            Diligent::SHADER_TYPE_VS_PS},
+                UniformBufferDesc{"WireframeProperties",   Diligent::SHADER_TYPE_VS_PS},
                 UniformBufferDesc{"OutlinePassProperties", Diligent::SHADER_TYPE_PIXEL}
               },
               m_perPassSignature{

--- a/source/ncengine/graphics2/diligent/resource/ShaderBindings.h
+++ b/source/ncengine/graphics2/diligent/resource/ShaderBindings.h
@@ -24,25 +24,25 @@ class ShaderBindings
                 context, device,
                 "PerFrameResourceSignature",
                 0,
-                StructuredBufferResourceDesc{"TransformBufferData",        Diligent::SHADER_TYPE::SHADER_TYPE_VERTEX, memorySettings.maxRenderers,         memorySettings.maxRenderers / 2},
-                StructuredBufferResourceDesc{"StaticInstanceBufferData",   Diligent::SHADER_TYPE::SHADER_TYPE_VERTEX, memorySettings.maxRenderers,         memorySettings.maxRenderers / 2},
-                StructuredBufferResourceDesc{"SkinnedInstanceBufferData",  Diligent::SHADER_TYPE::SHADER_TYPE_VERTEX, memorySettings.maxRenderers,         memorySettings.maxRenderers / 2},
-                StructuredBufferResourceDesc{"LightBufferData",            Diligent::SHADER_TYPE::SHADER_TYPE_VS_PS,  GetTotalLightCount(memorySettings),  GetTotalLightCount(memorySettings)},
-                StructuredBufferResourceDesc{"MaterialBufferData",         Diligent::SHADER_TYPE::SHADER_TYPE_PIXEL,  memorySettings.maxRenderers,         memorySettings.maxRenderers / 2},
-                StructuredBufferResourceDesc{"BoneBufferData",             Diligent::SHADER_TYPE::SHADER_TYPE_VERTEX, memorySettings.maxBones,             memorySettings.maxBones / 4},
-                StructuredBufferResourceDesc{"ParticleBufferData",         Diligent::SHADER_TYPE::SHADER_TYPE_VS_PS,  memorySettings.maxParticles,         memorySettings.maxParticles / 4},
-                TextureBufferResourceDesc{"TextureBufferData",             Diligent::SHADER_TYPE::SHADER_TYPE_PIXEL,  memorySettings.maxTextures},
-                UniformBufferResourceDesc{"EnvironmentBufferData",         Diligent::SHADER_TYPE::SHADER_TYPE_VS_PS},
-                UniformBufferResourceDesc{"WireframeBufferData",           Diligent::SHADER_TYPE::SHADER_TYPE_VS_PS},
-                UniformBufferResourceDesc{"OutlinePassBufferData",         Diligent::SHADER_TYPE::SHADER_TYPE_PIXEL}
+                StructuredBufferDesc{"Transforms",         Diligent::SHADER_TYPE_VERTEX, memorySettings.maxRenderers,         memorySettings.maxRenderers / 2},
+                StructuredBufferDesc{"StaticInstances",    Diligent::SHADER_TYPE_VERTEX, memorySettings.maxRenderers,         memorySettings.maxRenderers / 2},
+                StructuredBufferDesc{"SkinnedInstances",   Diligent::SHADER_TYPE_VERTEX, memorySettings.maxRenderers,         memorySettings.maxRenderers / 2},
+                StructuredBufferDesc{"Lights",             Diligent::SHADER_TYPE_VS_PS,  GetTotalLightCount(memorySettings),  GetTotalLightCount(memorySettings)},
+                StructuredBufferDesc{"Materials",          Diligent::SHADER_TYPE_PIXEL,  memorySettings.maxRenderers,         memorySettings.maxRenderers / 2},
+                StructuredBufferDesc{"Bones",              Diligent::SHADER_TYPE_VERTEX, memorySettings.maxBones,             memorySettings.maxBones / 4},
+                StructuredBufferDesc{"Particles",          Diligent::SHADER_TYPE_VS_PS,  memorySettings.maxParticles,         memorySettings.maxParticles / 4},
+                TextureBufferDesc{"Textures",              Diligent::SHADER_TYPE_PIXEL,  memorySettings.maxTextures},
+                UniformBufferDesc{"EnvironmentProperties", Diligent::SHADER_TYPE_VS_PS},
+                UniformBufferDesc{"Wireframes",            Diligent::SHADER_TYPE_VS_PS},
+                UniformBufferDesc{"OutlinePassProperties", Diligent::SHADER_TYPE_PIXEL}
               },
               m_perPassSignature{
                 device, context,
                 "PerPassResourceSignature",
                 1,
-                TextureBufferResourceDesc{"PostProcessColorSinkBufferData", Diligent::SHADER_TYPE::SHADER_TYPE_PIXEL, 20},
-                TextureBufferResourceDesc{"PostProcessDepthSinkBufferData", Diligent::SHADER_TYPE::SHADER_TYPE_PIXEL, 20},
-                UniformBufferResourceDesc{"PostProcessSinkIndexBufferData", Diligent::SHADER_TYPE::SHADER_TYPE_PIXEL}
+                TextureBufferDesc{"ColorSinks", Diligent::SHADER_TYPE_PIXEL, 20},
+                TextureBufferDesc{"DepthSinks", Diligent::SHADER_TYPE_PIXEL, 20},
+                UniformBufferDesc{"SinkIndices", Diligent::SHADER_TYPE_PIXEL}
             }
         {
         }

--- a/source/ncengine/graphics2/diligent/resource/base/StructuredBuffer.h
+++ b/source/ncengine/graphics2/diligent/resource/base/StructuredBuffer.h
@@ -52,7 +52,7 @@ class StructuredBuffer : public StructuredBufferBase
         explicit StructuredBuffer(Diligent::IDeviceContext& context,
                                   Diligent::IRenderDevice& device,
                                   Diligent::IShaderResourceVariable& variable,
-                                  const StructuredBufferResourceDesc& resourceDesc)
+                                  const StructuredBufferDesc& resourceDesc)
             : StructuredBufferBase{resourceDesc.resourceKey, variable, resourceDesc.maxElementCount, resourceDesc.initialElementCount}
         {
             CreateBuffer(context, device, resourceDesc.initialElementCount);

--- a/test/integration_test/ncengine/graphics2/EnvironmentBufferResource_tests.cpp
+++ b/test/integration_test/ncengine/graphics2/EnvironmentBufferResource_tests.cpp
@@ -16,7 +16,7 @@ class EnvironmentBufferResourceTest : public DiligentEngineFixture
         EnvironmentBufferResourceTest()
         {
             constexpr auto variableName = "EnvironmentDataUniformBuffer";
-            const auto resourceDesc = nc::graphics::UniformBufferResourceDesc{
+            const auto resourceDesc = nc::graphics::UniformBufferDesc{
                 variableName,
                 Diligent::SHADER_TYPE::SHADER_TYPE_PIXEL
             };

--- a/test/integration_test/ncengine/graphics2/StructuredBuffer_tests.cpp
+++ b/test/integration_test/ncengine/graphics2/StructuredBuffer_tests.cpp
@@ -22,7 +22,7 @@ class StructuredBufferTest : public DiligentEngineFixture
 
         StructuredBufferTest()
         {
-            const auto bufferDesc = nc::graphics::StructuredBufferResourceDesc{
+            const auto bufferDesc = nc::graphics::StructuredBufferDesc{
                 variableName,
                 Diligent::SHADER_TYPE::SHADER_TYPE_PIXEL,
                 maxInstanceCount,

--- a/test/integration_test/ncengine/graphics2/TextureBufferResource_tests.cpp
+++ b/test/integration_test/ncengine/graphics2/TextureBufferResource_tests.cpp
@@ -23,7 +23,7 @@ class TextureBufferResourceTest : public DiligentEngineFixture
         TextureBufferResourceTest()
         {
             constexpr auto variableName = "testTexture";
-            const auto resourceDesc = nc::graphics::TextureBufferResourceDesc{
+            const auto resourceDesc = nc::graphics::TextureBufferDesc{
                 .resourceKey = variableName,
                 .shaderType = Diligent::SHADER_TYPE_PIXEL,
                 .maxElementCount = maxTextures


### PR DESCRIPTION
I'm working primarily in `ShaderBindings` and the shaders to do this validation errors fix, so I decided to do a rename pass on all resource-related names. 

We had a lot of redundant naming that is now fixed. It's a lot easier to visually parse `ShaderBindings` and all the resources in the shaders now.