### PR TITLE
Add shape key animation tests

### DIFF
--- a/test/ncconvert/CMakeLists.txt
+++ b/test/ncconvert/CMakeLists.txt
@@ -186,6 +186,7 @@ if(NC_BUILD_NCCONVERT)
     target_compile_definitions(GeometryConverter_unit_tests
         PRIVATE
             TEST_COLLATERAL_DIR="${NC_CONVERT_TEST_COLLATERAL_DIR}"
+            SAMPLE_MODEL_DIR="${PROJECT_SOURCE_DIR}/sample/assets/raw/model"
     )
 
     target_include_directories(GeometryConverter_unit_tests

--- a/test/ncconvert/GeometryConverter_unit_tests.cpp
+++ b/test/ncconvert/GeometryConverter_unit_tests.cpp
@@ -1,6 +1,6 @@
-#include "gtest/gtest.h"
-#include "GeometryTestUtility.h"
 #include "CollateralGeometry.h"
+#include "GeometryTestUtility.h"
+#include "gtest/gtest.h"
 
 #include "analysis/GeometryAnalysis.h"
 #include "converters/GeometryConverter.h"
@@ -75,7 +75,8 @@ TEST(GeometryConverterTest, ImportedMesh_convertsToNca)
     }
 
     const auto nVertices = actual.vertices.size();
-    EXPECT_TRUE(std::ranges::all_of(actual.indices, [&nVertices](auto i){ return i < nVertices; }));
+    EXPECT_TRUE(
+        std::ranges::all_of(actual.indices, [&nVertices](auto i) { return i < nVertices; }));
 }
 
 TEST(GeometryConverterTest, ImportedMesh_optimizeMesh_convertsToNca)
@@ -97,7 +98,8 @@ TEST(GeometryConverterTest, ImportedMesh_optimizeMesh_convertsToNca)
     }
 
     const auto nVertices = actual.vertices.size();
-    EXPECT_TRUE(std::ranges::all_of(actual.indices, [&nVertices](auto i){ return i < nVertices; }));
+    EXPECT_TRUE(
+        std::ranges::all_of(actual.indices, [&nVertices](auto i) { return i < nVertices; }));
 }
 
 TEST(GeometryConverterTest, ImportedMesh_multipleSubResources_specifiedMeshParsed)
@@ -159,12 +161,13 @@ TEST(GeometryConverterTest, GetBoneWeights_fiveBonesPerVertex_importFails)
     {
         uut.ImportMesh(test_data::filePath);
     }
-    catch(const nc::NcError& e)
+    catch (const nc::NcError& e)
     {
-        EXPECT_TRUE(std::string(e.what()).find(std::string("more than four bones")) != std::string::npos);
+        EXPECT_TRUE(std::string(e.what()).find(std::string("more than four bones")) !=
+                    std::string::npos);
         threwNcError = true;
     }
-    
+
     EXPECT_TRUE(threwNcError);
 }
 
@@ -177,12 +180,13 @@ TEST(GeometryConverterTest, GetBoneWeights_weightsNotEqual100_importFails)
     {
         uut.ImportMesh(test_data::filePath);
     }
-    catch(const nc::NcError& e)
+    catch (const nc::NcError& e)
     {
-        EXPECT_TRUE(std::string(e.what()).find(std::string("affecting each vertex must equal 1")) != std::string::npos);
+        EXPECT_TRUE(std::string(e.what()).find(std::string("affecting each vertex must equal 1")) !=
+                    std::string::npos);
         threwNcError = true;
     }
-    
+
     EXPECT_TRUE(threwNcError);
 }
 
@@ -205,14 +209,14 @@ TEST(GeometryConverterTest, GetBonesData_getBonesWeight_elementsCorrespond)
 
     for (const auto& vertex : actual.vertices)
     {
-        EXPECT_EQ(vertex.boneIds[0], 0); // Bone0
-        EXPECT_EQ(vertex.boneIds[1], 1); // Bone1
-        EXPECT_EQ(vertex.boneIds[2], 2); // Bone2
-        EXPECT_EQ(vertex.boneIds[3], 3); // Bone3
-        EXPECT_FLOAT_EQ(vertex.boneWeights.x, 0.1f);  // Bone0
-        EXPECT_FLOAT_EQ(vertex.boneWeights.y, 0.1f);  // Bone1
-        EXPECT_FLOAT_EQ(vertex.boneWeights.z, 0.1f);  // Bone2
-        EXPECT_FLOAT_EQ(vertex.boneWeights.w, 0.7f);  // Bone3
+        EXPECT_EQ(vertex.boneIds[0], 0);             // Bone0
+        EXPECT_EQ(vertex.boneIds[1], 1);             // Bone1
+        EXPECT_EQ(vertex.boneIds[2], 2);             // Bone2
+        EXPECT_EQ(vertex.boneIds[3], 3);             // Bone3
+        EXPECT_FLOAT_EQ(vertex.boneWeights.x, 0.1f); // Bone0
+        EXPECT_FLOAT_EQ(vertex.boneWeights.y, 0.1f); // Bone1
+        EXPECT_FLOAT_EQ(vertex.boneWeights.z, 0.1f); // Bone2
+        EXPECT_FLOAT_EQ(vertex.boneWeights.w, 0.7f); // Bone3
     }
 
     const auto& bonesData = actual.bonesData.value();
@@ -230,11 +234,11 @@ TEST(GeometryConverterTest, GetBonesData_complexMesh_convertedCorrectly)
     auto uut = nc::convert::GeometryConverter{};
     const auto actual = uut.ImportMesh(test_data::filePath);
 
-    EXPECT_FLOAT_EQ(actual.vertices[0].boneWeights.x, 0.35232919f);  // Bone0
-    EXPECT_FLOAT_EQ(actual.vertices[0].boneWeights.y, 0.17152755f);  // Bone1
-    EXPECT_FLOAT_EQ(actual.vertices[0].boneWeights.z, 0.11047833f);  // Bone2
-    EXPECT_FLOAT_EQ(actual.vertices[0].boneWeights.w, 0.36566496f);  // Bone3
-    
+    EXPECT_FLOAT_EQ(actual.vertices[0].boneWeights.x, 0.35232919f); // Bone0
+    EXPECT_FLOAT_EQ(actual.vertices[0].boneWeights.y, 0.17152755f); // Bone1
+    EXPECT_FLOAT_EQ(actual.vertices[0].boneWeights.z, 0.11047833f); // Bone2
+    EXPECT_FLOAT_EQ(actual.vertices[0].boneWeights.w, 0.36566496f); // Bone3
+
     const auto& bonesData = actual.bonesData.value();
     EXPECT_EQ(bonesData.boneSpaceToParentSpace.size(), 383);
     EXPECT_EQ(bonesData.vertexSpaceToBoneSpace.size(), 283);
@@ -248,7 +252,8 @@ TEST(GeometryConverterTest, ImportSkeletalAnimation_singleClip_convertedCorrectl
 {
     namespace test_data = collateral::simple_cube_animation_fbx;
     auto uut = nc::convert::GeometryConverter{};
-    const auto actual = uut.ImportSkeletalAnimation(test_data::filePath, std::string("Armature|Wiggle"));
+    const auto actual =
+        uut.ImportSkeletalAnimation(test_data::filePath, std::string("Armature|Wiggle"));
 
     EXPECT_EQ(actual.name, std::string("Armature|Wiggle"));
     EXPECT_EQ(actual.durationInTicks, 60);
@@ -260,5 +265,62 @@ TEST(GeometryConverterTest, ImportSkeletalAnimation_incorrectSubResourceName_thr
 {
     namespace test_data = collateral::simple_cube_animation_fbx;
     auto uut = nc::convert::GeometryConverter{};
-    EXPECT_THROW(uut.ImportSkeletalAnimation(test_data::filePath, std::string("Armature|Wigglde")), nc::NcError);
+    EXPECT_THROW(uut.ImportSkeletalAnimation(test_data::filePath, std::string("Armature|Wigglde")),
+                 nc::NcError);
+}
+
+TEST(GeometryConverterTest, ImportShapeKeyAnimation_cube_convertedCorrectly)
+{
+    namespace test_data = collateral::cube_glb;
+    auto uut = nc::convert::GeometryConverter{};
+    const auto actual = uut.ImportShapeKeyAnimation(test_data::filePath, std::string{"Move"});
+
+    EXPECT_EQ(actual.numShapeKeys, test_data::shapeKeyCount);
+    EXPECT_EQ(actual.animation.width, test_data::vertexCount * 3u);
+    EXPECT_EQ(actual.animation.height, test_data::shapeKeyCount);
+    EXPECT_NEAR(actual.durationInSeconds, test_data::animationDuration, 0.0001f);
+    EXPECT_EQ(actual.animation.pixelData.size(),
+              test_data::vertexCount * 3ull * test_data::shapeKeyCount);
+}
+
+TEST(GeometryConverterTest, ImportShapeKeyAnimation_plane_convertedCorrectly)
+{
+    namespace test_data = collateral::plane_glb;
+    auto uut = nc::convert::GeometryConverter{};
+    const auto actual = uut.ImportShapeKeyAnimation(test_data::filePath, std::string{"Y2"});
+
+    EXPECT_EQ(actual.numShapeKeys, test_data::shapeKeyCount);
+    EXPECT_EQ(actual.animation.width, test_data::vertexCount * 3u);
+    EXPECT_EQ(actual.animation.height, test_data::shapeKeyCount);
+    EXPECT_NEAR(actual.durationInSeconds, test_data::animationDuration, 0.0001f);
+    EXPECT_EQ(actual.animation.pixelData.size(),
+              test_data::vertexCount * 3ull * test_data::shapeKeyCount);
+}
+
+TEST(GeometryConverterTest, ImportShapeKeyAnimation_flag_convertedCorrectly)
+{
+    namespace test_data = collateral::flag_glb;
+    auto uut = nc::convert::GeometryConverter{};
+    const auto actual = uut.ImportShapeKeyAnimation(test_data::filePath, std::string{"FlagWave"});
+
+    EXPECT_EQ(actual.numShapeKeys, test_data::shapeKeyCount);
+    EXPECT_EQ(actual.animation.width, test_data::vertexCount * 3u);
+    EXPECT_EQ(actual.animation.height, test_data::shapeKeyCount);
+    EXPECT_NEAR(actual.durationInSeconds, test_data::animationDuration, 0.0001f);
+    EXPECT_EQ(actual.animation.pixelData.size(),
+              test_data::vertexCount * 3ull * test_data::shapeKeyCount);
+}
+
+TEST(GeometryConverterTest, ImportShapeKeyAnimation_steeple_convertedCorrectly)
+{
+    namespace test_data = collateral::steeple_glb;
+    auto uut = nc::convert::GeometryConverter{};
+    const auto actual = uut.ImportShapeKeyAnimation(test_data::filePath, std::string{"Chute"});
+
+    EXPECT_EQ(actual.numShapeKeys, test_data::shapeKeyCount);
+    EXPECT_EQ(actual.animation.width, test_data::vertexCount * 3u);
+    EXPECT_EQ(actual.animation.height, test_data::shapeKeyCount);
+    EXPECT_NEAR(actual.durationInSeconds, test_data::animationDuration, 0.0001f);
+    EXPECT_EQ(actual.animation.pixelData.size(),
+              test_data::vertexCount * 3ull * test_data::shapeKeyCount);
 }

--- a/test/ncconvert/collateral/CollateralGeometry.h
+++ b/test/ncconvert/collateral/CollateralGeometry.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "CollateralCommon.h"
 #include "analysis/GeometryAnalysis.h"
+#include "CollateralCommon.h"
 
 #include "ncmath/Geometry.h"
 
@@ -15,17 +15,21 @@ namespace cube_fbx
 {
 const auto filePath = collateralDirectory / "cube.fbx";
 constexpr auto vertexCount = 24ull; // note that duplicates are removed below
-constexpr auto possibleVertices = std::array<nc::Vector3, 8>{
-    nc::Vector3{ 0.5f,  0.5f,  0.5f}, nc::Vector3{-0.5f,  0.5f,  0.5f},
-    nc::Vector3{ 0.5f,  0.5f, -0.5f}, nc::Vector3{-0.5f,  0.5f, -0.5f},
-    nc::Vector3{ 0.5f, -0.5f,  0.5f}, nc::Vector3{-0.5f, -0.5f,  0.5f},
-    nc::Vector3{ 0.5f, -0.5f, -0.5f}, nc::Vector3{-0.5f, -0.5f, -0.5f}
-};
+constexpr auto possibleVertices = std::array<nc::Vector3, 8>{nc::Vector3{0.5f, 0.5f, 0.5f},
+                                                             nc::Vector3{-0.5f, 0.5f, 0.5f},
+                                                             nc::Vector3{0.5f, 0.5f, -0.5f},
+                                                             nc::Vector3{-0.5f, 0.5f, -0.5f},
+                                                             nc::Vector3{0.5f, -0.5f, 0.5f},
+                                                             nc::Vector3{-0.5f, -0.5f, 0.5f},
+                                                             nc::Vector3{0.5f, -0.5f, -0.5f},
+                                                             nc::Vector3{-0.5f, -0.5f, -0.5f}};
 
-constexpr auto possibleNormals = std::array<nc::Vector3, 6>{
-    nc::Vector3::Left(), nc::Vector3::Right(), nc::Vector3::Up(),
-    nc::Vector3::Down(), nc::Vector3::Front(), nc::Vector3::Back()
-};
+constexpr auto possibleNormals = std::array<nc::Vector3, 6>{nc::Vector3::Left(),
+                                                            nc::Vector3::Right(),
+                                                            nc::Vector3::Up(),
+                                                            nc::Vector3::Down(),
+                                                            nc::Vector3::Front(),
+                                                            nc::Vector3::Back()};
 
 constexpr auto meshVertexExtents = nc::Vector3::One();
 const auto furthestDistanceFromOrigin = std::sqrt(0.75f);
@@ -90,20 +94,48 @@ namespace plane_fbx
 {
 const auto filePath = collateralDirectory / "plane.fbx";
 constexpr auto triangleCount = 2ull;
-constexpr auto possibleTriangles = std::array<nc::Triangle, triangleCount>{
-    nc::Triangle{
-        nc::Vector3{-1.0f, -1.0f, 0.0f},
-        nc::Vector3{-1.0f,  1.0f, 0.0f},
-        nc::Vector3{ 1.0f, -1.0f, 0.0f}
-    },
-    nc::Triangle{
-        nc::Vector3{-1.0f,  1.0f, 0.0f},
-        nc::Vector3{ 1.0f,  1.0f, 0.0f},
-        nc::Vector3{ 1.0f, -1.0f, 0.0f}
-    }
-};
+constexpr auto possibleTriangles =
+    std::array<nc::Triangle, triangleCount>{nc::Triangle{nc::Vector3{-1.0f, -1.0f, 0.0f},
+                                                         nc::Vector3{-1.0f, 1.0f, 0.0f},
+                                                         nc::Vector3{1.0f, -1.0f, 0.0f}},
+                                            nc::Triangle{nc::Vector3{-1.0f, 1.0f, 0.0f},
+                                                         nc::Vector3{1.0f, 1.0f, 0.0f},
+                                                         nc::Vector3{1.0f, -1.0f, 0.0f}}};
 
 constexpr auto meshVertexExtents = nc::Vector3{2.0f, 2.0f, 0.0f};
 const auto furthestDistanceFromOrigin = std::sqrt(2.0f);
 } // namespace plane_fbx
+
+// Sample models with shape key animations
+namespace cube_glb
+{
+const auto filePath = std::filesystem::path{SAMPLE_MODEL_DIR} / "cube.glb";
+constexpr auto vertexCount = 14ull;
+constexpr auto shapeKeyCount = 2u;
+constexpr auto animationDuration = 0.41666666f;
+} // namespace cube_glb
+
+namespace plane_glb
+{
+const auto filePath = std::filesystem::path{SAMPLE_MODEL_DIR} / "plane.glb";
+constexpr auto vertexCount = 4ull;
+constexpr auto shapeKeyCount = 3u;
+constexpr auto animationDuration = 8.333333f;
+} // namespace plane_glb
+
+namespace flag_glb
+{
+const auto filePath = std::filesystem::path{SAMPLE_MODEL_DIR} / "flag.glb";
+constexpr auto vertexCount = 1281ull;
+constexpr auto shapeKeyCount = 25u;
+constexpr auto animationDuration = 10.041667f;
+} // namespace flag_glb
+
+namespace steeple_glb
+{
+const auto filePath = std::filesystem::path{SAMPLE_MODEL_DIR} / "steeple.glb";
+constexpr auto vertexCount = 4225ull;
+constexpr auto shapeKeyCount = 20u;
+constexpr auto animationDuration = 4.0f;
+} // namespace steeple_glb
 } // namespace collateral


### PR DESCRIPTION
## Summary
- expand `CollateralGeometry.h` with shape key constants for sample models
- expose `SAMPLE_MODEL_DIR` to GeometryConverter tests
- verify importing shape key animations for cube, plane, flag and steeple models

## Testing
- `cmake .. -DNC_BUILD_TESTS=ON -DNC_BUILD_NCCONVERT=ON` *(fails: Could NOT find Vulkan)*

------
https://chatgpt.com/codex/tasks/task_e_686c73507288832785bdfd08b6a5bdf8