### PR TITLE
Update Diligent

### DIFF
--- a/.github/actions/linux_setup/action.yml
+++ b/.github/actions/linux_setup/action.yml
@@ -37,7 +37,7 @@ runs:
         echo "VULKAN_SDK=${{ github.workspace }}/VulkanSDK/x86_64" >> $GITHUB_ENV
         echo "PATH=${{ github.workspace }}/VulkanSDK/x86_64/bin:$PATH" >> $GITHUB_ENV
         echo "LD_LIBRARY_PATH=${{ github.workspace }}/VulkanSDK/x86_64/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
-        echo "VK_LAYER_PATH=${{ github.workspace }}/VulkanSDK/x86_64/etc/vulkan/explicit_layer.d" >> $GITHUB_ENV
+        echo "VK_LAYER_PATH=${{ github.workspace }}/VulkanSDK/x86_64/share/vulkan/explicit_layer.d" >> $GITHUB_ENV
 
     - name: Setup Display
       shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,13 +51,13 @@ jobs:
         if: ${{ matrix.shortName == 'Windows' }}
         uses: NcStudios/VulkanCI@v1.1
         with:
-          sdkVersion: 1.3.261.1
+          sdkVersion: 1.4.309.0
 
       - name: Setup Linux
         if: ${{ matrix.shortName == 'Linux' }}
         uses: ./.github/actions/linux_setup
         with:
-          sdkVersion: 1.3.261.1
+          sdkVersion: 1.4.309.0
 
       - name: Configure
         run: ${{ matrix.cmakeEnv }} cmake -G "${{ matrix.generator }}" -S . -B build ${{ matrix.cmakeArgs }} -DCMAKE_BUILD_TYPE=${{ matrix.config }} -DCMAKE_INSTALL_PREFIX=install -DNC_BUILD_TESTS=ON -DNC_BUILD_INTEGRATION_TESTS=ON

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Setup VulkanCI (Windows)
         if: ${{ matrix.shortName == 'Windows' }}
-        uses: NcStudios/VulkanCI@v1.1
+        uses: NcStudios/VulkanCI@v1.2
         with:
           sdkVersion: 1.4.309.0
 

--- a/cmake/FetchDependencies.cmake
+++ b/cmake/FetchDependencies.cmake
@@ -44,7 +44,7 @@ FetchContent_Declare(glfw
 # Dear ImGui
 FetchContent_Declare(imgui
                      GIT_REPOSITORY https://github.com/NcStudios/imgui.git
-                     GIT_TAG        v1.91.5+nc.1
+                     GIT_TAG        v1.91.5+nc.2
                      GIT_SHALLOW    TRUE
 )
 
@@ -118,16 +118,18 @@ set(DILIGENT_LIBRARIES Diligent-GraphicsEngineVk-static
                        Diligent-Imgui
 )
 
+set(DILIGENT_TAG API256008) # require patch from #666, can update to official release once available
+
 FetchContent_Declare(DiligentCore
                      GIT_REPOSITORY https://github.com/DiligentGraphics/DiligentCore.git
-                     GIT_TAG        v2.5.6
+                     GIT_TAG        ${DILIGENT_TAG}
                      GIT_SHALLOW    TRUE
                      SOURCE_DIR     _deps/DiligentCore
 )
 
 FetchContent_Declare(DiligentTools
                      GIT_REPOSITORY https://github.com/DiligentGraphics/DiligentTools.git
-                     GIT_TAG        v2.5.6
+                     GIT_TAG        ${DILIGENT_TAG}
                      GIT_SHALLOW    TRUE
                      SOURCE_DIR     _deps/DiligentTools
 )


### PR DESCRIPTION
presumably a fix for #898

Updating diligent to get a fix for the synchronization validation error. Also, had to do a simple to our imgui fork to make the sdl (1) backend header available. The version of imgui we're on has renamed it to sdl2, while diligent still tries to include the old name. 