### PR TITLE
Remove Duplicate Transform Update

### DIFF
--- a/source/ncengine/ecs/NcEcsImpl.cpp
+++ b/source/ncengine/ecs/NcEcsImpl.cpp
@@ -38,11 +38,7 @@ void EcsModule::OnBuildTaskGraph(task::UpdateTasks& update, task::RenderTasks&)
     (
         update_task_id::CommitStagedChanges,
         "CommitStagedChanges",
-        [this]
-        {
-            m_registry->CommitPendingChanges();
-            UpdateWorldSpaceMatrices();
-        },
+        [this] { m_registry->CommitPendingChanges(); },
         {update_task_id::FrameLogicUpdate}
     );
 


### PR DESCRIPTION
In #847 I moved the transform update to a new task but didn't remove the old call, so we've been doing it twice. Fixing.