### PR TITLE
SampleUI Bug

### DIFF
--- a/sample/source/SampleMain.cpp
+++ b/sample/source/SampleMain.cpp
@@ -54,6 +54,7 @@ int main(int argc, char** argv)
     try
     {
         auto config = nc::config::Load(args.configPath);
+        auto ui = std::unique_ptr<nc::sample::SampleUI>{};
         auto engine = nc::InitializeNcEngine(config);
         nc::sample::InitializeResources();
 
@@ -65,7 +66,7 @@ int main(int argc, char** argv)
         }
         else
         {
-            auto ui = nc::sample::InitializeSampleUI(engine.get());
+            ui = nc::sample::InitializeSampleUI(engine.get());
             engine->Start(std::make_unique<nc::sample::PhysicsTest>(ui.get()));
         }
     }

--- a/sample/source/shared/SampleUI.cpp
+++ b/sample/source/shared/SampleUI.cpp
@@ -46,12 +46,10 @@ namespace nc::sample
           m_font{nc::asset::AcquireFont(font::ui)}
     {
         ui::SetDefaultUIStyle();
-        window::RegisterOnResizeReceiver(this);
     }
 
     SampleUI::~SampleUI() noexcept
     {
-        window::UnregisterOnResizeReceiver(this);
     }
 
     void SampleUI::Draw()
@@ -142,11 +140,6 @@ namespace nc::sample
     bool SampleUI::IsHovered()
     {
         return ImGui::GetIO().WantCaptureMouse;
-    }
-
-    void SampleUI::OnResize(nc::Vector2 dimensions)
-    {
-        m_windowDimensions = dimensions;
     }
 
     void SampleUI::SetWidgetCallback(std::function<void()> func)

--- a/sample/source/shared/SampleUI.h
+++ b/sample/source/shared/SampleUI.h
@@ -12,14 +12,13 @@
 
 namespace nc::sample
 {
-class SampleUI : public ui::IUI, public window::IOnResizeReceiver
+class SampleUI : public ui::IUI
 {
     public:
         SampleUI(NcScene* ncScene);
         ~SampleUI() noexcept;
         void Draw() override;
         bool IsHovered() override;
-        void OnResize(Vector2 dimensions) override;
         void SetWidgetCallback(std::function<void()> func);
 
     private:


### PR DESCRIPTION
resolves #939

Exceptions can cause scenes to call into SampleUI after its lifetime has ended. Moved it so its guaranteed to outlive the engine.