### PR TITLE
Request DepthClamp Feature

### DIFF
--- a/source/ncengine/graphics2/NcGraphicsImpl2.cpp
+++ b/source/ncengine/graphics2/NcGraphicsImpl2.cpp
@@ -70,6 +70,7 @@ auto MakeEngineCreateInfo(bool enableValidation) -> Diligent::EngineCreateInfo
     engineCI.Features.BindlessResources = Diligent::DEVICE_FEATURE_STATE_ENABLED;
     engineCI.Features.ShaderResourceRuntimeArrays = Diligent::DEVICE_FEATURE_STATE_ENABLED;
     engineCI.Features.WireframeFill = Diligent::DEVICE_FEATURE_STATE_ENABLED;
+    engineCI.Features.DepthClamp = Diligent::DEVICE_FEATURE_STATE_ENABLED;
     return engineCI;
 }
 


### PR DESCRIPTION
Depth clamp feature needs to be enabled in order to disable depth clipping in the PSO.