### PR TITLE
Spot Light Shadows

### DIFF
--- a/include/ncengine/config/Config.h
+++ b/include/ncengine/config/Config.h
@@ -1,6 +1,6 @@
 /**
  * @file Config.h
- * @copyright Jaremie Romer and McCallister Romer 2023
+ * @copyright Jaremie Romer and McCallister Romer 2025
  */
 #pragma once
 
@@ -75,6 +75,7 @@ struct GraphicsSettings
     unsigned screenHeight = 1000;        ///< height of the screen
     unsigned targetFPS = 60;             ///< target frame rate
     bool useShadows = true;              ///< enable shadow mapping and shadow rendering
+    unsigned shadowMapResolution = 2048; ///< shadow map resolution. Minimum value = 128
     unsigned antialiasing = 8u;          ///< the number of samples for MSAA
     unsigned initialBatchSize = 1u;      ///< default instance capacity for render batch allocation (size hint - can grow beyond this)
     bool useValidationLayers = false;    ///< turn on validation layers in debug builds

--- a/include/ncengine/graphics/GraphicsUtility.h
+++ b/include/ncengine/graphics/GraphicsUtility.h
@@ -33,13 +33,6 @@ auto GetMaterialPassNames() -> std::span<const std::string_view>;
 /** @brief Returns a view of all material pass flags, ordered by ascending flag value. */
 auto GetMaterialPassFlags() -> std::span<const MaterialPassFlag::type>;
 
-/**
- * @brief Returns a view of all currently implemented material pass flags.
- * @todo 794 Temporary solution while passes are being implemented. Add passes as they become available.
- *           Eventually, usage of this should switch to GetMaterialPassFlags().
- */
-auto GetImplementedMaterialPassFlags() -> std::span<const MaterialPassFlag::type>;
-
 /** @brief Returns a view of all miscellaneous pass flags, ordered by ascending flag value. */
 auto GetMiscsPassFlags() -> std::span<const MiscPassFlag::type>;
 

--- a/include/ncengine/graphics/Light.h
+++ b/include/ncengine/graphics/Light.h
@@ -35,5 +35,6 @@ struct SpotLight
     float innerAngle = 0.3491f;
     float outerAngle = 0.5236f;
     float radius = 25.0f;
+    bool castsShadows = true;
 };
 } // namespace nc

--- a/resources/shaders/Lighting.fxh
+++ b/resources/shaders/Lighting.fxh
@@ -30,7 +30,7 @@ float CalculateSpecular(float3 L, float3 V, float3 N)
 {
     float3 H = normalize(L + V);
     float NDotH = max(0, dot(N, H));
-    return pow(NDotH, 32);
+    return max(pow(NDotH, 32), 0.0f);
 }
 
 float CalculateAttenuation(float D, float R)

--- a/resources/shaders/Lighting.fxh
+++ b/resources/shaders/Lighting.fxh
@@ -83,16 +83,18 @@ LightInfluence SpotLightRadiance(LightData light, float3 fragWorldPos, float3 ca
     float specularTotal = CalculateSpecular(lightVec, viewVec, normal);
 
     // Spot Light Cutoff
+    light.innerAngle *= 1-(light.radius * 0.01f);
+    light.outerAngle *= 1-(light.radius * 0.01f);
     float theta = dot(lightVec, normalize(-light.direction));
-    float epsilon = light.outerAngle - light.innerAngle;
-    float intensity = saturate((theta - light.innerAngle) / epsilon);
+    float epsilon = max(light.innerAngle - light.outerAngle, 0.0001f);
+    float intensity = clamp((theta - light.outerAngle) / epsilon, 0.0f, 1.0f);
 
     // Attenuation
     float distance = length(light.position - fragWorldPos);
     diffuseTotal *= CalculateAttenuation(distance, light.radius);
     specularTotal *= CalculateAttenuation(distance, light.radius);
 
-    LightInfluence lightInfluence = {light.diffuseColor, light.specularColor,  specularTotal, diffuseTotal, light.intensity};
+    LightInfluence lightInfluence = {light.diffuseColor, light.specularColor,  specularTotal, diffuseTotal, intensity * light.intensity};
     return lightInfluence;
 }
 

--- a/resources/shaders/PPEnd.psh
+++ b/resources/shaders/PPEnd.psh
@@ -18,6 +18,7 @@ cbuffer SinkIndices
     int depthRT2;
     int depthRT3;
     uint hasPostProcess;
+    int lightIndex;
 };
 
 struct PSInput 

--- a/resources/shaders/PPEnd.psh
+++ b/resources/shaders/PPEnd.psh
@@ -18,7 +18,7 @@ cbuffer SinkIndices
     int depthRT2;
     int depthRT3;
     uint hasPostProcess;
-    int lightIndex;
+    uint lightIndex;
 };
 
 struct PSInput 

--- a/resources/shaders/PPFxaa.psh
+++ b/resources/shaders/PPFxaa.psh
@@ -25,6 +25,7 @@ cbuffer SinkIndices
     int depthRT2;
     int depthRT3;
     uint hasPostProcess;
+    int lightIndex;
 };
 
 struct PSInput 

--- a/resources/shaders/PPFxaa.psh
+++ b/resources/shaders/PPFxaa.psh
@@ -25,7 +25,7 @@ cbuffer SinkIndices
     int depthRT2;
     int depthRT3;
     uint hasPostProcess;
-    int lightIndex;
+    uint lightIndex;
 };
 
 struct PSInput 

--- a/resources/shaders/PPNoise.psh
+++ b/resources/shaders/PPNoise.psh
@@ -24,6 +24,7 @@ cbuffer SinkIndices
     int depthRT2;
     int depthRT3;
     uint hasPostProcess;
+    int lightIndex;
 };
 
 cbuffer PostProcessProperties

--- a/resources/shaders/PPNoise.psh
+++ b/resources/shaders/PPNoise.psh
@@ -24,7 +24,7 @@ cbuffer SinkIndices
     int depthRT2;
     int depthRT3;
     uint hasPostProcess;
-    int lightIndex;
+    uint lightIndex;
 };
 
 cbuffer PostProcessProperties

--- a/resources/shaders/PPOutline.psh
+++ b/resources/shaders/PPOutline.psh
@@ -24,6 +24,7 @@ cbuffer SinkIndices
     int depthRT2;
     int depthRT3;
     uint hasPostProcess;
+    int lightIndex;
 };
 
 cbuffer PostProcessProperties

--- a/resources/shaders/PPOutline.psh
+++ b/resources/shaders/PPOutline.psh
@@ -24,7 +24,7 @@ cbuffer SinkIndices
     int depthRT2;
     int depthRT3;
     uint hasPostProcess;
-    int lightIndex;
+    uint lightIndex;
 };
 
 cbuffer PostProcessProperties

--- a/resources/shaders/ShadowMap.vsh
+++ b/resources/shaders/ShadowMap.vsh
@@ -61,7 +61,7 @@ cbuffer SinkIndices
     int depthRT2;
     int depthRT3;
     uint hasPostProcess;
-    int lightIndex;
+    uint lightIndex;
 };
 
 void main(in  VSInput VSIn, uint InstanceID : SV_InstanceID,  out PSInput PSIn)

--- a/resources/shaders/ShadowMap.vsh
+++ b/resources/shaders/ShadowMap.vsh
@@ -1,0 +1,55 @@
+struct VSInput
+{
+    // Vertex attributes
+    float3 Pos         : ATTRIB0;
+    float3 Normal      : ATTRIB1;
+    float2 UV          : ATTRIB2;
+};
+
+struct PSInput 
+{
+    float4 Pos           : SV_POSITION;
+    float3 Normal        : NORMAL;
+    float2 UV            : TEX_COORD;
+    uint   MaterialIndex;
+    float3 WorldPos;
+    float3 LocalPos;
+};
+
+struct TransformData
+{
+    float4x4 model;
+};
+
+StructuredBuffer<TransformData> Transforms;
+
+struct StaticMeshInstanceData
+{
+    uint transformIndex;
+    uint materialIndex;
+};
+
+StructuredBuffer<StaticMeshInstanceData> StaticInstances;
+
+cbuffer EnvironmentProperties
+{
+    float4x4 cameraViewProjection;
+    float4x4 cameraInvProjection;
+    float3 cameraPosition;
+    uint lightCount;
+    float nearClip;
+    float farClip;
+};
+
+void main(in  VSInput VSIn, uint InstanceID : SV_InstanceID,  out PSInput PSIn)
+{
+    uint transformIndex = StaticInstances[InstanceID].transformIndex;
+    uint materialIndex = StaticInstances[InstanceID].materialIndex;
+    float4 TransformedPos = mul(float4(VSIn.Pos, 1.0), Transforms[transformIndex].model);
+    PSIn.Pos = mul(TransformedPos, cameraViewProjection);
+    PSIn.UV  = VSIn.UV;
+    PSIn.Normal = normalize(mul(Transforms[transformIndex].model, VSIn.Normal));
+    PSIn.WorldPos = TransformedPos.xyz;
+    PSIn.LocalPos = VSIn.Pos.xyz;
+    PSIn.MaterialIndex = materialIndex;
+}

--- a/resources/shaders/ShadowMap.vsh
+++ b/resources/shaders/ShadowMap.vsh
@@ -1,19 +1,14 @@
 struct VSInput
 {
     // Vertex attributes
-    float3 Pos         : ATTRIB0;
-    float3 Normal      : ATTRIB1;
-    float2 UV          : ATTRIB2;
+    float3 Pos    : ATTRIB0;
+    float3 Normal : ATTRIB1;
+    float2 UV     : ATTRIB2;
 };
 
 struct PSInput 
 {
-    float4 Pos           : SV_POSITION;
-    float3 Normal        : NORMAL;
-    float2 UV            : TEX_COORD;
-    uint   MaterialIndex;
-    float3 WorldPos;
-    float3 LocalPos;
+    float4 Pos : SV_POSITION;
 };
 
 struct TransformData
@@ -21,7 +16,22 @@ struct TransformData
     float4x4 model;
 };
 
+struct LightData {
+    float3 diffuseColor;
+    int type; // 0: Directional, 1: Point, 2: Spot
+    float3 specularColor;
+    float radius;
+    float3 position;
+    float innerAngle;
+    float3 direction;
+    float outerAngle;
+    float intensity;
+    int castsShadows;
+    float4x4 viewProj;
+};
+
 StructuredBuffer<TransformData> Transforms;
+StructuredBuffer<LightData> Lights;
 
 struct StaticMeshInstanceData
 {
@@ -41,15 +51,22 @@ cbuffer EnvironmentProperties
     float farClip;
 };
 
+cbuffer SinkIndices
+{
+    int colorRT1;
+    int colorRT2;
+    int colorRT3;
+    int colorRT4;
+    int depthRT1;
+    int depthRT2;
+    int depthRT3;
+    uint hasPostProcess;
+    int lightIndex;
+};
+
 void main(in  VSInput VSIn, uint InstanceID : SV_InstanceID,  out PSInput PSIn)
 {
     uint transformIndex = StaticInstances[InstanceID].transformIndex;
-    uint materialIndex = StaticInstances[InstanceID].materialIndex;
     float4 TransformedPos = mul(float4(VSIn.Pos, 1.0), Transforms[transformIndex].model);
-    PSIn.Pos = mul(TransformedPos, cameraViewProjection);
-    PSIn.UV  = VSIn.UV;
-    PSIn.Normal = normalize(mul(Transforms[transformIndex].model, VSIn.Normal));
-    PSIn.WorldPos = TransformedPos.xyz;
-    PSIn.LocalPos = VSIn.Pos.xyz;
-    PSIn.MaterialIndex = materialIndex;
+    PSIn.Pos = mul(TransformedPos, Lights[lightIndex].viewProj);
 }

--- a/resources/shaders/ShadowMapSkinned.vsh
+++ b/resources/shaders/ShadowMapSkinned.vsh
@@ -24,7 +24,35 @@ struct TransformData
     float4x4 modelMatrix;
 };
 
+cbuffer SinkIndices
+{
+    int colorRT1;
+    int colorRT2;
+    int colorRT3;
+    int colorRT4;
+    int depthRT1;
+    int depthRT2;
+    int depthRT3;
+    uint hasPostProcess;
+    int lightIndex;
+};
+
+struct LightData {
+    float3 diffuseColor;
+    int type; // 0: Directional, 1: Point, 2: Spot
+    float3 specularColor;
+    float radius;
+    float3 position;
+    float innerAngle;
+    float3 direction;
+    float outerAngle;
+    float intensity;
+    int castsShadows;
+    float4x4 viewProj;
+};
+
 StructuredBuffer<TransformData> Transforms;
+StructuredBuffer<LightData> Lights;
 
 // todo: #802 Define this at compile time
 #define ENABLE_SKINNING 1
@@ -123,10 +151,6 @@ void main(in VSInput VSIn, uint InstanceID : SV_InstanceID, out PSInput PSIn)
 
     uint transformIndex = instance.transformIndex;
     float4 worldPos = mul(pos, Transforms[transformIndex].modelMatrix);
-    PSIn.Pos = mul(worldPos, cameraViewProjection);
-    PSIn.UV = VSIn.UV;
-    PSIn.Normal = normalize(mul(Transforms[transformIndex].modelMatrix, normal));
-    PSIn.LocalPos = VSIn.Pos.xyz;
-    PSIn.WorldPos = worldPos.xyz;
-    PSIn.MaterialIndex = instance.materialIndex;
+    PSIn.Pos = mul(worldPos, Lights[lightIndex].viewProj);
+
 }

--- a/resources/shaders/ShadowMapSkinned.vsh
+++ b/resources/shaders/ShadowMapSkinned.vsh
@@ -34,7 +34,7 @@ cbuffer SinkIndices
     int depthRT2;
     int depthRT3;
     uint hasPostProcess;
-    int lightIndex;
+    uint lightIndex;
 };
 
 struct LightData {

--- a/resources/shaders/ShadowMapSkinned.vsh
+++ b/resources/shaders/ShadowMapSkinned.vsh
@@ -1,0 +1,132 @@
+struct VSInput
+{
+    float3 Pos         : ATTRIB0;
+    float3 Normal      : ATTRIB1;
+    float2 UV          : ATTRIB2;
+    float3 Tangent     : ATTRIB3;
+    float3 Bitangent   : ATTRIB4;
+    float4 BoneWeights : ATTRIB5;
+    uint4  BoneIds     : ATTRIB6;
+};
+
+struct PSInput
+{
+    float4 Pos           : SV_POSITION;
+    float3 Normal        : NORMAL;
+    float2 UV            : TEX_COORD;
+    uint   MaterialIndex;
+    float3 WorldPos;
+    float3 LocalPos;
+};
+
+struct TransformData
+{
+    float4x4 modelMatrix;
+};
+
+StructuredBuffer<TransformData> Transforms;
+
+// todo: #802 Define this at compile time
+#define ENABLE_SKINNING 1
+
+#ifdef ENABLE_SKINNING
+
+struct SkinnedMeshInstanceData
+{
+    uint transformIndex;
+    uint materialIndex;
+    uint boneIndex;
+};
+
+StructuredBuffer<SkinnedMeshInstanceData> SkinnedInstances;
+
+#define INSTANCE_DATA SkinnedMeshInstanceData
+#define INSTANCE_BUFFER SkinnedInstances
+
+struct BoneData
+{
+    float4x4 animatedBoneMatrix;
+};
+
+StructuredBuffer<BoneData> Bones;
+
+bool IsValidBoneIndex(uint boneIndex)
+{
+    return boneIndex != 4294967295;
+}
+
+bool IsValidAnimationTransform(float4x4 mat)
+{
+    // Check for zero matrix, ignoring homogenous coord
+    return all(mat[0] != 0.0) ||
+           all(mat[1] != 0.0) ||
+           all(mat[2] != 0.0) ||
+           mat[3].xyz != float3(0.0, 0.0, 0.0);
+}
+
+float4x4 CombineBoneMatrices(uint base, uint4 boneOffsets, float4 boneWeights)
+{
+    float4x4 boneTransform = float4x4(0.0);
+    for (int i = 0; i < 4; i++)
+    {
+        if (boneWeights[i] > 0.0f)
+        {
+            boneTransform += Bones[base + boneOffsets[i]].animatedBoneMatrix * boneWeights[i];
+        }
+    }
+
+    return boneTransform;
+}
+
+#else
+
+struct StaticMeshInstanceData
+{
+    uint transformIndex;
+    uint materialIndex;
+};
+
+StructuredBuffer<StaticMeshInstanceData> StaticInstances;
+
+#define INSTANCE_DATA StaticMeshInstanceData
+#define INSTANCE_BUFFER StaticInstances
+
+#endif // ENABLE_SKINNING
+
+cbuffer EnvironmentProperties
+{
+    float4x4 cameraViewProjection;
+    float4x4 cameraInvProjection;
+    float3 cameraPosition;
+    uint lightCount;
+    float nearClip;
+    float farClip;
+};
+
+void main(in VSInput VSIn, uint InstanceID : SV_InstanceID, out PSInput PSIn)
+{
+    INSTANCE_DATA instance = INSTANCE_BUFFER[InstanceID];
+    float4 pos = float4(VSIn.Pos, 1.0);
+    float3 normal = VSIn.Normal;
+
+#ifdef ENABLE_SKINNING
+    if (IsValidBoneIndex(instance.boneIndex))
+    {
+        float4x4 animatedTransform = CombineBoneMatrices(instance.boneIndex, VSIn.BoneIds, VSIn.BoneWeights);
+        if (IsValidAnimationTransform(animatedTransform))
+        {
+            pos = mul(pos, animatedTransform);
+            normal = mul(animatedTransform, normal);
+        }
+    }
+#endif // ENABLE_SKINNING
+
+    uint transformIndex = instance.transformIndex;
+    float4 worldPos = mul(pos, Transforms[transformIndex].modelMatrix);
+    PSIn.Pos = mul(worldPos, cameraViewProjection);
+    PSIn.UV = VSIn.UV;
+    PSIn.Normal = normalize(mul(Transforms[transformIndex].modelMatrix, normal));
+    PSIn.LocalPos = VSIn.Pos.xyz;
+    PSIn.WorldPos = worldPos.xyz;
+    PSIn.MaterialIndex = instance.materialIndex;
+}

--- a/resources/shaders/Toon.psh
+++ b/resources/shaders/Toon.psh
@@ -92,17 +92,22 @@ float SampleShadow(Texture2D depthTex, SamplerComparisonState shadowSampler, flo
 {
     // Transform world-space position to light-space clip coordinates
     float4 lightClipPos = mul(worldPos, lightViewProj);
-    
+
     // Convert clip-space position to NDC by performing perspective divide
     float3 shadowCoord = lightClipPos.xyz / lightClipPos.w;
-    
+
     // Transform from NDC [-1, 1] to UV coordinates [0, 1]
-    shadowCoord.x = shadowCoord.x * 0.5 + 0.5;       // X: [-1, 1] -> [0, 1]
-    shadowCoord.y = shadowCoord.y * -0.5 + 0.5;       // Y: [-1, 1] -> [1, 0] (flip Y)
+    shadowCoord.x = shadowCoord.x * 0.5 + 0.5;  // X: [-1, 1] -> [0, 1]
+    shadowCoord.y = shadowCoord.y * -0.5 + 0.5; // Y: [-1, 1] -> [1, 0] (flip Y)
+
+    if (shadowCoord.x < 0.0 || shadowCoord.x > 1.0 || shadowCoord.y < 0.0 || shadowCoord.y > 1.0)
+    {
+        return 0.0f;
+    }
 
     // Sample shadow map depth using comparison sampling
     float shadowFactor = depthTex.SampleCmpLevelZero(ShadowMapSinks_sampler, shadowCoord.xy, shadowCoord.z - 0.01);
-    return 1-pow(shadowFactor, 32.0);
+    return pow(shadowFactor, 50.0);
 }
 
 void main(in  PSInput  PSIn, out PSOutput PSOut)
@@ -127,27 +132,41 @@ void main(in  PSInput  PSIn, out PSOutput PSOut)
         normals = normalize(Normals.xyz * float3(2.0) - float3(1.0));
     }
 
+    uint shadowMapIndex = 0u;
     float3 result = 0.0f;
     [unroll(lightCount)]
     for (int i = 0; i < lightCount; i++)
     {
         LightInfluence influence = LightRadiance(Lights[i], PSIn.WorldPos.xyz, cameraPosition, normals);
 
+        // Calculate shadows
+        float shadowFactor = 1.0f;
+        if (Lights[i].castsShadows)
+        {
+            Texture2D depthTex = ShadowMapSinks[shadowMapIndex];
+            float rawShadow = SampleShadow(depthTex, ShadowMapSinks_sampler, PSIn.WorldPos, Lights[i].viewProj);
+            shadowFactor = min(shadowFactor, rawShadow); 
+            shadowMapIndex++;
+        }
+        float intensityFactor = saturate(Lights[i].intensity / 200.0f);
+        shadowFactor = lerp(shadowFactor, 1.0, intensityFactor);
+
         float diffuseAmt = 0.0f;
         float specularAmt = 0.0f;
 
+        // Flat shading, apply shadows
         if (Materials[PSIn.MaterialIndex].useFlatShading == 0)
         {
             diffuseAmt = influence.diffuseAmt * influence.intensity;
             specularAmt = influence.specularAmt * influence.intensity * Materials[PSIn.MaterialIndex].reflectivity; 
         }
-        else
+        else // Smooth shading, apply shadows
         {
             diffuseAmt = Band(influence.diffuseAmt) * influence.intensity;
-            specularAmt = Band(influence.specularAmt) * influence.intensity * Materials[PSIn.MaterialIndex].reflectivity;
+            specularAmt = Band(influence.specularAmt ) * influence.intensity * Materials[PSIn.MaterialIndex].reflectivity;
         }
 
-        result += (diffuseAmt * influence.diffuseColor * Color.rgb) + (specularAmt * influence.specularColor * Color.rgb );
+        result += ((diffuseAmt * influence.diffuseColor * Color.rgb) + (specularAmt * influence.specularColor * Color.rgb )) * shadowFactor;
 
         // Apply hatching
         if (Materials[PSIn.MaterialIndex].hatchTiling > 0.0f)
@@ -165,26 +184,8 @@ void main(in  PSInput  PSIn, out PSOutput PSOut)
 
     // Change saturation
     float3 colHsv = RGBtoHSV(float3(result.r, result.g, result.b));
-    colHsv.y *= (1.0f);
     colHsv.z *= (1.5f);
     result.rgb = HSVtoRGB(colHsv.rgb);
-
-    float shadowFactor = 0.0f;
-
-    [unroll(lightCount)]
-    float shadowMapIndex = 0u;
-    for (int i = 0; i < lightCount; i++)
-    {
-        if (Lights[i].castsShadows)
-        {
-            Texture2D depthTex = ShadowMapSinks[shadowMapIndex];
-            shadowFactor += SampleShadow(depthTex, ShadowMapSinks_sampler, PSIn.WorldPos, Lights[i].viewProj);
-            shadowMapIndex++;
-        }
-    }
-
-    // Assuming PSOut.Color is being set elsewhere and we just want to apply shadow
-    result *= (1-shadowFactor);
 
     // Gradient
     float3 gradient = lerp(Materials[PSIn.MaterialIndex].gradientStart, Materials[PSIn.MaterialIndex].gradientEnd, (normalize(PSIn.LocalPos).y + 1) * 0.5);

--- a/resources/shaders/Toon.psh
+++ b/resources/shaders/Toon.psh
@@ -5,6 +5,7 @@
 
 #include "Lighting.fxh"
 
+Texture2D     ShadowMapSinks[];
 Texture2D     Textures[];
 SamplerState  Textures_sampler; // By convention, texture samplers must use the '_sampler' suffix
 
@@ -43,7 +44,7 @@ struct PSInput
     float3 Normal        : NORMAL;
     float2 UV            : TEX_COORD; 
     uint   MaterialIndex;
-    float3 WorldPos;
+    float4 WorldPos;
     float3 LocalPos;
     float3 ViewDir;
 };
@@ -86,6 +87,17 @@ float Band(float lightAmount)
     return 1.0f;
 }
 
+// Depth is non-linear. Linearize it and normalize it.
+float SampleNormalizeDepth(Texture2D tex, SamplerState smplr, float2 uv)
+{
+    float rawDepth = tex.Sample(smplr, uv).r;
+    float3 ndc = float3(uv * 2.0 - 1.0, rawDepth);
+    float4 view = cameraInvProjection * float4(ndc, 1.0);
+    view.xyz /= view.w;
+    float linearDepth = -view.z;
+    return (linearDepth - nearClip) / (farClip - nearClip);
+}
+
 void main(in  PSInput  PSIn, out PSOutput PSOut)
 {
     // Get texture colors
@@ -93,6 +105,7 @@ void main(in  PSInput  PSIn, out PSOutput PSOut)
     uint NormalIndex = Materials[PSIn.MaterialIndex].normalTexIndex;
     float4 Color = Textures[TexIndex].Sample(Textures_sampler, PSIn.UV);
     float4 Normals = Textures[NormalIndex].Sample(Textures_sampler, PSIn.UV);
+    Texture2D depthTex = ShadowMapSinks[1];
 
     // Get hatching texture and tiling property
     uint hatchTexIndex = Materials[PSIn.MaterialIndex].hatchTexIndex;
@@ -111,7 +124,7 @@ void main(in  PSInput  PSIn, out PSOutput PSOut)
     float3 result = 0.0f;
     for (int i = 0; i < lightCount; i++)
     {
-        LightInfluence influence = LightRadiance(Lights[i], PSIn.WorldPos, cameraPosition, normals);
+        LightInfluence influence = LightRadiance(Lights[i], PSIn.WorldPos.xyz, cameraPosition, normals);
 
         float diffuseAmt = 0.0f;
         float specularAmt = 0.0f;
@@ -154,5 +167,33 @@ void main(in  PSInput  PSIn, out PSOutput PSOut)
     float4 gradientApplied = float4(lerp(result.rgb, result.rgb + gradient, Materials[PSIn.MaterialIndex].gradientAmount), 1.0f);
     float4 outputColor = float4(lerp(gradientApplied, gradientApplied * gradient, 0.5f), 1.0f);
 
+
+    float4 fragLightPos = mul(PSIn.WorldPos, Lights[1].viewProj);
+
+    // Perform perspective division to get normalized device coordinates (NDC)
+    float3 ndc = fragLightPos.xyz / fragLightPos.w;
+
+    // Vulkan NDC to texture coordinates: NDC [-1, 1] -> UV [0, 1]
+    // Vulkan flips Y-axis compared to DirectX, so invert ndc.y
+    float2 shadowUV = ndc.xy * 0.5f + 0.5f;
+    shadowUV.y = 1.0f - shadowUV.y; 
+
+    // Sample the depth from the shadow map
+    float sampledDepth = depthTex.Sample(Textures_sampler, shadowUV).r;
+
+    // Convert the fragment's light space depth to [0, 1] range for comparison
+    float fragDepth = ndc.z * 0.5f + 0.5f;
+
+    // Compare the fragment depth to the sampled shadow map depth
+    float shadow = 0.0f;
+     if (shadowUV.x >= 0.01f && shadowUV.x <= 0.99f &&
+         shadowUV.y >= 0.01f && shadowUV.y <= 0.99f &&
+         fragDepth  >= 0.01f && fragDepth  <= 0.99f)
+    {
+        shadow = (fragDepth > sampledDepth + 0.001f) ? 0.5f : 0.0f;
+    }
+
+    // Assuming PSOut.Color is being set elsewhere and we just want to apply shadow
+    outputColor *= (1.0f - shadow);
     PSOut.Color = outputColor;
 }

--- a/resources/shaders/Toon.psh
+++ b/resources/shaders/Toon.psh
@@ -154,18 +154,19 @@ void main(in  PSInput  PSIn, out PSOutput PSOut)
         float diffuseAmt = 0.0f;
         float specularAmt = 0.0f;
 
-        // Flat shading, apply shadows
+        // Flat shading
         if (Materials[PSIn.MaterialIndex].useFlatShading == 0)
         {
             diffuseAmt = influence.diffuseAmt * influence.intensity;
             specularAmt = influence.specularAmt * influence.intensity * Materials[PSIn.MaterialIndex].reflectivity; 
         }
-        else // Smooth shading, apply shadows
+        else // Smooth shading
         {
             diffuseAmt = Band(influence.diffuseAmt) * influence.intensity;
             specularAmt = Band(influence.specularAmt ) * influence.intensity * Materials[PSIn.MaterialIndex].reflectivity;
         }
 
+        // Apply lighting influences and shadows
         result += ((diffuseAmt * influence.diffuseColor * Color.rgb) + (specularAmt * influence.specularColor * Color.rgb )) * shadowFactor;
 
         // Apply hatching

--- a/resources/shaders/Toon.psh
+++ b/resources/shaders/Toon.psh
@@ -8,6 +8,7 @@
 Texture2D     ShadowMapSinks[];
 Texture2D     Textures[];
 SamplerState  Textures_sampler; // By convention, texture samplers must use the '_sampler' suffix
+SamplerComparisonState  ShadowMapSinks_sampler; // By convention, texture samplers must use the '_sampler' suffix
 
 cbuffer EnvironmentProperties
 {
@@ -87,15 +88,21 @@ float Band(float lightAmount)
     return 1.0f;
 }
 
-// Depth is non-linear. Linearize it and normalize it.
-float SampleNormalizeDepth(Texture2D tex, SamplerState smplr, float2 uv)
+float SampleShadow(Texture2D depthTex, SamplerComparisonState shadowSampler, float4 worldPos, matrix lightViewProj)
 {
-    float rawDepth = tex.Sample(smplr, uv).r;
-    float3 ndc = float3(uv * 2.0 - 1.0, rawDepth);
-    float4 view = cameraInvProjection * float4(ndc, 1.0);
-    view.xyz /= view.w;
-    float linearDepth = -view.z;
-    return (linearDepth - nearClip) / (farClip - nearClip);
+    // Transform world-space position to light-space clip coordinates
+    float4 lightClipPos = mul(worldPos, lightViewProj);
+    
+    // Convert clip-space position to NDC by performing perspective divide
+    float3 shadowCoord = lightClipPos.xyz / lightClipPos.w;
+    
+    // Transform from NDC [-1, 1] to UV coordinates [0, 1]
+    shadowCoord.x = shadowCoord.x * 0.5 + 0.5;       // X: [-1, 1] -> [0, 1]
+    shadowCoord.y = shadowCoord.y * -0.5 + 0.5;       // Y: [-1, 1] -> [1, 0] (flip Y)
+
+    // Sample shadow map depth using comparison sampling
+    float shadowFactor = depthTex.SampleCmpLevelZero(ShadowMapSinks_sampler, shadowCoord.xy, shadowCoord.z - 0.01);
+    return 1-pow(shadowFactor, 32.0);
 }
 
 void main(in  PSInput  PSIn, out PSOutput PSOut)
@@ -105,7 +112,6 @@ void main(in  PSInput  PSIn, out PSOutput PSOut)
     uint NormalIndex = Materials[PSIn.MaterialIndex].normalTexIndex;
     float4 Color = Textures[TexIndex].Sample(Textures_sampler, PSIn.UV);
     float4 Normals = Textures[NormalIndex].Sample(Textures_sampler, PSIn.UV);
-    Texture2D depthTex = ShadowMapSinks[1];
 
     // Get hatching texture and tiling property
     uint hatchTexIndex = Materials[PSIn.MaterialIndex].hatchTexIndex;
@@ -122,6 +128,7 @@ void main(in  PSInput  PSIn, out PSOutput PSOut)
     }
 
     float3 result = 0.0f;
+    [unroll(lightCount)]
     for (int i = 0; i < lightCount; i++)
     {
         LightInfluence influence = LightRadiance(Lights[i], PSIn.WorldPos.xyz, cameraPosition, normals);
@@ -162,38 +169,27 @@ void main(in  PSInput  PSIn, out PSOutput PSOut)
     colHsv.z *= (1.5f);
     result.rgb = HSVtoRGB(colHsv.rgb);
 
+    float shadowFactor = 0.0f;
+
+    [unroll(lightCount)]
+    float shadowMapIndex = 0u;
+    for (int i = 0; i < lightCount; i++)
+    {
+        if (Lights[i].castsShadows)
+        {
+            Texture2D depthTex = ShadowMapSinks[shadowMapIndex];
+            shadowFactor += SampleShadow(depthTex, ShadowMapSinks_sampler, PSIn.WorldPos, Lights[i].viewProj);
+            shadowMapIndex++;
+        }
+    }
+
+    // Assuming PSOut.Color is being set elsewhere and we just want to apply shadow
+    result *= (1-shadowFactor);
+
     // Gradient
     float3 gradient = lerp(Materials[PSIn.MaterialIndex].gradientStart, Materials[PSIn.MaterialIndex].gradientEnd, (normalize(PSIn.LocalPos).y + 1) * 0.5);
     float4 gradientApplied = float4(lerp(result.rgb, result.rgb + gradient, Materials[PSIn.MaterialIndex].gradientAmount), 1.0f);
     float4 outputColor = float4(lerp(gradientApplied, gradientApplied * gradient, 0.5f), 1.0f);
 
-
-    float4 fragLightPos = mul(PSIn.WorldPos, Lights[1].viewProj);
-
-    // Perform perspective division to get normalized device coordinates (NDC)
-    float3 ndc = fragLightPos.xyz / fragLightPos.w;
-
-    // Vulkan NDC to texture coordinates: NDC [-1, 1] -> UV [0, 1]
-    // Vulkan flips Y-axis compared to DirectX, so invert ndc.y
-    float2 shadowUV = ndc.xy * 0.5f + 0.5f;
-    shadowUV.y = 1.0f - shadowUV.y; 
-
-    // Sample the depth from the shadow map
-    float sampledDepth = depthTex.Sample(Textures_sampler, shadowUV).r;
-
-    // Convert the fragment's light space depth to [0, 1] range for comparison
-    float fragDepth = ndc.z * 0.5f + 0.5f;
-
-    // Compare the fragment depth to the sampled shadow map depth
-    float shadow = 0.0f;
-     if (shadowUV.x >= 0.01f && shadowUV.x <= 0.99f &&
-         shadowUV.y >= 0.01f && shadowUV.y <= 0.99f &&
-         fragDepth  >= 0.01f && fragDepth  <= 0.99f)
-    {
-        shadow = (fragDepth > sampledDepth + 0.001f) ? 0.5f : 0.0f;
-    }
-
-    // Assuming PSOut.Color is being set elsewhere and we just want to apply shadow
-    outputColor *= (1.0f - shadow);
     PSOut.Color = outputColor;
 }

--- a/resources/shaders/Toon.vsh
+++ b/resources/shaders/Toon.vsh
@@ -12,7 +12,7 @@ struct PSInput
     float3 Normal        : NORMAL;
     float2 UV            : TEX_COORD;
     uint   MaterialIndex;
-    float3 WorldPos;
+    float4 WorldPos;
     float3 LocalPos;
 };
 
@@ -47,8 +47,8 @@ void main(in  VSInput VSIn, uint InstanceID : SV_InstanceID,  out PSInput PSIn)
     float4 TransformedPos = mul(float4(VSIn.Pos, 1.0), Transforms[transformIndex].model);
     PSIn.Pos = mul(TransformedPos, cameraViewProjection);
     PSIn.UV  = VSIn.UV;
-    PSIn.Normal = normalize(mul(Transforms[transformIndex].model, VSIn.Normal));
-    PSIn.WorldPos = TransformedPos.xyz;
+    PSIn.Normal = normalize( mul(VSIn.Normal, Transforms[transformIndex].model));
+    PSIn.WorldPos = TransformedPos;
     PSIn.LocalPos = VSIn.Pos.xyz;
     PSIn.MaterialIndex = materialIndex;
 }

--- a/resources/shaders/ToonSkinned.vsh
+++ b/resources/shaders/ToonSkinned.vsh
@@ -15,7 +15,7 @@ struct PSInput
     float3 Normal        : NORMAL;
     float2 UV            : TEX_COORD;
     uint   MaterialIndex;
-    float3 WorldPos;
+    float4 WorldPos;
     float3 LocalPos;
 };
 
@@ -125,8 +125,8 @@ void main(in VSInput VSIn, uint InstanceID : SV_InstanceID, out PSInput PSIn)
     float4 worldPos = mul(pos, Transforms[transformIndex].modelMatrix);
     PSIn.Pos = mul(worldPos, cameraViewProjection);
     PSIn.UV = VSIn.UV;
-    PSIn.Normal = normalize(mul(Transforms[transformIndex].modelMatrix, normal));
+    PSIn.Normal = normalize(mul(normal, Transforms[transformIndex].modelMatrix));
     PSIn.LocalPos = VSIn.Pos.xyz;
-    PSIn.WorldPos = worldPos.xyz;
+    PSIn.WorldPos = worldPos;
     PSIn.MaterialIndex = instance.materialIndex;
 }

--- a/sample/config.ini
+++ b/sample/config.ini
@@ -51,7 +51,7 @@ target_fps=60
 use_shadows=1
 antialiasing=1
 initial_batch_size=1
-use_validation_layers=0
+use_validation_layers=1
 [audio_settings]
 audio_enabled=1
 buffer_frames=512

--- a/sample/config.ini
+++ b/sample/config.ini
@@ -49,9 +49,10 @@ screen_width=1600
 screen_height=900
 target_fps=60
 use_shadows=1
+shadow_map_resolution=2048
 antialiasing=1
 initial_batch_size=1
-use_validation_layers=1
+use_validation_layers=0
 [audio_settings]
 audio_enabled=1
 buffer_frames=512

--- a/sample/source/scenes/PhysicsTest.cpp
+++ b/sample/source/scenes/PhysicsTest.cpp
@@ -1283,15 +1283,15 @@ void PhysicsTest::Load(ecs::Ecs world, ModuleProvider modules)
 
     world.Emplace<SpotLight>(
         world.Emplace<Entity>({
-            .position = Vector3{0.0f, 3.0f, 1.0f},
+            .position = Vector3{-1.0f, 3.0f, -10.0f},
             .tag = "Spot Light"
         }),
         Vector3{1.0f, 1.0f, 1.0f},
         Vector3{0.8f, 0.8f, 0.8f},
-        3.5f,
-        0.3491f,
-        0.5236f,
-        50.0f
+        12.4f,
+        0.0f,
+        0.461f,
+        57.8f
     );
 
     world.Emplace<DirectionalLight>(

--- a/sample/source/scenes/PhysicsTest.cpp
+++ b/sample/source/scenes/PhysicsTest.cpp
@@ -1281,15 +1281,17 @@ void PhysicsTest::Load(ecs::Ecs world, ModuleProvider modules)
     BuildChain(world);
     BuildTriggers(world);
 
-    world.Emplace<PointLight>(
+    world.Emplace<SpotLight>(
         world.Emplace<Entity>({
-            .position = Vector3{-15.0f, 50.0f, 35.0f},
-            .tag = "Point Light"
+            .position = Vector3{0.0f, 3.0f, 1.0f},
+            .tag = "Spot Light"
         }),
         Vector3{1.0f, 1.0f, 1.0f},
         Vector3{0.8f, 0.8f, 0.8f},
         3.5f,
-        300.0f
+        0.3491f,
+        0.5236f,
+        50.0f
     );
 
     world.Emplace<DirectionalLight>(

--- a/source/ncengine/config/Config.cpp
+++ b/source/ncengine/config/Config.cpp
@@ -71,7 +71,8 @@ constexpr auto LaunchInFullscreenKey = "launch_fullscreen"sv;
 constexpr auto ScreenWidthKey = "screen_width"sv;
 constexpr auto ScreenHeightKey = "screen_height"sv;
 constexpr auto TargetFpsKey = "target_fps"sv;
-constexpr auto UseShadowsKey = "use_shadows"sv; /** @todo: Make this a property of the material */
+constexpr auto UseShadowsKey = "use_shadows"sv;
+constexpr auto ShadowMapResolutionKey = "shadow_map_resolution"sv;
 constexpr auto AntialiasingKey = "antialiasing"sv;
 constexpr auto InitialBatchSize = "initial_batch_size"sv;
 constexpr auto UseValidationLayersKey = "use_validation_layers"sv;
@@ -230,6 +231,7 @@ auto BuildFromConfigMap(const std::unordered_map<std::string, std::string>& kvPa
         ParseValueIfExists(out.screenHeight, ScreenHeightKey, kvPairs);
         ParseValueIfExists(out.targetFPS, TargetFpsKey, kvPairs);
         ParseValueIfExists(out.useShadows, UseShadowsKey, kvPairs);
+        ParseValueIfExists(out.shadowMapResolution, ShadowMapResolutionKey, kvPairs);
         ParseValueIfExists(out.antialiasing, AntialiasingKey, kvPairs);
         ParseValueIfExists(out.initialBatchSize, InitialBatchSize, kvPairs);
         ParseValueIfExists(out.useValidationLayers, UseValidationLayersKey, kvPairs);
@@ -397,6 +399,7 @@ void Write(std::ostream& stream, const Config& config, bool writeSections)
     ::WriteKVPair(stream, ScreenHeightKey, config.graphicsSettings.screenHeight);
     ::WriteKVPair(stream, TargetFpsKey, config.graphicsSettings.targetFPS);
     ::WriteKVPair(stream, UseShadowsKey, config.graphicsSettings.useShadows);
+    ::WriteKVPair(stream, ShadowMapResolutionKey, config.graphicsSettings.shadowMapResolution);
     ::WriteKVPair(stream, AntialiasingKey, config.graphicsSettings.antialiasing);
     ::WriteKVPair(stream, InitialBatchSize, config.graphicsSettings.initialBatchSize);
     ::WriteKVPair(stream, UseValidationLayersKey, config.graphicsSettings.useValidationLayers);
@@ -423,6 +426,7 @@ bool Validate(const Config& config)
            (config.graphicsSettings.screenHeight != 0) &&
            (config.graphicsSettings.targetFPS != 0) &&
            (config.graphicsSettings.antialiasing > 0) &&
+           (config.graphicsSettings.shadowMapResolution >= 128) &&
            ValidatePhysicsSettings(config.physicsSettings) &&
            ValidateBufferFrames(config.audioSettings.bufferFrames);
 }

--- a/source/ncengine/config/default_config.ini
+++ b/source/ncengine/config/default_config.ini
@@ -46,6 +46,7 @@ screen_width=1000
 screen_height=1000
 target_fps=60
 use_shadows=1
+shadow_map_resolution=2048
 antialiasing=1
 initial_batch_size=1
 use_validation_layers=0

--- a/source/ncengine/graphics2/GraphicsUtility.cpp
+++ b/source/ncengine/graphics2/GraphicsUtility.cpp
@@ -101,11 +101,6 @@ auto GetMaterialPassFlags() -> std::span<const MaterialPassFlag::type>
     return g_materialPassFlags;
 }
 
-auto GetImplementedMaterialPassFlags() -> std::span<const MaterialPassFlag::type>
-{
-    return std::span<const MaterialPassFlag::type>{g_materialPassFlags.data() + 1, 3};
-}
-
 auto GetMiscsPassFlags() -> std::span<const MiscPassFlag::type>
 {
     return g_miscPassFlags;

--- a/source/ncengine/graphics2/NcGraphicsImpl2.cpp
+++ b/source/ncengine/graphics2/NcGraphicsImpl2.cpp
@@ -295,6 +295,8 @@ NcGraphicsImpl2::NcGraphicsImpl2(const config::GraphicsSettings& graphicsSetting
             m_engine.GetShaderFactory(),
             m_shaderBindings,
             m_passManifest,
+            graphicsSettings,
+            memorySettings,
             m_engine.GetDeviceCapability().msaaSampleCount
           },
           m_frontend{

--- a/source/ncengine/graphics2/NcGraphicsImpl2.cpp
+++ b/source/ncengine/graphics2/NcGraphicsImpl2.cpp
@@ -162,6 +162,24 @@ NcGraphicsImpl2::NcGraphicsImpl2(const config::GraphicsSettings& graphicsSetting
             std::vector<PassDesc>
             {
                 PassDesc{
+                    .flag = MaterialPassFlag::Shadow,
+                    .name = "Shadow",
+                    .type = PassType::Material,
+                    .shaderPaths = ShaderPaths{.vertexShaderPath = "ShadowMap.vsh"},
+                    .depthSink = DepthTarget::Shadow,
+                    .isMsaa = false,
+                    .useDepthTest = true
+                },
+                PassDesc{
+                    .flag = MaterialPassFlag::Shadow,
+                    .name = "Shadow",
+                    .type = PassType::SkinnedMaterial,
+                    .shaderPaths = ShaderPaths{.vertexShaderPath = "ShadowMapSkinned.vsh"},
+                    .depthSink = DepthTarget::Shadow,
+                    .isMsaa = false,
+                    .useDepthTest = true
+                },
+                PassDesc{
                     .flag = MaterialPassFlag::Depth,
                     .name = "Depth",
                     .type = PassType::Material,
@@ -266,7 +284,7 @@ NcGraphicsImpl2::NcGraphicsImpl2(const config::GraphicsSettings& graphicsSetting
                     .useDepthTest = false
                 }
             },
-            GetImplementedMaterialPassFlags(),
+            GetMaterialPassFlags(),
             GetPostProcessPassFlags(),
             GetMiscsPassFlags()
           },
@@ -433,7 +451,8 @@ void NcGraphicsImpl2::Run()
         swapChain,
         m_shaderBindings.GetPerPassSignature(),
         renderState.meshRenderState.staticMeshBatches,
-        renderState.meshRenderState.skinnedMeshBatches
+        renderState.meshRenderState.skinnedMeshBatches,
+        renderState.lightRenderState.lights
     );
 
     m_passBackend.RenderWireframe(

--- a/source/ncengine/graphics2/NcGraphicsImpl2.cpp
+++ b/source/ncengine/graphics2/NcGraphicsImpl2.cpp
@@ -166,7 +166,7 @@ NcGraphicsImpl2::NcGraphicsImpl2(const config::GraphicsSettings& graphicsSetting
                     .name = "Shadow",
                     .type = PassType::Material,
                     .shaderPaths = ShaderPaths{.vertexShaderPath = "ShadowMap.vsh"},
-                    .depthSink = DepthTarget::Shadow,
+                    .shadowMapSink = ShadowMapTarget::Uni,
                     .isMsaa = false,
                     .useDepthTest = true
                 },
@@ -175,7 +175,7 @@ NcGraphicsImpl2::NcGraphicsImpl2(const config::GraphicsSettings& graphicsSetting
                     .name = "Shadow",
                     .type = PassType::SkinnedMaterial,
                     .shaderPaths = ShaderPaths{.vertexShaderPath = "ShadowMapSkinned.vsh"},
-                    .depthSink = DepthTarget::Shadow,
+                    .shadowMapSink = ShadowMapTarget::Uni,
                     .isMsaa = false,
                     .useDepthTest = true
                 },

--- a/source/ncengine/graphics2/ShaderTypes.h
+++ b/source/ncengine/graphics2/ShaderTypes.h
@@ -50,6 +50,7 @@ struct PostProcessSinkIndexData
     int32_t depthRenderTargetIndex2;
     int32_t depthRenderTargetIndex3;
     uint32_t hasPostProcessTarget;
+    int32_t lightIndex;
 };
 
 // Object model for StaticMeshes (type: StructuredBuffer element type).

--- a/source/ncengine/graphics2/ShaderTypes.h
+++ b/source/ncengine/graphics2/ShaderTypes.h
@@ -50,7 +50,7 @@ struct PostProcessSinkIndexData
     int32_t depthRenderTargetIndex2;
     int32_t depthRenderTargetIndex3;
     uint32_t hasPostProcessTarget;
-    int32_t lightIndex;
+    uint32_t lightIndex;
 };
 
 // Object model for StaticMeshes (type: StructuredBuffer element type).

--- a/source/ncengine/graphics2/diligent/pass/MaterialPass.cpp
+++ b/source/ncengine/graphics2/diligent/pass/MaterialPass.cpp
@@ -30,19 +30,25 @@ auto CreatePipeline(Diligent::IRenderDevice& device,
     ci.pPS = pixelShader;
     ci.pVS = vertexShader;
 
+    auto depthFormat = TEX_FORMAT_UNKNOWN;
+    if (passDesc.depthSink != DepthTarget::None || passDesc.shadowMapSink != ShadowMapTarget::None)
+    {
+      depthFormat = OffScreenDepthRTFormat;
+    }
+
     ci.GraphicsPipeline.NumRenderTargets                  = passDesc.colorSink == ColorTarget::None ? 0 : 1;
     ci.GraphicsPipeline.RTVFormats[0]                     = passDesc.colorSink == ColorTarget::None ? TEX_FORMAT_UNKNOWN : OffScreenColorRTFormat;
-    ci.GraphicsPipeline.DSVFormat                         = passDesc.depthSink == DepthTarget::None ? TEX_FORMAT_UNKNOWN : OffScreenDepthRTFormat;
+    ci.GraphicsPipeline.DSVFormat                         = depthFormat;
     ci.GraphicsPipeline.RasterizerDesc.CullMode           = CULL_MODE_BACK;
     ci.GraphicsPipeline.DepthStencilDesc.DepthEnable      = passDesc.useDepthTest;
-    ci.GraphicsPipeline.DepthStencilDesc.DepthWriteEnable = passDesc.depthSink != DepthTarget::None;
+    ci.GraphicsPipeline.DepthStencilDesc.DepthWriteEnable = passDesc.depthSink != DepthTarget::None || passDesc.shadowMapSink != ShadowMapTarget::None;
     ci.GraphicsPipeline.InputLayout.LayoutElements        = layoutElements.data();
     ci.GraphicsPipeline.InputLayout.NumElements           = static_cast<uint32_t>(layoutElements.size());
 
     ci.GraphicsPipeline.SmplDesc.Count               = passDesc.isMsaa ? static_cast<uint8_t>(numSamples) : static_cast<uint8_t>(1);
     ci.GraphicsPipeline.PrimitiveTopology            = PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
 
-    auto signatures = std::array{&shaderBindings.GetPerFrameSignature().GetResourceSignature()};
+    auto signatures = std::array{&shaderBindings.GetPerFrameSignature().GetResourceSignature(), &shaderBindings.GetPerPassSignature().GetResourceSignature()};
     ci.ppResourceSignatures = signatures.data();
     ci.ResourceSignaturesCount = static_cast<uint32_t>(signatures.size());
 

--- a/source/ncengine/graphics2/diligent/pass/PassBackend.cpp
+++ b/source/ncengine/graphics2/diligent/pass/PassBackend.cpp
@@ -185,6 +185,50 @@ void PassBackend::Update(const PostProcessState& postProcessState)
     m_finalPostProcessTarget = std::nullopt;
 }
 
+void PassBackend::RenderShadowPass(IDeviceContext& context,
+                                   PerPassResourceSignature& perPassResourceSignature,
+                                   const MaterialPass& staticPass,
+                                   const MaterialPass& skinnedPass,
+                                   const std::vector<Batch>& staticBatches,
+                                   const std::vector<Batch>& skinnedBatches,
+                                   const std::span<const LightData>& lights)
+{
+    auto& sinkIndexBuffer = perPassResourceSignature.GetSinkIndexBufferResource();
+    auto& shadowMapsBuffer = perPassResourceSignature.GetShadowMapSinksResource();
+
+    bool hasSomeShadowCaster = false;
+    uint32_t lightIndex = 0u;
+
+    for (const auto& light : lights)
+    {
+        if (!light.castsShadows)
+        {
+            lightIndex++;
+            continue;
+        }
+
+        hasSomeShadowCaster = true;
+        sinkIndexBuffer.Update(context, std::vector<uint32_t>{}, std::vector<uint32_t>{}, false, lightIndex);
+
+        BindShadowMapRenderTarget(context, shadowMapsBuffer, lightIndex);
+        ClearShadowMapRenderTarget(context, shadowMapsBuffer, lightIndex);
+
+        context.SetPipelineState(staticPass.pso);
+        DrawIndexed(context, staticBatches);
+        context.SetPipelineState(skinnedPass.pso);
+        DrawIndexed(context, skinnedBatches);
+        lightIndex++;
+    }
+
+    if (!hasSomeShadowCaster)
+    {
+        // No shadow-casting lights; ensure buffer is updated to prevent usage issues.
+        sinkIndexBuffer.Update(context, std::vector<uint32_t>{}, std::vector<uint32_t>{}, false, -1);
+    }
+
+    perPassResourceSignature.Commit(context);
+}
+
 void PassBackend::RenderMaterial(IDeviceContext& context,
                                  ISwapChain& swapChain,
                                  PerPassResourceSignature& perPassResourceSignature,
@@ -206,52 +250,16 @@ void PassBackend::RenderMaterial(IDeviceContext& context,
         skinnedPassBatches
     );
 
-    auto& sinkIndexBuffer = perPassResourceSignature.GetSinkIndexBufferResource();
-    auto& shadowMapsBuffer = perPassResourceSignature.GetShadowMapSinksResource();
-
-
     for (auto [staticPass, skinnedPass, staticBatches, skinnedBatches] : passView)
     {
-        if (m_finalColorTarget.has_value())
-        {
-            m_finalColorTarget = std::min(staticPass.sinks.color, m_finalColorTarget.value());
-        }
-        else
-        {
-            m_finalColorTarget = staticPass.sinks.color;
-        }
+        m_finalColorTarget = m_finalColorTarget.has_value() ? std::min(staticPass.sinks.color, m_finalColorTarget.value()) : staticPass.sinks.color;
 
         if (staticPass.flag & MaterialPassFlag::Shadow)
         {
-            bool hasSomeShadowCaster = false;
-            uint32_t lightIndex = 0u;
-            for (const auto& light : lights)
-            {
-                if (!light.castsShadows)
-                {
-                    lightIndex++;
-                    continue;
-                }
-
-                hasSomeShadowCaster = true;
-                sinkIndexBuffer.Update(context, std::vector<uint32_t>{}, std::vector<uint32_t>{}, false, lightIndex);
-
-                BindShadowMapRenderTarget(context, shadowMapsBuffer, lightIndex);
-                ClearShadowMapRenderTarget(context, shadowMapsBuffer, lightIndex);
-
-                context.SetPipelineState(staticPass.pso);
-                DrawIndexed(context, staticBatches);
-                context.SetPipelineState(skinnedPass.pso);
-                DrawIndexed(context, skinnedBatches);
-                lightIndex++;
-            }
-            if (hasSomeShadowCaster == false)
-            {
-                // No lights are being shadowcasters so after frame is done material is trying to use buffer and it hasn't been mapped since the frame started.
-                sinkIndexBuffer.Update(context, std::vector<uint32_t>{}, std::vector<uint32_t>{}, false, -1);
-            }
+            RenderShadowPass(context, perPassResourceSignature, staticPass, skinnedPass, staticBatches, skinnedBatches, lights);
             continue;
         }
+
 
         // PassManifest verifies static/skinned pass pairs specify the same render targets, so we can just choose from either here.
         BindRenderTarget(context, swapChain, perPassResourceSignature, staticPass.sinks.color, staticPass.sinks.depth, staticPass.isMsaa && m_numSamples > 1);

--- a/source/ncengine/graphics2/diligent/pass/PassBackend.cpp
+++ b/source/ncengine/graphics2/diligent/pass/PassBackend.cpp
@@ -198,10 +198,11 @@ void PassBackend::RenderShadowPass(IDeviceContext& context,
 {
     auto& sinkIndexBuffer = perPassResourceSignature.GetSinkIndexBufferResource();
     auto& shadowMapsBuffer = perPassResourceSignature.GetShadowMapSinksResource();
-
     bool hasSomeShadowCaster = false;
-
     auto renderTargetIndex = 0u;
+
+    // LightDataIndex corresponds to the index the shader will use to index the LightData buffer.
+    // RenderTargetIndex corresponds to the index of the shadow map in the SinkBuffer.
     for (const auto& [lightDataIndex, light] : std::views::enumerate(lights))
     {
         if (!light.castsShadows)
@@ -225,7 +226,7 @@ void PassBackend::RenderShadowPass(IDeviceContext& context,
 
     if (!hasSomeShadowCaster)
     {
-        // No shadow-casting lights; ensure buffer is updated because it will be discarded at the end of the frame, and read from in the materials pass.
+        // No shadow-casting lights; ensure buffer is updated because it will be discarded at the end of the frame and read from in the materials pass - so it needs to be updated before that read.
         sinkIndexBuffer.Update(context, std::vector<uint32_t>{}, std::vector<uint32_t>{}, false, std::numeric_limits<uint32_t>::max());
         perPassResourceSignature.Commit(context);
     }

--- a/source/ncengine/graphics2/diligent/pass/PassBackend.cpp
+++ b/source/ncengine/graphics2/diligent/pass/PassBackend.cpp
@@ -7,6 +7,7 @@
 #include "graphics2/diligent/resource/SinkIndexBufferResource.h"
 #include "graphics2/diligent/resource/WireframeBufferResource.h"
 #include "graphics2/frontend/subsystem/PostProcessState.h"
+#include "ncengine/config/Config.h"
 #include "ncengine/debug/Profile.h"
 
 #include "ncutility/NcError.h"
@@ -121,6 +122,8 @@ PassBackend::PassBackend(IRenderDevice& device,
                          ShaderFactory& shaderFactory,
                          ShaderBindings& shaderBindings,
                          const PassManifest& passManifest,
+                         const config::GraphicsSettings& graphicsSettings,
+                         const config::MemorySettings& memorySettings,
                          uint32_t numSamples)
     : m_numSamples{numSamples},
       m_finalColorTarget{std::nullopt},
@@ -157,7 +160,7 @@ PassBackend::PassBackend(IRenderDevice& device,
     }
 
     // Make all the shadow map render targets that will be used by the passes
-    shadowMapSinks.Add(device, context, 20, screenWidth, screenHeight); // @todo parameterize with max lights
+    shadowMapSinks.Add(device, context, memorySettings.maxSpotLights + memorySettings.maxDirectionalLights, graphicsSettings.shadowMapResolution, graphicsSettings.shadowMapResolution);
 
     // Make the pass and pipeline objects
     MakePassesAndPipelines(device, swapChain, shaderFactory, shaderBindings, passManifest);
@@ -226,6 +229,8 @@ void PassBackend::RenderShadowPass(IDeviceContext& context,
         sinkIndexBuffer.Update(context, std::vector<uint32_t>{}, std::vector<uint32_t>{}, false, std::numeric_limits<uint32_t>::max());
         perPassResourceSignature.Commit(context);
     }
+
+    context.TransitionShaderResources(&perPassResourceSignature.GetResourceBinding());
 }
 
 void PassBackend::RenderMaterial(IDeviceContext& context,

--- a/source/ncengine/graphics2/diligent/pass/PassBackend.cpp
+++ b/source/ncengine/graphics2/diligent/pass/PassBackend.cpp
@@ -130,6 +130,7 @@ PassBackend::PassBackend(IRenderDevice& device,
     auto& perPassSignature = shaderBindings.GetPerPassSignature();
     auto& colorSinks = perPassSignature.GetColorSinksResource();
     auto& depthSinks = perPassSignature.GetDepthSinksResource();
+    auto& shadowMapSinks = perPassSignature.GetShadowMapSinksResource();
 
     // Get swapchain width and height to create screen-sized render targets
     auto screenWidth = swapChain.GetDesc().Width;
@@ -154,6 +155,9 @@ PassBackend::PassBackend(IRenderDevice& device,
         auto& postProcessSink = perPassSignature.GetPostProcessSinkResource(i);
         postProcessSink.Add(device, context, 1, screenWidth, screenHeight);
     }
+
+    // Make all the shadow map render targets that will be used by the passes
+    shadowMapSinks.Add(device, context, 20, screenWidth, screenHeight); // @todo parameterize with max lights
 
     // Make the pass and pipeline objects
     MakePassesAndPipelines(device, swapChain, shaderFactory, shaderBindings, passManifest);
@@ -202,6 +206,10 @@ void PassBackend::RenderMaterial(IDeviceContext& context,
         skinnedPassBatches
     );
 
+    auto& sinkIndexBuffer = perPassResourceSignature.GetSinkIndexBufferResource();
+    auto& shadowMapsBuffer = perPassResourceSignature.GetShadowMapSinksResource();
+
+
     for (auto [staticPass, skinnedPass, staticBatches, skinnedBatches] : passView)
     {
         if (m_finalColorTarget.has_value())
@@ -215,24 +223,34 @@ void PassBackend::RenderMaterial(IDeviceContext& context,
 
         if (staticPass.flag & MaterialPassFlag::Shadow)
         {
+            bool hasSomeShadowCaster = false;
             uint32_t lightIndex = 0u;
             for (const auto& light : lights)
             {
                 if (!light.castsShadows)
                 {
+                    lightIndex++;
                     continue;
                 }
 
-                BindShadowMapRenderTarget(context, perPassResourceSignature.GetShadowMapSinksResource(), lightIndex);
-                ClearShadowMapRenderTarget(context, perPassResourceSignature.GetShadowMapSinksResource(), lightIndex);
+                hasSomeShadowCaster = true;
+                sinkIndexBuffer.Update(context, std::vector<uint32_t>{}, std::vector<uint32_t>{}, false, lightIndex);
+
+                BindShadowMapRenderTarget(context, shadowMapsBuffer, lightIndex);
+                ClearShadowMapRenderTarget(context, shadowMapsBuffer, lightIndex);
 
                 context.SetPipelineState(staticPass.pso);
                 DrawIndexed(context, staticBatches);
                 context.SetPipelineState(skinnedPass.pso);
                 DrawIndexed(context, skinnedBatches);
-
                 lightIndex++;
             }
+            if (hasSomeShadowCaster == false)
+            {
+                // No lights are being shadowcasters so after frame is done material is trying to use buffer and it hasn't been mapped since the frame started.
+                sinkIndexBuffer.Update(context, std::vector<uint32_t>{}, std::vector<uint32_t>{}, false, -1);
+            }
+            continue;
         }
 
         // PassManifest verifies static/skinned pass pairs specify the same render targets, so we can just choose from either here.
@@ -339,7 +357,7 @@ void PassBackend::RenderPostProcess(IDeviceContext& context,
             postProcessSourceBuffer.Update();
             perPassResourceSignature.Commit(context);
         }
-        sinkIndexBuffer.Update(context, pass.sources.color, pass.sources.depth, hasPostProcessSource);
+        sinkIndexBuffer.Update(context, pass.sources.color, pass.sources.depth, hasPostProcessSource, -1);
         context.SetPipelineState(pass.pso);
 
         // Bind the property buffer for the instance, if any
@@ -385,7 +403,7 @@ void PassBackend::RenderOutputToSwapchain(IDeviceContext& context, ISwapChain& s
         hasPostProcess = false;
     }
 
-    sinkIndexBuffer.Update(context, m_finalPass->sources.color, std::vector<uint32_t>(), hasPostProcess);
+    sinkIndexBuffer.Update(context, m_finalPass->sources.color, std::vector<uint32_t>(), hasPostProcess, -1);
     context.SetPipelineState(m_finalPass->pso);
     context.Draw(drawAttribs);
 }

--- a/source/ncengine/graphics2/diligent/pass/PassBackend.cpp
+++ b/source/ncengine/graphics2/diligent/pass/PassBackend.cpp
@@ -185,7 +185,8 @@ void PassBackend::RenderMaterial(IDeviceContext& context,
                                  ISwapChain& swapChain,
                                  PerPassResourceSignature& perPassResourceSignature,
                                  const std::vector<std::vector<Batch>>& staticPassBatches,
-                                 const std::vector<std::vector<Batch>>& skinnedPassBatches)
+                                 const std::vector<std::vector<Batch>>& skinnedPassBatches,
+                                 const std::span<const LightData>& lights)
 {
     NC_PROFILE_SCOPE("PassBackend::RenderMaterial()", ProfileCategory::Rendering);
     NC_ASSERT(
@@ -210,6 +211,28 @@ void PassBackend::RenderMaterial(IDeviceContext& context,
         else
         {
             m_finalColorTarget = staticPass.sinks.color;
+        }
+
+        if (staticPass.flag & MaterialPassFlag::Shadow)
+        {
+            uint32_t lightIndex = 0u;
+            for (const auto& light : lights)
+            {
+                if (!light.castsShadows)
+                {
+                    continue;
+                }
+
+                BindShadowMapRenderTarget(context, perPassResourceSignature.GetShadowMapSinksResource(), lightIndex);
+                ClearShadowMapRenderTarget(context, perPassResourceSignature.GetShadowMapSinksResource(), lightIndex);
+
+                context.SetPipelineState(staticPass.pso);
+                DrawIndexed(context, staticBatches);
+                context.SetPipelineState(skinnedPass.pso);
+                DrawIndexed(context, skinnedBatches);
+
+                lightIndex++;
+            }
         }
 
         // PassManifest verifies static/skinned pass pairs specify the same render targets, so we can just choose from either here.
@@ -305,8 +328,8 @@ void PassBackend::RenderPostProcess(IDeviceContext& context,
         // Get the post process resource we are writing to to bind in the next step
         auto& postProcessSinkBuffer = perPassResourceSignature.GetPostProcessSinkResource(pass.sinks.postProcess);
 
-        BindRenderTarget(context, swapChain, postProcessSinkBuffer, pass.sinks.postProcess);
-        ClearRenderTarget(context, swapChain, postProcessSinkBuffer, pass.sinks.postProcess);
+        BindPostProcessRenderTarget(context, swapChain, postProcessSinkBuffer, pass.sinks.postProcess);
+        ClearPostProcessRenderTarget(context, swapChain, postProcessSinkBuffer, pass.sinks.postProcess);
 
         // If this post process pass consumes any post process pass as a source, bind that source's shader resource view to the SRB.
         auto hasPostProcessSource = pass.sources.postProcess != NoTarget;

--- a/source/ncengine/graphics2/diligent/pass/PassBackend.cpp
+++ b/source/ncengine/graphics2/diligent/pass/PassBackend.cpp
@@ -197,36 +197,35 @@ void PassBackend::RenderShadowPass(IDeviceContext& context,
     auto& shadowMapsBuffer = perPassResourceSignature.GetShadowMapSinksResource();
 
     bool hasSomeShadowCaster = false;
-    uint32_t lightIndex = 0u;
 
-    for (const auto& light : lights)
+    auto renderTargetIndex = 0u;
+    for (const auto& [lightDataIndex, light] : std::views::enumerate(lights))
     {
         if (!light.castsShadows)
         {
-            lightIndex++;
             continue;
         }
 
         hasSomeShadowCaster = true;
-        sinkIndexBuffer.Update(context, std::vector<uint32_t>{}, std::vector<uint32_t>{}, false, lightIndex);
+        sinkIndexBuffer.Update(context, std::vector<uint32_t>{}, std::vector<uint32_t>{}, false, static_cast<uint32_t>(lightDataIndex));
+        perPassResourceSignature.Commit(context);
 
-        BindShadowMapRenderTarget(context, shadowMapsBuffer, lightIndex);
-        ClearShadowMapRenderTarget(context, shadowMapsBuffer, lightIndex);
+        BindShadowMapRenderTarget(context, shadowMapsBuffer, renderTargetIndex);
+        ClearShadowMapRenderTarget(context, shadowMapsBuffer, renderTargetIndex);
 
         context.SetPipelineState(staticPass.pso);
         DrawIndexed(context, staticBatches);
         context.SetPipelineState(skinnedPass.pso);
         DrawIndexed(context, skinnedBatches);
-        lightIndex++;
+        renderTargetIndex++;
     }
 
     if (!hasSomeShadowCaster)
     {
-        // No shadow-casting lights; ensure buffer is updated to prevent usage issues.
-        sinkIndexBuffer.Update(context, std::vector<uint32_t>{}, std::vector<uint32_t>{}, false, -1);
+        // No shadow-casting lights; ensure buffer is updated because it will be discarded at the end of the frame, and read from in the materials pass.
+        sinkIndexBuffer.Update(context, std::vector<uint32_t>{}, std::vector<uint32_t>{}, false, std::numeric_limits<uint32_t>::max());
+        perPassResourceSignature.Commit(context);
     }
-
-    perPassResourceSignature.Commit(context);
 }
 
 void PassBackend::RenderMaterial(IDeviceContext& context,
@@ -259,7 +258,6 @@ void PassBackend::RenderMaterial(IDeviceContext& context,
             RenderShadowPass(context, perPassResourceSignature, staticPass, skinnedPass, staticBatches, skinnedBatches, lights);
             continue;
         }
-
 
         // PassManifest verifies static/skinned pass pairs specify the same render targets, so we can just choose from either here.
         BindRenderTarget(context, swapChain, perPassResourceSignature, staticPass.sinks.color, staticPass.sinks.depth, staticPass.isMsaa && m_numSamples > 1);
@@ -365,7 +363,7 @@ void PassBackend::RenderPostProcess(IDeviceContext& context,
             postProcessSourceBuffer.Update();
             perPassResourceSignature.Commit(context);
         }
-        sinkIndexBuffer.Update(context, pass.sources.color, pass.sources.depth, hasPostProcessSource, -1);
+        sinkIndexBuffer.Update(context, pass.sources.color, pass.sources.depth, hasPostProcessSource, std::numeric_limits<uint32_t>::max());
         context.SetPipelineState(pass.pso);
 
         // Bind the property buffer for the instance, if any
@@ -411,7 +409,7 @@ void PassBackend::RenderOutputToSwapchain(IDeviceContext& context, ISwapChain& s
         hasPostProcess = false;
     }
 
-    sinkIndexBuffer.Update(context, m_finalPass->sources.color, std::vector<uint32_t>(), hasPostProcess, -1);
+    sinkIndexBuffer.Update(context, m_finalPass->sources.color, std::vector<uint32_t>(), hasPostProcess, std::numeric_limits<uint32_t>::max());
     context.SetPipelineState(m_finalPass->pso);
     context.Draw(drawAttribs);
 }

--- a/source/ncengine/graphics2/diligent/pass/PassBackend.h
+++ b/source/ncengine/graphics2/diligent/pass/PassBackend.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "graphics2/frontend/subsystem/LightRenderState.h"
 #include "graphics2/frontend/subsystem/MeshRenderState.h"
 #include "graphics2/frontend/subsystem/particle/ParticleRenderState.h"
 #include "graphics2/frontend/subsystem/PostProcessState.h"
@@ -37,7 +38,8 @@ class PassBackend
                             Diligent::ISwapChain& swapChain,
                             PerPassResourceSignature& perPassResourceSignature,
                             const std::vector<std::vector<Batch>>& staticPassBatches,
-                            const std::vector<std::vector<Batch>>& skinnedPassBatches);
+                            const std::vector<std::vector<Batch>>& skinnedPassBatches,
+                            const std::span<const LightData>& lights);
 
         void RenderWireframe(Diligent::IDeviceContext& context,
                              Diligent::ISwapChain& swapChain,

--- a/source/ncengine/graphics2/diligent/pass/PassBackend.h
+++ b/source/ncengine/graphics2/diligent/pass/PassBackend.h
@@ -15,7 +15,14 @@
 #include <memory>
 #include <vector>
 
-namespace nc::graphics
+namespace nc
+{
+namespace config
+{
+struct GraphicsSettings;
+struct MemorySettings;
+}
+namespace graphics
 {
 class PerFrameResourceSignature;
 class PerPassResourceSignature;
@@ -30,6 +37,8 @@ class PassBackend
                              ShaderFactory& shaderFactory,
                              ShaderBindings& shaderBindings,
                              const PassManifest& passManifest,
+                             const config::GraphicsSettings& graphicsSettings,
+                             const config::MemorySettings& memorySettings,
                              uint32_t numSamples = 1u);
 
         void Update(const PostProcessState& postProcessState);
@@ -85,4 +94,5 @@ class PassBackend
         std::optional<uint32_t> m_finalColorTarget;
         std::optional<uint32_t> m_finalPostProcessTarget;
 };
-} // namespace nc::graphics
+} // namespace graphics
+} // namespace nc

--- a/source/ncengine/graphics2/diligent/pass/PassBackend.h
+++ b/source/ncengine/graphics2/diligent/pass/PassBackend.h
@@ -34,6 +34,14 @@ class PassBackend
 
         void Update(const PostProcessState& postProcessState);
 
+        void RenderShadowPass(Diligent::IDeviceContext& context,
+                              PerPassResourceSignature& perPassResourceSignature,
+                              const MaterialPass& staticPass,
+                              const MaterialPass& skinnedPass,
+                              const std::vector<Batch>& staticBatches,
+                              const std::vector<Batch>& skinnedBatches,
+                              const std::span<const LightData>& lights);
+
         void RenderMaterial(Diligent::IDeviceContext& context,
                             Diligent::ISwapChain& swapChain,
                             PerPassResourceSignature& perPassResourceSignature,

--- a/source/ncengine/graphics2/diligent/pass/PassTypes.h
+++ b/source/ncengine/graphics2/diligent/pass/PassTypes.h
@@ -30,7 +30,8 @@ enum class DepthTarget : uint8_t
 {
     None,
     DepthStencil,
-    Main
+    Main,
+    Shadow
 };
 
 enum class PostProcessTarget : uint8_t

--- a/source/ncengine/graphics2/diligent/pass/PassTypes.h
+++ b/source/ncengine/graphics2/diligent/pass/PassTypes.h
@@ -30,8 +30,7 @@ enum class DepthTarget : uint8_t
 {
     None,
     DepthStencil,
-    Main,
-    Shadow
+    Main
 };
 
 enum class PostProcessTarget : uint8_t
@@ -40,6 +39,13 @@ enum class PostProcessTarget : uint8_t
     PPOutline,
     PPFxaa,
     PPNoise
+};
+
+enum class ShadowMapTarget : uint8_t
+{
+    None,
+    Uni,
+    Omni
 };
 
 struct Sources
@@ -83,6 +89,7 @@ struct PassDesc
     PostProcessTarget postProcessSource = PostProcessTarget::None;
     ColorTarget colorSink = ColorTarget::None;
     DepthTarget depthSink = DepthTarget::None;
+    ShadowMapTarget shadowMapSink = ShadowMapTarget::None;
     PostProcessTarget postProcessSink = PostProcessTarget::None;
     bool isMsaa = true;
     bool useDepthTest = true;

--- a/source/ncengine/graphics2/diligent/pass/PassUtilities.cpp
+++ b/source/ncengine/graphics2/diligent/pass/PassUtilities.cpp
@@ -41,16 +41,27 @@ void ClearRenderTarget(Diligent::IDeviceContext& context,
     }
 }
 
-void ClearRenderTarget(Diligent::IDeviceContext& context,
-                       Diligent::ISwapChain& swapChain,
-                       SinkBufferResource& postProcessSinkBufferResource,
-                       uint32_t postProcessRenderTargetIndex)
+void ClearPostProcessRenderTarget(Diligent::IDeviceContext& context,
+                                  Diligent::ISwapChain& swapChain,
+                                  SinkBufferResource& postProcessSinkBufferResource,
+                                  uint32_t postProcessRenderTargetIndex)
 {
     Diligent::ITextureView* pRTV = ToPostProcessRenderTargetView(swapChain, postProcessSinkBufferResource, postProcessRenderTargetIndex);
 
     if (pRTV)
     {
         context.ClearRenderTarget(pRTV, &ClearColor.x, Diligent::RESOURCE_STATE_TRANSITION_MODE_TRANSITION);
+    }
+}
+
+void ClearShadowMapRenderTarget(Diligent::IDeviceContext& context,
+                                SinkBufferResource& shadowMapSinkBufferResource,
+                                uint32_t shadowMapRenderTargetIndex)
+{
+    Diligent::ITextureView* pDSV = shadowMapSinkBufferResource.GetRenderTargetView(shadowMapRenderTargetIndex);
+    if (pDSV)
+    {
+        context.ClearDepthStencil(pDSV, Diligent::CLEAR_DEPTH_FLAG, 1.f, 0, Diligent::RESOURCE_STATE_TRANSITION_MODE_TRANSITION);
     }
 }
 
@@ -66,13 +77,21 @@ void BindRenderTarget(Diligent::IDeviceContext& context,
     context.SetRenderTargets(pRTV ? 1 : 0, &pRTV, pDSV, Diligent::RESOURCE_STATE_TRANSITION_MODE_TRANSITION);
 }
 
-void BindRenderTarget(Diligent::IDeviceContext& context,
-                      Diligent::ISwapChain& swapChain,
-                      SinkBufferResource& postProcessSinkBufferResource,
-                      uint32_t postProcessRenderTargetIndex)
+void BindPostProcessRenderTarget(Diligent::IDeviceContext& context,
+                                 Diligent::ISwapChain& swapChain,
+                                 SinkBufferResource& postProcessSinkBufferResource,
+                                 uint32_t postProcessRenderTargetIndex)
 {
     Diligent::ITextureView* pRTV = ToPostProcessRenderTargetView(swapChain, postProcessSinkBufferResource, postProcessRenderTargetIndex);
     context.SetRenderTargets(pRTV ? 1 : 0, &pRTV, nullptr, Diligent::RESOURCE_STATE_TRANSITION_MODE_TRANSITION);
+}
+
+void BindShadowMapRenderTarget(Diligent::IDeviceContext& context,
+                               SinkBufferResource& shadowMapSinkBufferResource,
+                               uint32_t shadowMapRenderTargetIndex)
+{
+    Diligent::ITextureView* pDSV = shadowMapSinkBufferResource.GetRenderTargetView(shadowMapRenderTargetIndex);
+    context.SetRenderTargets(0, nullptr, pDSV, Diligent::RESOURCE_STATE_TRANSITION_MODE_TRANSITION);
 }
 
 auto CreateShaderFromSourceIfInitialized(ShaderFactory& shaderFactory, Diligent::SHADER_TYPE shaderType, const nc::graphics::ShaderPaths& shaderPaths) -> Diligent::RefCntAutoPtr<Diligent::IShader>

--- a/source/ncengine/graphics2/diligent/pass/PassUtilities.h
+++ b/source/ncengine/graphics2/diligent/pass/PassUtilities.h
@@ -20,32 +20,54 @@ namespace nc::graphics
 constexpr auto ClearColor = nc::Vector4{0.050f, 0.050f, 0.050f, 1.0f};
 auto ToPassBaseId(const ShaderPaths& shaderPaths, std::string_view name) -> size_t;
 auto CreateShaderFromSourceIfInitialized(ShaderFactory& shaderFactory, Diligent::SHADER_TYPE shaderType, const nc::graphics::ShaderPaths& shaderPaths) -> Diligent::RefCntAutoPtr<Diligent::IShader>;
-void ClearRenderTarget(Diligent::IDeviceContext& context,
-                       Diligent::ISwapChain& swapChain,
-                       PerPassResourceSignature& perPassResourceSignature,
-                       uint32_t colorRenderTargetIndex,
-                       uint32_t depthRenderTargetIndex,
-                       bool isMsaa);
-void ClearRenderTarget(Diligent::IDeviceContext& context,
-                       Diligent::ISwapChain& swapChain,
-                       SinkBufferResource& postProcessSinkBufferResource,
-                      uint32_t postProcessRenderTargetIndex);
-void BindRenderTarget(Diligent::IDeviceContext& context,
-                      Diligent::ISwapChain& swapChain,
-                      PerPassResourceSignature& perPassResourceSignature,
-                      uint32_t colorRenderTargetIndex,
-                      uint32_t depthRenderTargetIndex,
-                      bool isMsaa);
-void BindRenderTarget(Diligent::IDeviceContext& context,
-                      Diligent::ISwapChain& swapChain,
-                      SinkBufferResource& postProcessSinkBufferResource,
-                      uint32_t postProcessRenderTargetIndex);
 auto GetSinks(const PassManifest& passManifest, const PassDesc& passDesc) -> Sinks;
 auto GetSources(const PassManifest& passManifest, const PassDesc& passDesc) -> Sources;
 auto HasAnyColorSources(const Sources& sources) -> bool;
 auto HasAnyDepthSources(const Sources& sources) -> bool;
-auto ToDepthRenderTargetView(Diligent::ISwapChain& swapChain, SinkBufferResource& depthSinkBufferResource, uint32_t index, bool isMsaa) -> Diligent::ITextureView*;
-auto ToPostProcessRenderTargetView(Diligent::ISwapChain& swapChain, SinkBufferResource& postProcessSinkBufferResource, uint32_t index) -> Diligent::ITextureView*;
-auto ToColorRenderTargetView(Diligent::ISwapChain& swapChain, SinkBufferResource& colorSinkBufferResource, uint32_t index, bool isMsaa) -> Diligent::ITextureView*;
 
+void ClearRenderTarget(Diligent::IDeviceContext& context,
+                       Diligent::ISwapChain& swapChain,
+                       PerPassResourceSignature& perPassResourceSignature,
+                       uint32_t colorIndex,
+                       uint32_t depthIndex,
+                       bool isMsaa);
+
+void ClearPostProcessRenderTarget(Diligent::IDeviceContext& context,
+                                  Diligent::ISwapChain& swapChain,
+                                  SinkBufferResource& postProcessSinkBufferResource,
+                                  uint32_t postProcessIndex);
+
+void ClearShadowMapRenderTarget(Diligent::IDeviceContext& context,
+                                SinkBufferResource& shadowMapSinkBufferResource,
+                                uint32_t shadowMapIndex);
+
+void BindRenderTarget(Diligent::IDeviceContext& context,
+                      Diligent::ISwapChain& swapChain,
+                      PerPassResourceSignature& perPassResourceSignature,
+                      uint32_t colorIndex,
+                      uint32_t depthIndex,
+                      bool isMsaa);
+
+void BindPostProcessRenderTarget(Diligent::IDeviceContext& context,
+                                 Diligent::ISwapChain& swapChain,
+                                 SinkBufferResource& postProcessSinkBufferResource,
+                                 uint32_t postProcessIndex);
+
+void BindShadowMapRenderTarget(Diligent::IDeviceContext& context,
+                               SinkBufferResource& shadowMapSinkBufferResource,
+                               uint32_t shadowMapIndex);
+
+auto ToDepthRenderTargetView(Diligent::ISwapChain& swapChain,
+                             SinkBufferResource& depthSinkBufferResource,
+                             uint32_t index,
+                             bool isMsaa) -> Diligent::ITextureView*;
+
+auto ToPostProcessRenderTargetView(Diligent::ISwapChain& swapChain,
+                                   SinkBufferResource& postProcessSinkBufferResource,
+                                   uint32_t index) -> Diligent::ITextureView*;
+
+auto ToColorRenderTargetView(Diligent::ISwapChain& swapChain,
+                             SinkBufferResource& colorSinkBufferResource,
+                             uint32_t index,
+                             bool isMsaa) -> Diligent::ITextureView*;
 } // namespace nc::graphics

--- a/source/ncengine/graphics2/diligent/resource/PerPassResourceSignature.cpp
+++ b/source/ncengine/graphics2/diligent/resource/PerPassResourceSignature.cpp
@@ -32,13 +32,17 @@ PerPassResourceSignature::PerPassResourceSignature(Diligent::IRenderDevice& devi
         ToPipelineResourceDesc(shadowMapSinksDesc)
     };
 
-    const auto sampler = SinkBufferResource::MakeSamplerDesc(colorSinksDesc.resourceKey);
+    const auto samplers = std::array{
+        SinkBufferResource::MakeSamplerDesc(colorSinksDesc.resourceKey),
+        SinkBufferResource::MakeShadowSamplerDesc(shadowMapSinksDesc.resourceKey),
+    };
+
     auto desc = Diligent::PipelineResourceSignatureDesc{};
     desc.Name = signatureName.data();
     desc.Resources = resources.data();
     desc.NumResources = static_cast<uint32_t>(resources.size());
-    desc.ImmutableSamplers = &sampler,
-    desc.NumImmutableSamplers = 1,
+    desc.ImmutableSamplers = samplers.data(),
+    desc.NumImmutableSamplers = static_cast<uint32_t>(samplers.size()),
     desc.UseCombinedTextureSamplers = true,
     desc.BindingIndex = bindingIndex;
 

--- a/source/ncengine/graphics2/diligent/resource/PerPassResourceSignature.cpp
+++ b/source/ncengine/graphics2/diligent/resource/PerPassResourceSignature.cpp
@@ -15,6 +15,7 @@ PerPassResourceSignature::PerPassResourceSignature(Diligent::IRenderDevice& devi
                                                    const SinkBufferDesc& colorSinksDesc,
                                                    const SinkBufferDesc& depthSinksDesc,
                                                    const SinkBufferDesc& postProcessSinksDesc,
+                                                   const SinkBufferDesc& shadowMapSinksDesc,
                                                    const UniformBufferDesc& postProcessPassPropertiesDesc,
                                                    const UniformBufferDesc& sinkIndexDesc)
     : m_postProcessSinkCount{postProcessSinksDesc.maxElementCount},
@@ -27,7 +28,8 @@ PerPassResourceSignature::PerPassResourceSignature(Diligent::IRenderDevice& devi
         ToPipelineResourceDesc(depthSinksDesc),
         ToPipelineResourceDesc(postProcessTexDesc), // Even though we have multiple post process resources, we only ever bind one at a time.
         ToPipelineResourceDesc(sinkIndexDesc),
-        ToPipelineResourceDesc(postProcessPassPropertiesDesc)
+        ToPipelineResourceDesc(postProcessPassPropertiesDesc),
+        ToPipelineResourceDesc(shadowMapSinksDesc)
     };
 
     const auto sampler = SinkBufferResource::MakeSamplerDesc(colorSinksDesc.resourceKey);
@@ -69,10 +71,10 @@ PerPassResourceSignature::PerPassResourceSignature(Diligent::IRenderDevice& devi
         GetVariable(sinkIndexDesc.shaderType, sinkIndexDesc.resourceKey.data(), m_srb)
     );
 
-    m_postProcessSinkResources.reserve(postProcessSinksDesc.maxElementCount);
+    m_postProcessSinksResource.reserve(postProcessSinksDesc.maxElementCount);
     for (auto i = 0u; i < postProcessSinksDesc.maxElementCount; i++)
     {
-        m_postProcessSinkResources.emplace_back(
+        m_postProcessSinksResource.emplace_back(
             GetVariable( Diligent::SHADER_TYPE_PIXEL, m_postProcessResourceKey.data(), m_srb),
             MakeColorSinkBufferDesc(1));
     }
@@ -82,6 +84,12 @@ PerPassResourceSignature::PerPassResourceSignature(Diligent::IRenderDevice& devi
         device,
         GetVariable(postProcessPassPropertiesDesc.shaderType, postProcessPassPropertiesDesc.resourceKey.data(), m_srb)
     );
+
+    m_shadowMapSinksResource = std::make_unique<SinkBufferResource>(
+        GetVariable(shadowMapSinksDesc.shaderType, shadowMapSinksDesc.resourceKey.data(), m_srb),
+        MakeDepthSinkBufferDesc(shadowMapSinksDesc.maxElementCount)
+    );
+    m_shadowMapSinksResource->Update();
 }
 
 void PerPassResourceSignature::BindPostProcessSink(uint32_t index)

--- a/source/ncengine/graphics2/diligent/resource/PerPassResourceSignature.h
+++ b/source/ncengine/graphics2/diligent/resource/PerPassResourceSignature.h
@@ -25,6 +25,7 @@ class PerPassResourceSignature
                                           const SinkBufferDesc& colorSinksDesc,
                                           const SinkBufferDesc& depthSinksDesc,
                                           const SinkBufferDesc& postProcessSinksDesc,
+                                          const SinkBufferDesc& shadowMapSinksDesc,
                                           const UniformBufferDesc& postProcessResourceDesc,
                                           const UniformBufferDesc& sinkIndexDesc);
 
@@ -38,8 +39,9 @@ class PerPassResourceSignature
         auto GetColorSinksResource()                    -> SinkBufferResource&                 { return *m_colorSinksResource; }
         auto GetDepthSinksResource()                    -> SinkBufferResource&                 { return *m_depthSinksResource; }
         auto GetSinkIndexBufferResource()               -> SinkIndexBufferResource&            { return *m_sinkIndexBufferResource; }
-        auto GetPostProcessSinkResource(uint32_t index) -> SinkBufferResource&                 { return m_postProcessSinkResources.at(index); }
+        auto GetPostProcessSinkResource(uint32_t index) -> SinkBufferResource&                 { return m_postProcessSinksResource.at(index); }
         auto GetPostProcessPropertyResource()           -> PostProcessPropertyBufferResource&  { return *m_postProcessPropertyResource; }
+        auto GetShadowMapSinksResource()                -> SinkBufferResource&                 { return *m_shadowMapSinksResource; }
 
         auto GetPostProcessSinkCount() const      -> uint32_t                               { return m_postProcessSinkCount; }
         auto GetColorSinkCount(bool isMsaa) const -> uint32_t                               { return isMsaa ? m_colorSinksResource->GetMsaaSinkCount() : m_colorSinksResource->GetSinkCount(); }
@@ -50,10 +52,11 @@ class PerPassResourceSignature
         Diligent::RefCntAutoPtr<Diligent::IPipelineResourceSignature> m_signature;
         std::unique_ptr<SinkBufferResource> m_colorSinksResource;
         std::unique_ptr<SinkBufferResource> m_depthSinksResource;
-        std::vector<SinkBufferResource> m_postProcessSinkResources;
+        std::vector<SinkBufferResource> m_postProcessSinksResource;
         std::vector<TextureBufferDesc> m_postProcessSinkDescs;
         std::unique_ptr<SinkIndexBufferResource> m_sinkIndexBufferResource;
         std::unique_ptr<PostProcessPropertyBufferResource> m_postProcessPropertyResource;
+        std::unique_ptr<SinkBufferResource> m_shadowMapSinksResource;
         uint32_t m_postProcessSinkCount;
         std::string m_postProcessResourceKey;
 };

--- a/source/ncengine/graphics2/diligent/resource/ShaderBindings.h
+++ b/source/ncengine/graphics2/diligent/resource/ShaderBindings.h
@@ -44,7 +44,7 @@ class ShaderBindings
                 SinkBufferDesc{"PostProcessSinks",         Diligent::SHADER_TYPE_PIXEL, 3, true},
                 SinkBufferDesc{"ShadowMapSinks",           Diligent::SHADER_TYPE_VS_PS, 20},
                 UniformBufferDesc{"PostProcessProperties", Diligent::SHADER_TYPE_PIXEL, true},
-                UniformBufferDesc{"SinkIndices",           Diligent::SHADER_TYPE_PIXEL}
+                UniformBufferDesc{"SinkIndices",           Diligent::SHADER_TYPE_VS_PS}
             }
         {
         }

--- a/source/ncengine/graphics2/diligent/resource/ShaderBindings.h
+++ b/source/ncengine/graphics2/diligent/resource/ShaderBindings.h
@@ -42,7 +42,7 @@ class ShaderBindings
                 SinkBufferDesc{"ColorSinks",               Diligent::SHADER_TYPE_PIXEL, 20},
                 SinkBufferDesc{"DepthSinks",               Diligent::SHADER_TYPE_PIXEL, 20},
                 SinkBufferDesc{"PostProcessSinks",         Diligent::SHADER_TYPE_PIXEL, 3, true},
-                SinkBufferDesc{"ShadowMapSinks",           Diligent::SHADER_TYPE_VS_PS, 20},
+                SinkBufferDesc{"ShadowMapSinks",           Diligent::SHADER_TYPE_VS_PS, memorySettings.maxDirectionalLights + memorySettings.maxSpotLights},
                 UniformBufferDesc{"PostProcessProperties", Diligent::SHADER_TYPE_PIXEL, true},
                 UniformBufferDesc{"SinkIndices",           Diligent::SHADER_TYPE_VS_PS}
             }

--- a/source/ncengine/graphics2/diligent/resource/ShaderBindings.h
+++ b/source/ncengine/graphics2/diligent/resource/ShaderBindings.h
@@ -42,6 +42,7 @@ class ShaderBindings
                 SinkBufferDesc{"ColorSinks",               Diligent::SHADER_TYPE_PIXEL, 20},
                 SinkBufferDesc{"DepthSinks",               Diligent::SHADER_TYPE_PIXEL, 20},
                 SinkBufferDesc{"PostProcessSinks",         Diligent::SHADER_TYPE_PIXEL, 3, true},
+                SinkBufferDesc{"ShadowMapSinks",           Diligent::SHADER_TYPE_VS_PS, 20},
                 UniformBufferDesc{"PostProcessProperties", Diligent::SHADER_TYPE_PIXEL, true},
                 UniformBufferDesc{"SinkIndices",           Diligent::SHADER_TYPE_PIXEL}
             }

--- a/source/ncengine/graphics2/diligent/resource/SinkBufferResource.cpp
+++ b/source/ncengine/graphics2/diligent/resource/SinkBufferResource.cpp
@@ -90,6 +90,28 @@ auto SinkBufferResource::MakeSamplerDesc(std::string_view variableName) -> Dilig
     };
 }
 
+auto SinkBufferResource::MakeShadowSamplerDesc(std::string_view variableName) -> Diligent::ImmutableSamplerDesc
+{
+    auto samplerDesc = Diligent::SamplerDesc{};
+    samplerDesc.AddressU = Diligent::TEXTURE_ADDRESS_CLAMP;
+    samplerDesc.AddressV = Diligent::TEXTURE_ADDRESS_CLAMP;
+    samplerDesc.AddressW = Diligent::TEXTURE_ADDRESS_CLAMP;
+    samplerDesc.BorderColor[0] = 0.0f;
+    samplerDesc.BorderColor[1] = 0.0f;
+    samplerDesc.BorderColor[2] = 0.0f;
+    samplerDesc.BorderColor[3] = 0.0f;
+    samplerDesc.ComparisonFunc = Diligent::COMPARISON_FUNC_LESS;
+    samplerDesc.MagFilter = Diligent::FILTER_TYPE::FILTER_TYPE_LINEAR;
+    samplerDesc.MinFilter = Diligent::FILTER_TYPE::FILTER_TYPE_LINEAR;
+    samplerDesc.MipFilter = Diligent::FILTER_TYPE::FILTER_TYPE_LINEAR;
+
+    return Diligent::ImmutableSamplerDesc{
+        Diligent::SHADER_TYPE_VS_PS,
+        variableName.data(),
+        samplerDesc
+    };
+}
+
 void SinkBufferResource::Add(Diligent::IRenderDevice& device,
                              Diligent::IDeviceContext& context,
                              uint32_t numRenderTargets,

--- a/source/ncengine/graphics2/diligent/resource/SinkBufferResource.h
+++ b/source/ncengine/graphics2/diligent/resource/SinkBufferResource.h
@@ -33,6 +33,7 @@ class SinkBufferResource
         }
 
         static auto MakeSamplerDesc(std::string_view variableName) -> Diligent::ImmutableSamplerDesc;
+        static auto MakeShadowSamplerDesc(std::string_view variableName) -> Diligent::ImmutableSamplerDesc;
 
         void Add(Diligent::IRenderDevice& device,
                  Diligent::IDeviceContext& context,

--- a/source/ncengine/graphics2/diligent/resource/SinkIndexBufferResource.cpp
+++ b/source/ncengine/graphics2/diligent/resource/SinkIndexBufferResource.cpp
@@ -23,7 +23,8 @@ SinkIndexBufferResource::SinkIndexBufferResource(Diligent::IDeviceContext& conte
 void SinkIndexBufferResource::Update(Diligent::IDeviceContext& context,
                                      std::span<const uint32_t> colorSources,
                                      std::span<const uint32_t> depthSources,
-                                     bool hasPostProcessSource)
+                                     bool hasPostProcessSource,
+                                     int32_t lightIndex)
 {
     NC_ASSERT(colorSources.size() <= 4u, "Only four color sources supported.");
     NC_ASSERT(depthSources.size() <= 3u, "Only three depth sources supported.");
@@ -50,7 +51,8 @@ void SinkIndexBufferResource::Update(Diligent::IDeviceContext& context,
     const auto data = PostProcessSinkIndexData
     {
         colorSourcesArray[0], colorSourcesArray[1], colorSourcesArray[2], colorSourcesArray[3],
-        depthSourcesArray[0], depthSourcesArray[1], depthSourcesArray[2], hasPostProcessSource ? 1u : 0u
+        depthSourcesArray[0], depthSourcesArray[1], depthSourcesArray[2], hasPostProcessSource ? 1u : 0u,
+        lightIndex
     };
     m_buffer.Write(context, data);
 }

--- a/source/ncengine/graphics2/diligent/resource/SinkIndexBufferResource.cpp
+++ b/source/ncengine/graphics2/diligent/resource/SinkIndexBufferResource.cpp
@@ -24,7 +24,7 @@ void SinkIndexBufferResource::Update(Diligent::IDeviceContext& context,
                                      std::span<const uint32_t> colorSources,
                                      std::span<const uint32_t> depthSources,
                                      bool hasPostProcessSource,
-                                     int32_t lightIndex)
+                                     uint32_t lightIndex)
 {
     NC_ASSERT(colorSources.size() <= 4u, "Only four color sources supported.");
     NC_ASSERT(depthSources.size() <= 3u, "Only three depth sources supported.");

--- a/source/ncengine/graphics2/diligent/resource/SinkIndexBufferResource.h
+++ b/source/ncengine/graphics2/diligent/resource/SinkIndexBufferResource.h
@@ -22,7 +22,8 @@ class SinkIndexBufferResource
         void Update(Diligent::IDeviceContext& context,
                     std::span<const uint32_t> colorSources,
                     std::span<const uint32_t> depthSources,
-                    bool hasPostProcessSource);
+                    bool hasPostProcessSource,
+                    int32_t lightIndex);
 
         auto GetShaderVariable() -> Diligent::IShaderResourceVariable&
         {

--- a/source/ncengine/graphics2/diligent/resource/SinkIndexBufferResource.h
+++ b/source/ncengine/graphics2/diligent/resource/SinkIndexBufferResource.h
@@ -23,7 +23,7 @@ class SinkIndexBufferResource
                     std::span<const uint32_t> colorSources,
                     std::span<const uint32_t> depthSources,
                     bool hasPostProcessSource,
-                    int32_t lightIndex);
+                    uint32_t lightIndex);
 
         auto GetShaderVariable() -> Diligent::IShaderResourceVariable&
         {

--- a/source/ncengine/graphics2/frontend/subsystem/LightSubsystem.cpp
+++ b/source/ncengine/graphics2/frontend/subsystem/LightSubsystem.cpp
@@ -59,7 +59,7 @@ auto LightSubsystem::BuildState(ecs::ExplicitEcs<DirectionalLight, PointLight, S
                 light.specularColor,
                 light.intensity,
                 transform.Position(),
-                0, /** @todo, come up with shadow decisioning (which lights cast shadows) */
+                1, /** @todo, come up with shadow decisioning (which lights cast shadows) */
                 light.radius,
                 pointlight2::CalculateLightViewProjectionMatrix(transform.TransformationMatrix())
             );
@@ -80,7 +80,7 @@ auto LightSubsystem::BuildState(ecs::ExplicitEcs<DirectionalLight, PointLight, S
                 transform.Forward(),
                 light.outerAngle,
                 light.radius,
-                0, /** @todo, come up with shadow decisioning (which lights cast shadows) */
+                1, /** @todo, come up with shadow decisioning (which lights cast shadows) */
                 spotlight2::CalculateLightViewProjectionMatrix(transform.TransformationMatrix())
             );
         }

--- a/source/ncengine/graphics2/frontend/subsystem/LightSubsystem.cpp
+++ b/source/ncengine/graphics2/frontend/subsystem/LightSubsystem.cpp
@@ -22,8 +22,8 @@ auto CalculateLightViewProjectionMatrix(DirectX::FXMMATRIX transformMatrix) -> D
 
 namespace spotlight2
 {
-constexpr float g_nearClip = 0.3f;
-constexpr float g_farClip = 200.f;
+constexpr float g_nearClip = 0.25f;
+constexpr float g_farClip = 1000.f;
 
 auto CalculateLightViewProjectionMatrix(float arcRadians, DirectX::FXMMATRIX transformMatrix) -> DirectX::XMMATRIX
 {

--- a/source/ncengine/graphics2/frontend/subsystem/LightSubsystem.cpp
+++ b/source/ncengine/graphics2/frontend/subsystem/LightSubsystem.cpp
@@ -22,15 +22,13 @@ auto CalculateLightViewProjectionMatrix(DirectX::FXMMATRIX transformMatrix) -> D
 
 namespace spotlight2
 {
-constexpr float g_lightFieldOfView = nc::DegreesToRadians(45.0f);
-constexpr float g_nearClip = 1.0f;
-constexpr float g_farClip = 100.f;
-const auto g_lightProjectionMatrix = DirectX::XMMatrixPerspectiveRH(g_lightFieldOfView, 1.0f, g_nearClip, g_farClip);
+constexpr float g_nearClip = 0.3f;
+constexpr float g_farClip = 200.f;
 
-auto CalculateLightViewProjectionMatrix(DirectX::FXMMATRIX transformMatrix) -> DirectX::XMMATRIX
+auto CalculateLightViewProjectionMatrix(float arcRadians, DirectX::FXMMATRIX transformMatrix) -> DirectX::XMMATRIX
 {
     const auto look = DirectX::XMVector3Transform(DirectX::g_XMIdentityR2, transformMatrix);
-    return DirectX::XMMatrixLookAtRH(transformMatrix.r[3], look, DirectX::g_XMNegIdentityR1) * g_lightProjectionMatrix;
+    return DirectX::XMMatrixLookAtRH(transformMatrix.r[3], look, DirectX::g_XMNegIdentityR1) * DirectX::XMMatrixPerspectiveRH(arcRadians, 1.0f, g_nearClip, g_farClip);
 }
 } // namespace spotlight2
 
@@ -59,7 +57,7 @@ auto LightSubsystem::BuildState(ecs::ExplicitEcs<DirectionalLight, PointLight, S
                 light.specularColor,
                 light.intensity,
                 transform.Position(),
-                1, /** @todo, come up with shadow decisioning (which lights cast shadows) */
+                0, /** @todo, come up with shadow decisioning (which lights cast shadows) */
                 light.radius,
                 pointlight2::CalculateLightViewProjectionMatrix(transform.TransformationMatrix())
             );
@@ -70,18 +68,23 @@ auto LightSubsystem::BuildState(ecs::ExplicitEcs<DirectionalLight, PointLight, S
         const auto& pool = ecs.GetPool<SpotLight>();
         for (auto [entity, light] : std::views::zip(pool.GetEntityPool(), pool.GetComponents()))
         {
+            float innerAngle = cos(std::max<float>(light.innerAngle, 0.0001f));
+            float outerAngle = cos(std::max<float>(light.outerAngle, 0.0001f));
+            float radius = std::max<float>(light.radius, 0.0001f);
+
+
             auto& transform = ecs.Get<Transform>(entity);
             m_data.emplace_back(
                 light.diffuseColor,
                 light.specularColor,
                 light.intensity,
                 transform.Position(),
-                light.innerAngle,
+                innerAngle,
                 transform.Forward(),
-                light.outerAngle,
-                light.radius,
+                outerAngle,
+                radius,
                 1, /** @todo, come up with shadow decisioning (which lights cast shadows) */
-                spotlight2::CalculateLightViewProjectionMatrix(transform.TransformationMatrix())
+                spotlight2::CalculateLightViewProjectionMatrix(std::max<float>(std::max<float>(innerAngle, innerAngle-outerAngle) * (radius*0.025f), 0.0001f), transform.TransformationMatrix())
             );
         }
     }

--- a/source/ncengine/graphics2/frontend/subsystem/LightSubsystem.cpp
+++ b/source/ncengine/graphics2/frontend/subsystem/LightSubsystem.cpp
@@ -83,7 +83,7 @@ auto LightSubsystem::BuildState(ecs::ExplicitEcs<DirectionalLight, PointLight, S
                 transform.Forward(),
                 outerAngle,
                 radius,
-                1, /** @todo, come up with shadow decisioning (which lights cast shadows) */
+                light.castsShadows,
                 spotlight2::CalculateLightViewProjectionMatrix(std::max<float>(std::max<float>(innerAngle, innerAngle-outerAngle) * (radius*0.025f), 0.0001f), transform.TransformationMatrix())
             );
         }

--- a/source/ncengine/graphics2/frontend/subsystem/MeshSubsystem.cpp
+++ b/source/ncengine/graphics2/frontend/subsystem/MeshSubsystem.cpp
@@ -179,8 +179,8 @@ auto MeshSubsystem::BuildState(ecs::ExplicitEcs<Transform> ecs) -> MeshRenderSta
         .transformData = m_transformCache.BuildState(),
         .staticMeshInstanceData = m_staticMeshInstanceCache.BuildState(),
         .skinnedMeshInstanceData = m_skinnedMeshInstanceCache.BuildState(),
-        .staticMeshBatches = m_staticMeshInstanceCache.BuildBatches(GetImplementedMaterialPassFlags()),
-        .skinnedMeshBatches = m_skinnedMeshInstanceCache.BuildBatches(GetImplementedMaterialPassFlags())
+        .staticMeshBatches = m_staticMeshInstanceCache.BuildBatches(GetMaterialPassFlags()),
+        .skinnedMeshBatches = m_skinnedMeshInstanceCache.BuildBatches(GetMaterialPassFlags())
     };
 }
 

--- a/source/ncengine/ui/editor/impl/ComponentWidgets.cpp
+++ b/source/ncengine/ui/editor/impl/ComponentWidgets.cpp
@@ -1186,6 +1186,7 @@ void SpotLightUIWidget(SpotLight& light, EditorContext&, const std::any&)
     ui::DragFloat(light.innerAngle, "innerAngle", step, min, light.outerAngle);
     ui::DragFloat(light.outerAngle, "outerAngle", step, light.innerAngle, max);
     ui::DragFloat(light.radius, "radius", 0.1f, min, 100.0f);
+    nc::ui::Checkbox(light.castsShadows, "castsShadows");
 }
 
 void CollisionListenerUIWidget(CollisionListener&, EditorContext&, const std::any&)

--- a/source/ncengine/ui/editor/impl/ComponentWidgets.cpp
+++ b/source/ncengine/ui/editor/impl/ComponentWidgets.cpp
@@ -1179,13 +1179,13 @@ void SpotLightUIWidget(SpotLight& light, EditorContext&, const std::any&)
     IMGUI_SCOPE(ui::ImGuiId, "SpotLight");
     constexpr auto step = 0.01f;
     constexpr auto min = 0.0f;
-    constexpr auto max = 3.14159f;
+    constexpr auto max = 1.5707f;
     ui::InputColor3(light.diffuseColor, "diffuseColor");
     ui::InputColor3(light.specularColor, "specularColor");
     ui::DragFloat(light.intensity, "intensity", 0.1f, 0.0f, 200.0f);
     ui::DragFloat(light.innerAngle, "innerAngle", step, min, light.outerAngle);
     ui::DragFloat(light.outerAngle, "outerAngle", step, light.innerAngle, max);
-    ui::DragFloat(light.radius, "radius", 0.1f, min, 1200.0f);
+    ui::DragFloat(light.radius, "radius", 0.1f, min, 100.0f);
 }
 
 void CollisionListenerUIWidget(CollisionListener&, EditorContext&, const std::any&)

--- a/test/ncengine/config/collateral/config.ini
+++ b/test/ncengine/config/collateral/config.ini
@@ -60,6 +60,7 @@ launch_fullscreen=0
    
 target_fps=60
 use_shadows=1
+shadow_map_resolution=2048
 antialiasing=1
 initial_batch_size=1
 use_validation_layers=0

--- a/test/ncengine/graphics2/MeshSubsystem_tests.cpp
+++ b/test/ncengine/graphics2/MeshSubsystem_tests.cpp
@@ -13,7 +13,7 @@
 #include <ranges>
 
 const auto g_materialDesc = nc::MaterialDesc{
-    .passes = nc::MaterialPassFlag::Toon | nc::MaterialPassFlag::Normals
+    .passes = nc::MaterialPassFlag::Shadow | nc::MaterialPassFlag::Depth | nc::MaterialPassFlag::Toon | nc::MaterialPassFlag::Normals
 };
 
 constexpr auto g_meshView = nc::asset::MeshView{
@@ -122,7 +122,7 @@ TEST_F(MeshSubsystemTest, BuildState_BuildsExpectedState)
     EXPECT_EQ(3, actualSkinnedInstanceState.dirtyRanges[0].count);
 
     const auto& actualStaticPassBatches = actualRenderState.staticMeshBatches;
-    ASSERT_EQ(3, actualStaticPassBatches.size());
+    ASSERT_EQ(4, actualStaticPassBatches.size());
     const auto& actualStaticBatches = actualStaticPassBatches.at(1);
     EXPECT_EQ(1, actualStaticBatches.size());
     const auto& actualStaticBatch = actualStaticBatches.at(0);
@@ -130,7 +130,7 @@ TEST_F(MeshSubsystemTest, BuildState_BuildsExpectedState)
     EXPECT_EQ(5, actualStaticBatch.instanceCount);
 
     const auto& actualSkinnedPassBatches = actualRenderState.skinnedMeshBatches;
-    ASSERT_EQ(3, actualSkinnedPassBatches.size());
+    ASSERT_EQ(4, actualSkinnedPassBatches.size());
     const auto& actualSkinnedBatches = actualSkinnedPassBatches.at(1);
     EXPECT_EQ(1, actualSkinnedBatches.size());
     const auto& actualSkinnedBatch = actualSkinnedBatches.at(0);
@@ -169,7 +169,7 @@ TEST_F(MeshSubsystemTest, OnRemoveMesh_UntracksObject)
 
     // Batch reports only one instance
     const auto& actualPassState = actualRenderState.staticMeshBatches;
-    ASSERT_EQ(3, actualPassState.size());
+    ASSERT_EQ(4, actualPassState.size());
     const auto& actualBatches = actualPassState.at(1);
     EXPECT_EQ(1, actualBatches.size());
     const auto& actualBatch = actualBatches.at(0);
@@ -198,7 +198,7 @@ TEST_F(MeshSubsystemTest, UpdateMesh_UsingSetMesh_PatchesTrackedState)
     auto actualRenderState = uut.BuildState(world);
     auto verifyBatches = [](const auto& actualPassState)
     {
-        ASSERT_EQ(3, actualPassState.size());
+        ASSERT_EQ(4, actualPassState.size());
         const auto& actualBatches = actualPassState.at(1);
         EXPECT_EQ(2, actualBatches.size());
         const auto& actualBatch1 = actualBatches.at(0);

--- a/test/smoke_test/smoke_test_config.ini
+++ b/test/smoke_test/smoke_test_config.ini
@@ -47,6 +47,7 @@ launch_fullscreen=0
 screen_width=500
 screen_height=500
 target_fps=60
+shadow_map_resolution=2048
 use_shadows=1
 antialiasing=1
 initial_batch_size=1


### PR DESCRIPTION
closes #889
closes #794 

The first of three shadow map PRs. This one is just for spot lights.
Spot lights are working much better now.
Exposed `castsShadows` as a UI property for Spot Lights.

![image](https://github.com/user-attachments/assets/2ec6ff4c-afa0-483e-bc53-c8829b39c649)

Remaining work:
If you tinker with the radius enough, you can expand the spotlight beyond the dimensions of the shadow map. I am modulating the FOV of the projection matrix by the radius now, but more math and more calculations are required to get it an exact match. I went for an approximation to save on CPU cycles.

