### PR TITLE
Update Audio Device Handling + Buffers

### DIFF
--- a/include/ncengine/audio/NcAudio.h
+++ b/include/ncengine/audio/NcAudio.h
@@ -22,8 +22,11 @@ namespace config
 struct AudioSettings;
 } // namespace config
 
+/** @brief Id representing an audio device. */
+using AudioDeviceId = uint32_t;
+
 /** @brief Id representing a system's default audio device. */
-constexpr auto DefaultAudioDeviceId = std::numeric_limits<uint32_t>::max();
+constexpr auto DefaultAudioDeviceId = std::numeric_limits<AudioDeviceId>::max();
 
 /** @brief Id representing a null audio device. */
 constexpr auto InvalidAudioDeviceId = DefaultAudioDeviceId - 1u;
@@ -31,8 +34,8 @@ constexpr auto InvalidAudioDeviceId = DefaultAudioDeviceId - 1u;
 /** @brief The name and device id of an available audio device. */
 struct AudioDevice
 {
-    std::string name;
-    uint32_t id;
+    std::string name = "UnknownDevice";
+    AudioDeviceId id = InvalidAudioDeviceId;
 };
 
 /**
@@ -102,11 +105,13 @@ struct NcAudio : public Module
      * If the operation fails using the provided id, an attempt will be made to fallback
      * to another suitable device, preferring the system default.
      */
-    virtual auto SetOutputDevice(uint32_t deviceId = DefaultAudioDeviceId) noexcept -> bool = 0;
+    virtual auto SetOutputDevice(AudioDeviceId deviceId = DefaultAudioDeviceId) noexcept -> bool = 0;
 
     /**
      * @brief Get the signal for device change events.
      * @return A reference to the signal managing device change events.
+     * @note On device error (e.g. hot unplug), a device change is automatically attempted once. If the attempt fails,
+     *       this event will emit an empty AudioDevice.
     */
     virtual auto OnChangeOutputDevice() noexcept -> Signal<const AudioDevice&>& = 0;
 };

--- a/include/ncutility/SpscQueue.h
+++ b/include/ncutility/SpscQueue.h
@@ -4,16 +4,10 @@
  */
 #pragma once
 
-#include "ncutility/platform/Platform.h"
+#include "ncutility/platform/New.h"
 
 #include <array>
 #include <atomic>
-#include <new>
-
-#ifndef __cpp_lib_hardware_interference_size
-#error "Destructive interference not defined"
-#endif
-
 
 namespace nc
 {
@@ -83,7 +77,7 @@ class spsc_queue
 
         static_assert(N >= 1, "Queue capacity must be >= 1");
         static_assert(std::atomic<size_t>::is_always_lock_free);
-        static constexpr auto CacheLine = std::hardware_destructive_interference_size;
+        static constexpr auto CacheLine = nc::hardware_destructive_interference_size;
 
         alignas(CacheLine) std::array<T, N> m_buffer = {};
         alignas(CacheLine) std::atomic<size_t> m_head = 0;

--- a/include/ncutility/SpscQueue.h
+++ b/include/ncutility/SpscQueue.h
@@ -1,0 +1,110 @@
+/**
+ * @file SpscQueue.h
+ * @copyright Jaremie Romer and McCallister Romer 2025
+ */
+#pragma once
+
+#include "ncutility/platform/Platform.h"
+
+#include <array>
+#include <atomic>
+#include <new>
+
+namespace nc
+{
+NC_DISABLE_WARNING_PUSH
+NC_DISABLE_WARNING_MSVC(4324)
+
+/** @brief Fixed-size single-producer/single-consumer queue. */
+template <class T, size_t N>
+class spsc_queue
+{
+    public:
+        [[nodiscard]] auto push(const T& v) -> bool
+        {
+            return emplace(v);
+        }
+
+        [[nodiscard]] auto push(T&& v) -> bool
+        {
+            return emplace(std::move(v));
+        }
+
+        [[nodiscard]] auto pop(T& out) -> bool
+        {
+            if (is_empty(m_consumer))
+            {
+                refresh_consumer_cache();
+                if (is_empty(m_consumer))
+                {
+                    return false;
+                }
+            }
+
+            out = std::move(m_buffer[index(m_consumer.head)]);
+            advance_consumer();
+            return true;
+        }
+
+        template<class... Args>
+        [[nodiscard]] auto emplace(Args&&... args) -> bool
+        {
+            if (is_full(m_producer))
+            {
+                refresh_producer_cache();
+                if (is_full(m_producer))
+                {
+                    return false;
+                }
+            }
+
+            m_buffer[index(m_producer.tail)] = T(std::forward<Args>(args)...);
+            advance_producer();
+            return true;
+        }
+
+        [[nodiscard]] auto empty() const noexcept -> bool
+        {
+            return m_head.load(std::memory_order_acquire) ==
+                   m_tail.load(std::memory_order_acquire);
+        }
+
+    private:
+        struct Cache
+        {
+            size_t head = 0;
+            size_t tail = 0;
+        };
+
+        static_assert(N >= 1, "Queue capacity must be >= 1");
+        static_assert(std::atomic<size_t>::is_always_lock_free);
+        static constexpr auto CacheLine = std::hardware_destructive_interference_size;
+
+        alignas(CacheLine) std::array<T, N> m_buffer = {};
+        alignas(CacheLine) std::atomic<size_t> m_head = 0;
+        alignas(CacheLine) std::atomic<size_t> m_tail = 0;
+        alignas(CacheLine) Cache m_producer;
+        alignas(CacheLine) Cache m_consumer;
+
+        static constexpr auto index(size_t i) -> size_t
+        {
+            if constexpr ((N & (N - 1)) == 0)
+            {
+                return i & (N - 1);
+            }
+            else
+            {
+                return i % N;
+            }
+        }
+
+        static auto is_full(const Cache& cache)  -> bool { return cache.tail - cache.head >= N; }
+        static auto is_empty(const Cache& cache) -> bool { return cache.head == cache.tail; }
+        void refresh_producer_cache()                    { m_producer.head = m_head.load(std::memory_order_acquire); }
+        void refresh_consumer_cache()                    { m_consumer.tail = m_tail.load(std::memory_order_acquire); }
+        void advance_producer()                          { m_tail.store(++m_producer.tail, std::memory_order_release); }
+        void advance_consumer()                          { m_head.store(++m_consumer.head, std::memory_order_release); }
+};
+
+NC_DISABLE_WARNING_POP
+} // namespace nc

--- a/include/ncutility/SpscQueue.h
+++ b/include/ncutility/SpscQueue.h
@@ -10,6 +10,11 @@
 #include <atomic>
 #include <new>
 
+#ifndef __cpp_lib_hardware_interference_size
+#error "Destructive interference not defined"
+#endif
+
+
 namespace nc
 {
 NC_DISABLE_WARNING_PUSH

--- a/include/ncutility/platform/New.h
+++ b/include/ncutility/platform/New.h
@@ -1,0 +1,29 @@
+/**
+ * @file New.h
+ * @copyright Jaremie Romer and McCallister Romer 2025
+ */
+#pragma once
+
+#include "Platform.h"
+
+#include <new>
+
+#ifdef __cpp_lib_hardware_interference_size
+    #ifdef NC_COMPILER_GCC
+        // GCC issues diagnostics on any ODR use of constants in 'std' namespace b/c they are tuneable values.
+        #define NC_DESTRUCTIVE_INTERFERENCE_SIZE  __GCC_DESTRUCTIVE_SIZE
+        #define NC_CONSTRUCTIVE_INTERFERENCE_SIZE __GCC_CONSTRUCTIVE_SIZE
+    #else
+        #define NC_DESTRUCTIVE_INTERFERENCE_SIZE  std::hardware_destructive_interference_size
+        #define NC_CONSTRUCTIVE_INTERFERENCE_SIZE std::hardware_constructive_interference_size
+    #endif
+#else
+    #define NC_DESTRUCTIVE_INTERFERENCE_SIZE  64
+    #define NC_CONSTRUCTIVE_INTERFERENCE_SIZE 64
+#endif
+
+namespace nc
+{
+inline constexpr auto hardware_destructive_interference_size  = NC_DESTRUCTIVE_INTERFERENCE_SIZE;
+inline constexpr auto hardware_constructive_interference_size = NC_DESTRUCTIVE_INTERFERENCE_SIZE;
+} // namespace nc

--- a/include/ncutility/platform/New.h
+++ b/include/ncutility/platform/New.h
@@ -25,5 +25,5 @@
 namespace nc
 {
 inline constexpr auto hardware_destructive_interference_size  = NC_DESTRUCTIVE_INTERFERENCE_SIZE;
-inline constexpr auto hardware_constructive_interference_size = NC_DESTRUCTIVE_INTERFERENCE_SIZE;
+inline constexpr auto hardware_constructive_interference_size = NC_CONSTRUCTIVE_INTERFERENCE_SIZE;
 } // namespace nc

--- a/include/ncutility/platform/Platform.h
+++ b/include/ncutility/platform/Platform.h
@@ -1,3 +1,7 @@
+/**
+ * @file Platform.h
+ * @copyright Jaremie Romer and McCallister Romer 2025
+ */
 #pragma once
 
 #if defined(_WIN32) || defined(_WIN64)

--- a/include/ncutility/platform/SourceLocation.h
+++ b/include/ncutility/platform/SourceLocation.h
@@ -1,3 +1,7 @@
+/**
+ * @file SourceLocation.h
+ * @copyright Jaremie Romer and McCallister Romer 2025
+ */
 #pragma once
 
 #if __has_include(<source_location>)

--- a/source/ncengine/audio/AudioBuffer.h
+++ b/source/ncengine/audio/AudioBuffer.h
@@ -1,0 +1,87 @@
+#pragma once
+
+#include "ncutility/SpscQueue.h"
+
+#include <limits>
+#include <vector>
+
+namespace nc::audio
+{
+struct BufferSlice
+{
+    static constexpr auto NullIndex = std::numeric_limits<uint32_t>::max();
+
+    double* data = nullptr;
+    uint32_t index = NullIndex;
+};
+
+class AudioBuffer
+{
+    public:
+        static constexpr auto OutputChannelCount = 2u;
+        static constexpr auto SampleRate = 44100u;
+        static constexpr auto BufferSlices = 3u;
+
+        explicit AudioBuffer(uint32_t bufferFrames)
+            : m_memory(GetTotalBufferFrames(bufferFrames), 0.0),
+              m_bufferFrames{bufferFrames}
+        {
+            for (auto i = 0; i < BufferSlices; ++i)
+            {
+                (void)m_staleIndices.push(i);
+            }
+        }
+
+        auto FramesPerBuffer()                    const -> uint32_t    { return m_bufferFrames; }
+        auto SamplesPerBuffer()                   const -> uint32_t    { return FramesPerBuffer() * OutputChannelCount; }
+        auto BytesPerBuffer()                     const -> uint32_t    { return SamplesPerBuffer() * sizeof(double); }
+        auto AcquireStaleBuffer()                       -> BufferSlice { return AcquireBuffer(m_staleIndices); }
+        auto AcquireReadyBuffer()                       -> BufferSlice { return AcquireBuffer(m_readyIndices); }
+        void MarkBufferReady(const BufferSlice& buffer)                { (void)m_readyIndices.push(buffer.index); }
+        void MarkBufferStale(const BufferSlice& buffer)                { (void)m_staleIndices.push(buffer.index); }
+
+        void Resize(uint32_t bufferFrames)
+        {
+            Clear();
+            m_memory = std::vector<double>(GetTotalBufferFrames(bufferFrames), 0.0);
+            m_bufferFrames = bufferFrames;
+        }
+
+        void Clear() noexcept
+        {
+            auto index = 0u;
+            while (m_readyIndices.pop(index))
+            {
+                (void)m_staleIndices.push(index);
+            }
+        }
+
+    private:
+        std::vector<double> m_memory;
+        spsc_queue<uint32_t, BufferSlices> m_readyIndices;
+        spsc_queue<uint32_t, BufferSlices> m_staleIndices;
+        uint32_t m_bufferFrames;
+
+        static auto GetTotalBufferFrames(uint32_t bufferFrames) -> uint32_t
+        {
+            return bufferFrames * OutputChannelCount * BufferSlices;
+        }
+
+        auto ToBufferPtr(uint32_t index) noexcept -> double*
+        {
+            return m_memory.data() + index * SamplesPerBuffer();
+        }
+
+        auto AcquireBuffer(spsc_queue<uint32_t, BufferSlices>& indices) -> BufferSlice
+        {
+            auto out = BufferSlice{};
+            if (indices.pop(out.index))
+            {
+                out.data = ToBufferPtr(out.index);
+                return out;
+            }
+
+            return out;
+        }
+};
+} // namespace nc::audio

--- a/source/ncengine/audio/AudioBuffer.h
+++ b/source/ncengine/audio/AudioBuffer.h
@@ -26,7 +26,7 @@ class AudioBuffer
             : m_memory(GetTotalBufferFrames(bufferFrames), 0.0),
               m_bufferFrames{bufferFrames}
         {
-            for (auto i = 0; i < BufferSlices; ++i)
+            for (auto i = 0u; i < BufferSlices; ++i)
             {
                 (void)m_staleIndices.push(i);
             }

--- a/source/ncengine/audio/DeviceStream.cpp
+++ b/source/ncengine/audio/DeviceStream.cpp
@@ -32,7 +32,6 @@ auto ToString(RtAudioErrorType type) noexcept -> std::string_view
 
 auto IsSuitableDevice(const RtAudio::DeviceInfo& deviceInfo) noexcept -> bool
 {
-    // TODO: #374 - Need to pin down exact outputChannel requirements
     return deviceInfo.outputChannels >= 2;
 }
 } // anonymous namespace
@@ -153,7 +152,7 @@ void DeviceStream::CloseStream() noexcept
     }
 }
 
-void DeviceStream::AbandomStream() noexcept
+void DeviceStream::AbandonStream() noexcept
 {
     CloseStream();
     m_errorContext->SetStatus(StreamStatus::Abandoned);

--- a/source/ncengine/audio/DeviceStream.cpp
+++ b/source/ncengine/audio/DeviceStream.cpp
@@ -153,6 +153,12 @@ void DeviceStream::CloseStream() noexcept
     }
 }
 
+void DeviceStream::AbandomStream() noexcept
+{
+    CloseStream();
+    m_errorContext->SetStatus(StreamStatus::Abandoned);
+}
+
 auto DeviceStream::GetStreamStatus() const noexcept -> StreamStatus
 {
     return m_errorContext->GetStatus();

--- a/source/ncengine/audio/DeviceStream.h
+++ b/source/ncengine/audio/DeviceStream.h
@@ -37,7 +37,7 @@ class DeviceStream
 
         auto OpenStream(const StreamParameters& params) -> bool;
         void CloseStream() noexcept;
-        void AbandomStream() noexcept;
+        void AbandonStream() noexcept;
         auto GetStreamStatus() const noexcept -> StreamStatus;
         auto GetStreamTime() const noexcept -> double;
         void SetStreamTime(double time) noexcept;

--- a/source/ncengine/audio/DeviceStream.h
+++ b/source/ncengine/audio/DeviceStream.h
@@ -13,7 +13,7 @@ using StreamCallback = int (*)(void* outputBuffer, void* inputBuffer, unsigned n
 
 struct StreamParameters
 {
-    uint32_t deviceId;
+    AudioDeviceId deviceId;
     uint32_t bufferFrames;
     uint32_t channelCount;
     uint32_t sampleRate;
@@ -25,7 +25,8 @@ enum class StreamStatus : uint8_t
 {
     Open = 0,
     Closed = 1,
-    Failed = 1
+    Failed = 2,
+    Abandoned = 3
 };
 
 class DeviceStream
@@ -36,6 +37,7 @@ class DeviceStream
 
         auto OpenStream(const StreamParameters& params) -> bool;
         void CloseStream() noexcept;
+        void AbandomStream() noexcept;
         auto GetStreamStatus() const noexcept -> StreamStatus;
         auto GetStreamTime() const noexcept -> double;
         void SetStreamTime(double time) noexcept;

--- a/source/ncengine/audio/NcAudioImpl.cpp
+++ b/source/ncengine/audio/NcAudioImpl.cpp
@@ -238,7 +238,7 @@ auto NcAudioImpl::TryFailureRecovery() -> bool
     if (!result)
     {
         NC_LOG_TRACE("Failed to reopen an AudioDevice stream. Abandoning AudioDevice.");
-        m_deviceStream.AbandomStream();
+        m_deviceStream.AbandonStream();
         m_outputDeviceChanged.Emit(m_deviceStream.GetDevice());
         return false;
     }

--- a/source/ncengine/audio/NcAudioImpl.cpp
+++ b/source/ncengine/audio/NcAudioImpl.cpp
@@ -8,38 +8,6 @@
 
 namespace
 {
-constexpr auto g_outputChannelCount = 2u;
-constexpr auto g_sampleRate = 44100u;
-constexpr auto g_bufferCount = 3u;
-
-auto IndividualBufferSize(uint32_t bufferFrames) -> uint32_t
-{
-    return bufferFrames * g_outputChannelCount;
-}
-
-auto BuildBufferPool(uint32_t bufferFrames) -> std::vector<double>
-{
-    return std::vector<double>(IndividualBufferSize(bufferFrames) * g_bufferCount, 0.0);
-}
-
-auto BuildBufferQueue(std::span<double> bufferPool) -> std::queue<std::span<double>>
-{
-    if (bufferPool.size() % g_bufferCount != 0)
-    {
-        throw nc::NcError("Invalid buffer pool size");
-    }
-
-    const auto bufferLength = bufferPool.size() / g_bufferCount;
-    auto queue = std::queue<std::span<double>>{};
-    for(auto i = 0ull; i < g_bufferCount; ++i)
-    {
-        auto begin = bufferPool.begin() + i * bufferLength;
-        queue.emplace(begin, bufferLength);
-    }
-
-    return queue;
-}
-
 int AudioSystemCallback(void* outputBuffer, void*, unsigned nBufferFrames, double, unsigned, void* userData)
 {
     auto* system = static_cast<nc::audio::NcAudioImpl*>(userData);
@@ -52,8 +20,8 @@ auto CreateStreamParams(uint32_t deviceId, uint32_t bufferFrames, nc::audio::NcA
     {
         deviceId,
         bufferFrames,
-        g_outputChannelCount,
-        g_sampleRate,
+        nc::audio::AudioBuffer::OutputChannelCount,
+        nc::audio::AudioBuffer::SampleRate,
         ::AudioSystemCallback,
         static_cast<void*>(impl)
     };
@@ -103,11 +71,7 @@ namespace audio
 NcAudioImpl::NcAudioImpl(const config::AudioSettings& settings, ecs::ExplicitEcs<Entity, Transform, AudioSource> gameState)
     : m_gameState{gameState},
       m_deviceStream{::CreateStreamParams(DefaultAudioDeviceId, settings.bufferFrames, this)},
-      m_bufferMemory(::BuildBufferPool(m_deviceStream.GetBufferFrames())),
-      m_readyBuffers{},
-      m_staleBuffers{::BuildBufferQueue(m_bufferMemory)},
-      m_readyMutex{},
-      m_staleMutex{},
+      m_buffer{m_deviceStream.GetBufferFrames()},
       m_listener{Entity::Null()},
       m_configBufferFrames{settings.bufferFrames}
 {
@@ -120,13 +84,8 @@ NcAudioImpl::~NcAudioImpl() noexcept
 
 void NcAudioImpl::Clear() noexcept
 {
+    m_buffer.Clear();
     m_listener = Entity::Null();
-    auto lock = std::lock_guard{m_readyMutex};
-    while(!m_readyBuffers.empty())
-    {
-        m_staleBuffers.push(m_readyBuffers.front());
-        m_readyBuffers.pop();
-    }
 }
 
 void NcAudioImpl::OnBuildTaskGraph(task::UpdateTasks& update, task::RenderTasks&)
@@ -156,14 +115,11 @@ auto NcAudioImpl::GetOutputDevice() const noexcept -> const AudioDevice&
     return m_deviceStream.GetDevice();
 }
 
-auto NcAudioImpl::SetOutputDevice(uint32_t deviceId) noexcept -> bool
+auto NcAudioImpl::SetOutputDevice(AudioDeviceId deviceId) noexcept -> bool
 {
-    const auto result = m_deviceStream.OpenStream(::CreateStreamParams(deviceId, m_configBufferFrames, this));
-    if (result)
-    {
-        m_outputDeviceChanged.Emit(m_deviceStream.GetDevice());
-    }
-
+    const auto params = ::CreateStreamParams(deviceId, m_configBufferFrames, this);
+    const auto result = m_deviceStream.OpenStream(params);
+    ApplyDeviceChange();
     return result;
 }
 
@@ -184,28 +140,17 @@ void NcAudioImpl::SetStreamTime(double time) noexcept
 
 int NcAudioImpl::WriteToDeviceBuffer(double* output, uint32_t bufferFrames)
 {
-    assert(bufferFrames == m_deviceStream.GetBufferFrames());
-    const auto bufferSizeInBytes = ::IndividualBufferSize(bufferFrames) * sizeof(double);
-    // empty check before lock is only safe with 1 consumer
-    if(m_readyBuffers.empty())
+    assert(bufferFrames == m_buffer.FramesPerBuffer());
+    const auto buffer = m_buffer.AcquireReadyBuffer();
+    const auto bytes = m_buffer.BytesPerBuffer();
+    if (buffer.data)
     {
-        std::memset(output, 0, bufferSizeInBytes);
-        return 0;
+        std::memcpy(output, buffer.data, bytes);
+        m_buffer.MarkBufferStale(buffer);
     }
-
-    auto buffer = std::span<double>{};
-
+    else
     {
-        std::lock_guard lock{m_readyMutex};
-        buffer = m_readyBuffers.front();
-        m_readyBuffers.pop();
-    }
-
-    std::memcpy(output, buffer.data(), bufferSizeInBytes);
-
-    {
-        std::lock_guard lock{m_staleMutex};
-        m_staleBuffers.push(buffer);
+        std::memset(output, 0, bytes);
     }
 
     return 0;
@@ -214,59 +159,41 @@ int NcAudioImpl::WriteToDeviceBuffer(double* output, uint32_t bufferFrames)
 void NcAudioImpl::Run()
 {
     NC_PROFILE_TASK("AudioModule", ProfileCategory::Audio);
-    if(!m_listener.Valid())
+    if (!CheckStreamStatus() || !m_listener.Valid())
     {
         return;
     }
 
-    if (m_deviceStream.GetStreamStatus() == StreamStatus::Failed)
+    const auto bufferFrames = m_buffer.FramesPerBuffer();
+    for (auto bufferNumber = 0u; bufferNumber < AudioBuffer::BufferSlices; ++bufferNumber)
     {
-        // TODO #376: We'd like to attempt to reopen a stream on the same device, but device persistence may not be possible
-        return;
-    }
-
-    auto buffer = std::span<double>{};
-
-    for(auto i = 0u; i < g_bufferCount; ++i)
-    {
-        if(m_staleBuffers.empty())
+        const auto buffer = m_buffer.AcquireStaleBuffer();
+        if (buffer.data)
         {
-            return;
+            MixToBuffer(buffer.data, bufferFrames);
+            m_buffer.MarkBufferReady(buffer);
+            continue;
         }
 
-        {
-            auto lock = std::lock_guard{m_staleMutex};
-            buffer = m_staleBuffers.front();
-            m_staleBuffers.pop();
-        }
-
-        MixToBuffer(buffer.data());
-
-        {
-            auto lock = std::lock_guard{m_readyMutex};
-            m_readyBuffers.push(buffer);
-        }
+        break;
     }
 }
 
-void NcAudioImpl::MixToBuffer(double* buffer)
+void NcAudioImpl::MixToBuffer(double* buffer, uint32_t bufferFrames)
 {
-    const auto bufferFrames = m_deviceStream.GetBufferFrames();
-    const auto bufferSizeInBytes = ::IndividualBufferSize(bufferFrames) * sizeof(double);
-    std::memset(buffer, 0, bufferSizeInBytes);
-
+    std::memset(buffer, 0, m_buffer.BytesPerBuffer());
     const auto& listenerTransform = m_gameState.Get<Transform>(m_listener);
     const auto listenerPosition = listenerTransform.Position();
     const auto rightEar = listenerTransform.Right();
 
-    for(auto& source : m_gameState.GetAll<AudioSource>())
+    for (auto& source : m_gameState.GetAll<AudioSource>())
     {
-        if(!source.IsPlaying())
+        if (!source.IsPlaying())
         {
             continue;
         }
 
-        if(source.IsSpatial())
+        if (source.IsSpatial())
         {
             auto& transform = m_gameState.Get<Transform>(source.ParentEntity());
             source.WriteSpatialSamples(buffer, bufferFrames, transform.Position(), listenerPosition, rightEar);
@@ -276,6 +203,52 @@ void NcAudioImpl::MixToBuffer(double* buffer)
             source.WriteNonSpatialSamples(buffer, bufferFrames);
         }
     }
+}
+
+auto NcAudioImpl::CheckStreamStatus() -> bool
+{
+    switch (m_deviceStream.GetStreamStatus())
+    {
+        case StreamStatus::Open:      return true;
+        case StreamStatus::Failed:    return TryFailureRecovery();
+        default:                      return false;
+    }
+}
+
+void NcAudioImpl::ApplyDeviceChange()
+{
+    const auto bufferFrames = m_deviceStream.GetBufferFrames();
+    if (bufferFrames != m_buffer.FramesPerBuffer())
+    {
+        m_buffer.Resize(bufferFrames);
+    }
+
+    m_outputDeviceChanged.Emit(m_deviceStream.GetDevice());
+}
+
+auto NcAudioImpl::TryFailureRecovery() -> bool
+{
+    const auto lastKnownDevice = m_deviceStream.GetDevice().id;
+    const auto preferredDevice = lastKnownDevice == InvalidAudioDeviceId
+        ? DefaultAudioDeviceId
+        : lastKnownDevice;
+
+    NC_LOG_TRACE("Attempting to to reopen an AudioDevice stream (device {}).", preferredDevice);
+    const auto result = m_deviceStream.OpenStream(::CreateStreamParams(preferredDevice, m_configBufferFrames, this));
+    if (!result)
+    {
+        NC_LOG_TRACE("Failed to reopen an AudioDevice stream. Abandoning AudioDevice.");
+        m_deviceStream.AbandomStream();
+        m_outputDeviceChanged.Emit(m_deviceStream.GetDevice());
+        return false;
+    }
+
+    if (m_deviceStream.GetDevice().id != preferredDevice)
+    {
+        ApplyDeviceChange();
+    }
+
+    return true;
 }
 } // namespace audio
 } // namespace nc

--- a/source/ncengine/audio/NcAudioImpl.cpp
+++ b/source/ncengine/audio/NcAudioImpl.cpp
@@ -138,7 +138,7 @@ void NcAudioImpl::SetStreamTime(double time) noexcept
     m_deviceStream.SetStreamTime(time);
 }
 
-int NcAudioImpl::WriteToDeviceBuffer(double* output, uint32_t bufferFrames)
+int NcAudioImpl::WriteToDeviceBuffer(double* output, [[maybe_unused]] uint32_t bufferFrames)
 {
     assert(bufferFrames == m_buffer.FramesPerBuffer());
     const auto buffer = m_buffer.AcquireReadyBuffer();

--- a/source/ncengine/audio/NcAudioImpl.cpp
+++ b/source/ncengine/audio/NcAudioImpl.cpp
@@ -243,7 +243,7 @@ auto NcAudioImpl::TryFailureRecovery() -> bool
         return false;
     }
 
-    if (m_deviceStream.GetDevice().id != preferredDevice)
+    if (m_deviceStream.GetDevice().id != lastKnownDevice)
     {
         ApplyDeviceChange();
     }

--- a/source/ncengine/audio/NcAudioImpl.h
+++ b/source/ncengine/audio/NcAudioImpl.h
@@ -1,13 +1,11 @@
 #pragma once
 
+#include "AudioBuffer.h"
 #include "DeviceStream.h"
 #include "ncengine/audio/NcAudio.h"
 #include "ncengine/audio/AudioSource.h"
 #include "ncengine/ecs/Ecs.h"
 #include "ncengine/task/TaskGraph.h"
-
-#include <mutex>
-#include <queue>
 
 namespace nc::audio
 {
@@ -24,7 +22,7 @@ class NcAudioImpl final : public NcAudio
         void SetStreamTime(double time) noexcept override;
         auto EnumerateOutputDevices() noexcept -> std::vector<AudioDevice> override;
         auto GetOutputDevice() const noexcept -> const AudioDevice& override;
-        auto SetOutputDevice(uint32_t deviceId) noexcept -> bool override;
+        auto SetOutputDevice(AudioDeviceId deviceId) noexcept -> bool override;
         auto OnChangeOutputDevice() noexcept -> Signal<const AudioDevice&>& override;
 
         /** Module API */
@@ -37,15 +35,14 @@ class NcAudioImpl final : public NcAudio
     private:
         ecs::ExplicitEcs<Entity, Transform, AudioSource> m_gameState;
         DeviceStream m_deviceStream;
-        std::vector<double> m_bufferMemory;
-        std::queue<std::span<double>> m_readyBuffers;
-        std::queue<std::span<double>> m_staleBuffers;
-        std::mutex m_readyMutex;
-        std::mutex m_staleMutex;
+        AudioBuffer m_buffer;
         Entity m_listener;
         Signal<const AudioDevice&> m_outputDeviceChanged;
         unsigned m_configBufferFrames;
 
-        void MixToBuffer(double* buffer);
+        void MixToBuffer(double* buffer, uint32_t bufferFrames);
+        auto CheckStreamStatus() -> bool;
+        void ApplyDeviceChange();
+        auto TryFailureRecovery() -> bool;
 };
 } // namespace nc::audio

--- a/test/ncengine/audio/AudioBuffer_unit_test.cpp
+++ b/test/ncengine/audio/AudioBuffer_unit_test.cpp
@@ -1,0 +1,98 @@
+#include "gtest/gtest.h"
+#include "ncengine/audio/AudioBuffer.h"
+
+class AudioBufferTest : public ::testing::Test
+{
+    protected:
+        static constexpr uint32_t FramesPerBuffer = 128u;
+        nc::audio::AudioBuffer uut{FramesPerBuffer};
+};
+
+TEST_F(AudioBufferTest, constructor_allBuffersStartStale)
+{
+    for (auto i = 0u; i < nc::audio::AudioBuffer::BufferSlices; ++i)
+    {
+        const auto actual = uut.AcquireStaleBuffer();
+        EXPECT_NE(actual.data, nullptr);
+        EXPECT_LT(actual.index, nc::audio::AudioBuffer::BufferSlices);
+    }
+
+    const auto nonexistent = uut.AcquireStaleBuffer();
+    EXPECT_EQ(nonexistent.data, nullptr);
+    EXPECT_EQ(nonexistent.index, nc::audio::BufferSlice::NullIndex);
+}
+
+TEST_F(AudioBufferTest, trivialGetters_returnExpectedValues)
+{
+    EXPECT_EQ(uut.FramesPerBuffer(), FramesPerBuffer);
+    EXPECT_EQ(uut.SamplesPerBuffer(), FramesPerBuffer * nc::audio::AudioBuffer::OutputChannelCount);
+    EXPECT_EQ(uut.BytesPerBuffer(), uut.SamplesPerBuffer() * sizeof(double));
+}
+
+TEST_F(AudioBufferTest, MarkBufferReady_makesAvailableAsReadyBuffer)
+{
+    auto original = uut.AcquireStaleBuffer();
+    ASSERT_NE(original.data, nullptr);
+    std::fill(original.data, original.data + uut.SamplesPerBuffer(), 42.0);
+    uut.MarkBufferReady(original);
+
+    auto ready = uut.AcquireReadyBuffer();
+    EXPECT_EQ(ready.data, original.data);
+    EXPECT_EQ(ready.index, original.index);
+    for (auto i = 0u; i < uut.SamplesPerBuffer(); ++i)
+    {
+        EXPECT_EQ(42.0, ready.data[i]);
+    }
+}
+
+TEST_F(AudioBufferTest, MarkBufferStale_returnsToStaleQueue)
+{
+    const auto original = uut.AcquireStaleBuffer();
+    ASSERT_NE(original.data, nullptr);
+
+    while (uut.AcquireStaleBuffer().data != nullptr); // exhaust stale buffers
+    uut.MarkBufferReady(original);
+
+    const auto actual = uut.AcquireReadyBuffer();
+    EXPECT_EQ(original.data, actual.data);
+    EXPECT_EQ(original.index, actual.index);
+}
+
+TEST_F(AudioBufferTest, Resize_resetsBuffersAndCapacity)
+{
+    const auto newFrames = FramesPerBuffer * 2u;
+    uut.Resize(newFrames);
+
+    EXPECT_EQ(uut.FramesPerBuffer(), newFrames);
+    EXPECT_EQ(uut.SamplesPerBuffer(), newFrames * nc::audio::AudioBuffer::OutputChannelCount);
+
+    for (auto i = 0u; i < nc::audio::AudioBuffer::BufferSlices; ++i)
+    {
+        auto slice = uut.AcquireStaleBuffer();
+        EXPECT_NE(slice.data, nullptr);
+        EXPECT_EQ(slice.index, i);
+    }
+
+    auto slice = uut.AcquireStaleBuffer();
+    EXPECT_EQ(slice.data, nullptr);
+}
+
+TEST_F(AudioBufferTest, Clear_marksAllStale)
+{
+    for (auto i = 0u; i < nc::audio::AudioBuffer::BufferSlices; ++i)
+    {
+        auto slice = uut.AcquireStaleBuffer();
+        ASSERT_NE(slice.data, nullptr);
+        uut.MarkBufferReady(slice);
+    }
+
+    uut.Clear();
+
+    EXPECT_EQ(nullptr, uut.AcquireReadyBuffer().data);
+
+    for (auto i = 0u; i < nc::audio::AudioBuffer::BufferSlices; ++i)
+    {
+        auto slice = uut.AcquireStaleBuffer();
+        EXPECT_NE(slice.data, nullptr);
+    }
+}

--- a/test/ncengine/audio/CMakeLists.txt
+++ b/test/ncengine/audio/CMakeLists.txt
@@ -1,4 +1,29 @@
-### Config Tests ###
+### AudioBuffer Tests ###
+add_executable(AudioBuffer_tests
+    AudioBuffer_unit_test.cpp
+)
+
+target_include_directories(AudioBuffer_tests
+    PRIVATE
+        ${NC_INCLUDE_DIR}
+        ${PROJECT_SOURCE_DIR}/source
+)
+
+target_compile_options(AudioBuffer_tests
+    PUBLIC
+        ${NC_COMPILER_FLAGS}
+)
+
+target_link_libraries(AudioBuffer_tests
+    PRIVATE
+        NcUtility
+        NcMath
+        gtest_main
+)
+
+add_test(AudioBuffer_tests AudioBuffer_tests)
+
+### AudioSource Tests ###
 add_executable(AudioSource_tests
     AudioSource_tests.cpp
     ${NC_SOURCE_DIR}/audio/AudioSource.cpp

--- a/test/ncutility/CMakeLists.txt
+++ b/test/ncutility/CMakeLists.txt
@@ -94,6 +94,28 @@ target_link_libraries(ScopeExit_unit_tests
 
 add_test(ScopeExit_unit_tests ScopeExit_unit_tests)
 
+### SpscQueue Tests ###
+add_executable(SpscQueue_unit_tests
+    SpscQueue_unit_test.cpp
+)
+
+target_include_directories(SpscQueue_unit_tests
+    PRIVATE
+        ${PROJECT_SOURCE_DIR}/include
+)
+
+target_compile_options(SpscQueue_unit_tests
+    PUBLIC
+        ${NC_COMPILER_FLAGS}
+)
+
+target_link_libraries(SpscQueue_unit_tests
+    PRIVATE
+        gtest_main
+)
+
+add_test(SpscQueue_unit_tests SpscQueue_unit_tests)
+
 ### StringHash Tests ###
 set(NC_HASH_TEST_COLLATERAL_DIRECTORY ${PROJECT_SOURCE_DIR}/test/ncutility/collateral/)
 

--- a/test/ncutility/SpscQueue_unit_test.cpp
+++ b/test/ncutility/SpscQueue_unit_test.cpp
@@ -1,0 +1,152 @@
+#include "gtest/gtest.h"
+#include "ncutility/SpscQueue.h"
+
+#include <algorithm>
+#include <memory>
+#include <ranges>
+#include <thread>
+
+TEST(SpscQueueTest, emplace_constructsInPlace)
+{
+    auto uut = nc::spsc_queue<std::string, 1>{};
+    EXPECT_TRUE(uut.emplace(5, 'x'));
+
+    auto actual = std::string{};
+    EXPECT_TRUE(uut.pop(actual));
+    EXPECT_EQ("xxxxx", actual);
+}
+
+TEST(SpscQueueTest, push_lValueOverload_returnsTrueUntilFull)
+{
+    constexpr auto n = 4;
+    const auto value = 42;
+    auto uut = nc::spsc_queue<int, n>{};
+    for (auto i = 0; i < n; ++i)
+    {
+        EXPECT_TRUE(uut.push(value));
+    }
+
+    EXPECT_FALSE(uut.push(value));
+}
+
+TEST(SpscQueueTest, push_rValueOverload_handlesMoveOnlyType)
+{
+    constexpr auto value = 42;
+    auto uut = nc::spsc_queue<std::unique_ptr<int>, 2>{};
+    EXPECT_TRUE(uut.push(std::make_unique<int>(value)));
+
+    auto actual = std::unique_ptr<int>{};
+    EXPECT_TRUE(uut.pop(actual));
+    EXPECT_EQ(*actual, value);
+}
+
+TEST(SpscQueueTest, push_indexWrapping)
+{
+    constexpr auto n = 2;
+    auto uut = nc::spsc_queue<int, n>{};
+
+    for (int round = 0; round < 5; ++round)
+    {
+        for (int i = 0; i < n; ++i)
+            EXPECT_TRUE(uut.push(i + round * 10));
+
+        EXPECT_FALSE(uut.push(999));
+
+        for (int i = 0; i < n; ++i)
+        {
+            int out = -1;
+            EXPECT_TRUE(uut.pop(out));
+            EXPECT_EQ(out, i + round * 10);
+        }
+
+        EXPECT_TRUE(uut.empty());
+    }
+}
+
+TEST(SpscQueueTest, pop_returnsTrueUntilEmpty)
+{
+    constexpr auto n = 4;
+    auto uut = nc::spsc_queue<int, n>{};
+    for (auto i = 0; i < n; ++i)
+    {
+        EXPECT_TRUE(uut.push(i));
+    }
+
+    auto value = 0;
+    for (auto i = 0; i < n; ++i)
+    {
+        EXPECT_TRUE(uut.pop(value));
+        EXPECT_EQ(value, i);
+    }
+
+    EXPECT_FALSE(uut.pop(value));
+}
+
+TEST(SpscQueueTest, empty_returnsExpectedValue)
+{
+    constexpr auto n = 4;
+    auto uut = nc::spsc_queue<int, n>{};
+    EXPECT_TRUE(uut.empty());
+
+    int value = 42;
+    EXPECT_FALSE(uut.pop(value));
+    EXPECT_TRUE(uut.empty());
+
+    EXPECT_TRUE(uut.push(value));
+    EXPECT_FALSE(uut.empty());
+
+    EXPECT_TRUE(uut.pop(value));
+    EXPECT_TRUE(uut.empty());
+}
+
+TEST(SpscQueueTest, concurrencyStressTest)
+{
+    constexpr auto numValues = 2048;
+    constexpr auto size = 8ull;
+    auto uut = nc::spsc_queue<int, size>{};
+    auto values = std::vector<int>{};
+    auto start = std::atomic<bool>{false};
+    auto numProduced = 0;
+    auto numConsumed = 0;
+
+    auto producer = std::thread([&uut, &start, &numProduced] () {
+        while (!start.load(std::memory_order_acquire))
+        {
+            std::this_thread::yield();
+        }
+
+        while (numProduced < numValues)
+        {
+            if (uut.push(numProduced))
+            {
+                ++numProduced;
+            }
+        }
+    });
+
+    auto consumer = std::thread([&uut, &values, &start, &numConsumed]() {
+        while (!start.load(std::memory_order_acquire))
+        {
+            std::this_thread::yield();
+        }
+
+        auto value = -1;
+        while (numConsumed < numValues)
+        {
+            if (uut.pop(value))
+            {
+                values.push_back(value);
+                ++numConsumed;
+            }
+        }
+    });
+
+    start.store(true);
+    consumer.join();
+    producer.join();
+
+    EXPECT_EQ(numValues, numProduced);
+    EXPECT_EQ(numValues, numConsumed);
+    EXPECT_EQ(numValues, values.size());
+    EXPECT_TRUE(std::ranges::equal(values, std::views::iota(0, numValues)));
+}


### PR DESCRIPTION
resolves #374, resolves #375, resolves #376, resolves #378

- Changing audio buffers to use a more typical ring buffer + lock-free queue.
- Fixed bug where buffer size wasn't updated on device change.
- Adding a recovery attempt on `DeviceStream` failure. If recovery fails, we try to fallback to another valid device. If this fails, audio support is abandoned (and NcAudio trivially returns).
  - There are cases where a device can fail and not be immediately recoverable, but may become recoverable after a short delay. The engine defers to the game here by sending a 'Null' device via the `OnOutputDeviceChanged` signal. Client applications are free to attempt additional recovery attempts as/when they see fit.
    - These cases may be rare. not sure yet. Tweaking settings directly through my device's control application causes Windows to lose my device temporarily. Tweaking the same settings through Windows is well-behaved.