### PR TITLE
Added support for loading runtime texture data into TextureAssetManager

### DIFF
--- a/include/ncengine/asset/Assets.h
+++ b/include/ncengine/asset/Assets.h
@@ -1,10 +1,18 @@
+/**
+ * @file Assets.h
+ * @copyright Jaremie Romer and McCallister Romer 2025
+ */
+
 #pragma once
 
 #include "ncasset/AssetType.h"
 #include "ncengine/asset/AssetViews.h"
 
+#include <span>
+
 namespace nc::asset
 {
+struct Texture;
 /** Assets must be loaded before dependent objects are created and should be unloaded only
  *  when they are no longer in use.
  * 
@@ -55,11 +63,17 @@ void UnloadAllMeshAssets();
 auto AcquireMeshAsset(const std::string& path) -> MeshView;
 auto AcquireMeshAsset(AssetId id) -> MeshView;
 
-/** Supported file types: .nca 
+/** Supported file types: .nca
  *  @note Unloading textures invalidates all TextureViews. It is intended
  *  to be done on scene change. */
 bool LoadTextureAsset(const std::string& path);
 bool LoadTextureAssets(std::span<const std::string> paths);
+bool LoadTextureFromMemory(const std::string& key, Texture texture);
+bool LoadTextureFromRGBA(const std::string& key,
+                         std::span<const uint8_t> rgbaData,
+                         uint32_t width,
+                         uint32_t height,
+                         TextureFormat format = TextureFormat::RGBA8_UNORM);
 bool UnloadTextureAsset(const std::string& path);
 void UnloadAllTextureAssets();
 auto AcquireTextureAsset(const std::string& path) -> TextureView;

--- a/include/ncengine/asset/Assets.h
+++ b/include/ncengine/asset/Assets.h
@@ -63,7 +63,7 @@ void UnloadAllMeshAssets();
 auto AcquireMeshAsset(const std::string& path) -> MeshView;
 auto AcquireMeshAsset(AssetId id) -> MeshView;
 
-/** Supported file types: .nca
+/** Supported file types: .nca, raw texture data
  *  @note Unloading textures invalidates all TextureViews. It is intended
  *  to be done on scene change. */
 bool LoadTextureAsset(const std::string& path);

--- a/include/ncengine/asset/NcAsset.h
+++ b/include/ncengine/asset/NcAsset.h
@@ -61,8 +61,10 @@ class NcAsset : public Module
         /** @brief Load assets from an AssetMap. */
         virtual void LoadAssets(const AssetMap& assets) = 0;
 
-        /** @brief Get the names of all loaded assets as an AssetMap. */
-        virtual auto GetLoadedAssets() const noexcept -> AssetMap = 0;
+        /** @brief Get the names of all loaded assets as an AssetMap.
+         * @param serializableOnly If true, excludes runtime assets that are not from disk and cannot survive serialization.
+        */
+        virtual auto GetLoadedAssets(bool serializableOnly = false) const noexcept -> AssetMap = 0;
 
         /** @brief Get the path to a loaded asset given its id. */
         virtual auto GetAssetPath(AssetType type, size_t id) const -> std::string_view = 0;

--- a/sample/source/scenes/SmokeTest.cpp
+++ b/sample/source/scenes/SmokeTest.cpp
@@ -80,7 +80,7 @@ void SmokeTest::Load(ecs::Ecs world, ModuleProvider modules)
             {
                 isSecondPass = true;
                 auto ncAsset = modules.Get<asset::NcAsset>();
-                ::SaveScene(world, ncAsset->GetLoadedAssets());
+                ::SaveScene(world, ncAsset->GetLoadedAssets(true));
                 auto ncScene = modules.Get<NcScene>();
                 ncScene->Queue(std::make_unique<SmokeTest>(quit));
                 ncScene->ScheduleTransition();

--- a/source/ncengine/asset/AssetService.h
+++ b/source/ncengine/asset/AssetService.h
@@ -15,9 +15,9 @@ class IAssetServiceBase
     public:
         virtual ~IAssetServiceBase() = default;
 
-        virtual auto GetAllLoaded()        const -> std::vector<std::string_view> = 0;
-        virtual auto GetPath(AssetId hash) const -> std::string_view              = 0;
-        virtual auto GetAssetType()        const -> asset::AssetType              = 0;
+        virtual auto GetAllLoaded(bool serializableOnly = false) const -> std::vector<std::string_view> = 0;
+        virtual auto GetPath(AssetId hash)                       const -> std::string_view              = 0;
+        virtual auto GetAssetType()                              const -> asset::AssetType              = 0;
 };
 
 /** Interface for services that manage assets. */

--- a/source/ncengine/asset/Assets.cpp
+++ b/source/ncengine/asset/Assets.cpp
@@ -1,5 +1,8 @@
 #include "asset/Assets.h"
 #include "AssetService.h"
+#include "RuntimeTextureLoader.h"
+
+#include "ncasset/Assets.h"
 
 namespace nc::asset
 {
@@ -191,6 +194,20 @@ bool LoadTextureAsset(const std::string& path)
 bool LoadTextureAssets(std::span<const std::string> paths)
 {
     return AssetService<TextureView>::Get()->Load(paths);
+}
+
+bool LoadTextureFromMemory(const std::string& key, Texture texture)
+{
+    return RuntimeTextureLoaderService::Get()->LoadFromMemory(key, std::move(texture));
+}
+
+bool LoadTextureFromRGBA(const std::string& key,
+                         std::span<const uint8_t> rgbaData,
+                         uint32_t width,
+                         uint32_t height,
+                         TextureFormat format)
+{
+    return RuntimeTextureLoaderService::Get()->LoadFromRGBA(key, rgbaData, width, height, format);
 }
 
 bool UnloadTextureAsset(const std::string& path)

--- a/source/ncengine/asset/NcAssetImpl.cpp
+++ b/source/ncengine/asset/NcAssetImpl.cpp
@@ -102,7 +102,7 @@ void NcAssetImpl::LoadAssets(const AssetMap& assets)
         m_textureManager->Load(assets.at(asset::AssetType::Texture));
 }
 
-auto NcAssetImpl::GetLoadedAssets() const noexcept -> AssetMap
+auto NcAssetImpl::GetLoadedAssets(bool serializableOnly) const noexcept -> AssetMap
 {
     const auto managers = std::array<IAssetServiceBase*, 7>
     {
@@ -116,9 +116,9 @@ auto NcAssetImpl::GetLoadedAssets() const noexcept -> AssetMap
     };
 
     auto out = AssetMap{};
-    std::ranges::for_each(managers, [&out](auto manager) mutable
+    std::ranges::for_each(managers, [&out, serializableOnly](auto manager) mutable
     {
-        auto assets = manager->GetAllLoaded()
+        auto assets = manager->GetAllLoaded(serializableOnly)
             | std::views::transform([](auto&& name){ return std::string{name}; });
 
         out.emplace(manager->GetAssetType(), std::vector<std::string>{assets.begin(), assets.end()});

--- a/source/ncengine/asset/NcAssetImpl.h
+++ b/source/ncengine/asset/NcAssetImpl.h
@@ -43,7 +43,7 @@ class NcAssetImpl : public NcAsset
         auto OnMeshColliderUpdate() noexcept -> Signal<const MeshColliderUpdateEventData&>& override;
         auto OnFontUpdate() noexcept -> Signal<>& override;
         void LoadAssets(const AssetMap& assets) override;
-        auto GetLoadedAssets() const noexcept -> AssetMap override;
+        auto GetLoadedAssets(bool serializableOnly = false) const noexcept -> AssetMap override;
         auto GetAssetPath(AssetType type, size_t id) const -> std::string_view override;
 
     private:

--- a/source/ncengine/asset/RuntimeTextureLoader.h
+++ b/source/ncengine/asset/RuntimeTextureLoader.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "service/ServiceLocator.h"
+
+#include "ncasset/AssetType.h"
+
+#include <span>
+#include <string>
+
+namespace nc::asset
+{
+struct Texture;
+
+class IRuntimeTextureLoader
+{
+    public:
+        IRuntimeTextureLoader()
+        {
+            ServiceLocator<IRuntimeTextureLoader>::Register(this);
+        }
+
+        virtual ~IRuntimeTextureLoader() = default;
+
+        virtual auto LoadFromMemory(const std::string& key, Texture texture) -> bool = 0;
+        virtual auto LoadFromRGBA(const std::string& key,
+                                  std::span<const uint8_t> rgbaData,
+                                  uint32_t width,
+                                  uint32_t height,
+                                  TextureFormat format = TextureFormat::RGBA8_UNORM) -> bool = 0;
+};
+
+using RuntimeTextureLoaderService = ServiceLocator<IRuntimeTextureLoader>;
+} // namespace nc::asset

--- a/source/ncengine/asset/manager/AudioClipAssetManager.cpp
+++ b/source/ncengine/asset/manager/AudioClipAssetManager.cpp
@@ -72,8 +72,9 @@ auto AudioClipAssetManager::Acquire(AssetId id) const -> AudioClipView
     };
 }
 
-auto AudioClipAssetManager::GetAllLoaded() const -> std::vector<std::string_view>
+auto AudioClipAssetManager::GetAllLoaded(bool serializableOnly) const -> std::vector<std::string_view>
 {
+    (void)serializableOnly;
     return GetPaths(m_audioClips.keys());
 }
 } //namespace nc::asset

--- a/source/ncengine/asset/manager/AudioClipAssetManager.h
+++ b/source/ncengine/asset/manager/AudioClipAssetManager.h
@@ -15,16 +15,16 @@ class AudioClipAssetManager : public IAssetService<AudioClipView, std::string>
     public:
         explicit AudioClipAssetManager(const std::string& assetDirectory);
 
-        auto Load(const std::string& path)            -> bool                          override;
-        auto Load(std::span<const std::string> paths) -> bool                          override;
-        auto Unload(const std::string& path)          -> bool                          override;
-        void UnloadAll()                                                               override;
-        auto Acquire(const std::string& path)   const -> AudioClipView                 override;
-        auto Acquire(AssetId id)                const -> AudioClipView                 override;
-        auto GetAllLoaded()                     const -> std::vector<std::string_view> override;
-        auto IsLoaded(const std::string& path)  const -> bool                          override { return m_audioClips.contains(path); }
-        auto GetPath(AssetId id)                const -> std::string_view              override { return m_audioClips.key_at(id); }
-        auto GetAssetType()                     const -> AssetType                     override { return AssetType::AudioClip; }
+        auto Load(const std::string& path)                     -> bool                          override;
+        auto Load(std::span<const std::string> paths)          -> bool                          override;
+        auto Unload(const std::string& path)                   -> bool                          override;
+        void UnloadAll()                                                                        override;
+        auto Acquire(const std::string& path)            const -> AudioClipView                 override;
+        auto Acquire(AssetId id)                         const -> AudioClipView                 override;
+        auto GetAllLoaded(bool serializableOnly = false) const -> std::vector<std::string_view> override;
+        auto IsLoaded(const std::string& path)           const -> bool                          override { return m_audioClips.contains(path); }
+        auto GetPath(AssetId id)                         const -> std::string_view              override { return m_audioClips.key_at(id); }
+        auto GetAssetType()                              const -> AssetType                     override { return AssetType::AudioClip; }
 
     private:
         StringMap<AudioClip> m_audioClips;

--- a/source/ncengine/asset/manager/ConvexHullAssetManager.cpp
+++ b/source/ncengine/asset/manager/ConvexHullAssetManager.cpp
@@ -104,8 +104,9 @@ auto ConvexHullAssetManager::Acquire(AssetId id) const -> ConvexHullView
     return ConvexHullView{id};
 }
 
-auto ConvexHullAssetManager::GetAllLoaded() const -> std::vector<std::string_view>
+auto ConvexHullAssetManager::GetAllLoaded(bool serializableOnly) const -> std::vector<std::string_view>
 {
+    (void)serializableOnly;
     return GetPaths(m_map.keys());
 }
 } // namespace nc::asset

--- a/source/ncengine/asset/manager/ConvexHullAssetManager.h
+++ b/source/ncengine/asset/manager/ConvexHullAssetManager.h
@@ -17,17 +17,17 @@ class ConvexHullAssetManager : public IAssetService<ConvexHullView, std::string>
     public:
         explicit ConvexHullAssetManager(const std::string& assetDirectory);
 
-        auto Load(const std::string& path)            -> bool                          override;
-        auto Load(std::span<const std::string> paths) -> bool                          override;
-        auto Unload(const std::string& path)          -> bool                          override;
-        void UnloadAll()                                                               override;
-        auto Acquire(const std::string& path)   const -> ConvexHullView                override;
-        auto Acquire(AssetId id)                const -> ConvexHullView                override;
-        auto GetAllLoaded()                     const -> std::vector<std::string_view> override;
-        auto IsLoaded(const std::string& path)  const -> bool                          override { return m_map.contains(path); }
-        auto GetPath(AssetId id)                const -> std::string_view              override { return m_map.at(m_map.index(id)); }
-        auto GetAssetType()                     const -> asset::AssetType              override { return asset::AssetType::ConvexHull; }
-        auto OnUpdate()                               -> decltype(auto)                         { return (m_onUpdate); }
+        auto Load(const std::string& path)                     -> bool                          override;
+        auto Load(std::span<const std::string> paths)          -> bool                          override;
+        auto Unload(const std::string& path)                   -> bool                          override;
+        void UnloadAll()                                                                        override;
+        auto Acquire(const std::string& path)            const -> ConvexHullView                override;
+        auto Acquire(AssetId id)                         const -> ConvexHullView                override;
+        auto GetAllLoaded(bool serializableOnly = false) const -> std::vector<std::string_view> override;
+        auto IsLoaded(const std::string& path)           const -> bool                          override { return m_map.contains(path); }
+        auto GetPath(AssetId id)                         const -> std::string_view              override { return m_map.at(m_map.index(id)); }
+        auto GetAssetType()                              const -> asset::AssetType              override { return asset::AssetType::ConvexHull; }
+        auto OnUpdate()                                        -> decltype(auto)                         { return (m_onUpdate); }
 
     private:
         StringTable m_map;

--- a/source/ncengine/asset/manager/CubeMapAssetManager.cpp
+++ b/source/ncengine/asset/manager/CubeMapAssetManager.cpp
@@ -117,8 +117,9 @@ auto CubeMapAssetManager::Acquire(AssetId id) const -> CubeMapView
     };
 }
 
-auto CubeMapAssetManager::GetAllLoaded() const -> std::vector<std::string_view>
+auto CubeMapAssetManager::GetAllLoaded(bool serializableOnly) const -> std::vector<std::string_view>
 {
+    (void)serializableOnly;
     return GetPaths(m_cubeMapIds.keys());
 }
 } // namespace nc::asset

--- a/source/ncengine/asset/manager/CubeMapAssetManager.h
+++ b/source/ncengine/asset/manager/CubeMapAssetManager.h
@@ -16,17 +16,17 @@ class CubeMapAssetManager : public IAssetService<CubeMapView, std::string>
         explicit CubeMapAssetManager(const std::string& cubeMapAssetDirectory,
                                      uint32_t maxCubeMapsCount);
 
-        auto Load(const std::string& path)            -> bool                          override;
-        auto Load(std::span<const std::string> paths) -> bool                          override;
-        auto Unload(const std::string& path)          -> bool                          override;
-        void UnloadAll() override;
-        auto Acquire(const std::string& path)   const -> CubeMapView                   override;
-        auto Acquire(AssetId id)                const -> CubeMapView                   override;
-        auto GetAllLoaded()                     const -> std::vector<std::string_view> override;
-        auto IsLoaded(const std::string& path)  const -> bool                          override { return m_cubeMapIds.contains(path); }
-        auto GetPath(AssetId id)                const -> std::string_view              override { return m_cubeMapIds.at(m_cubeMapIds.index(id)); }
-        auto GetAssetType()                     const -> asset::AssetType              override { return asset::AssetType::CubeMap; }
-        auto OnUpdate()                               -> decltype(auto)                         { return (m_onUpdate); }
+        auto Load(const std::string& path)                     -> bool                          override;
+        auto Load(std::span<const std::string> paths)          -> bool                          override;
+        auto Unload(const std::string& path)                   -> bool                          override;
+        void UnloadAll() override; 
+        auto Acquire(const std::string& path)            const -> CubeMapView                   override;
+        auto Acquire(AssetId id)                         const -> CubeMapView                   override;
+        auto GetAllLoaded(bool serializableOnly = false) const -> std::vector<std::string_view> override;
+        auto IsLoaded(const std::string& path)           const -> bool                          override { return m_cubeMapIds.contains(path); }
+        auto GetPath(AssetId id)                         const -> std::string_view              override { return m_cubeMapIds.at(m_cubeMapIds.index(id)); }
+        auto GetAssetType()                              const -> asset::AssetType              override { return asset::AssetType::CubeMap; }
+        auto OnUpdate()                                        -> decltype(auto)                         { return (m_onUpdate); }
 
     private:
         StringTable m_cubeMapIds;

--- a/source/ncengine/asset/manager/FontAssetManager.cpp
+++ b/source/ncengine/asset/manager/FontAssetManager.cpp
@@ -121,8 +121,9 @@ auto FontAssetManager::IsLoaded(const FontInfo& font) const -> bool
     return m_fonts.contains(font);
 }
 
-auto FontAssetManager::GetAllLoaded() const -> std::vector<std::string_view>
+auto FontAssetManager::GetAllLoaded(bool serializableOnly) const -> std::vector<std::string_view>
 {
+    (void)serializableOnly;
     auto out = std::vector<std::string_view>{};
     out.reserve(m_fonts.size());
     std::ranges::transform(m_fonts, std::back_inserter(out), [](const auto& pair)

--- a/source/ncengine/asset/manager/FontAssetManager.h
+++ b/source/ncengine/asset/manager/FontAssetManager.h
@@ -35,17 +35,17 @@ class FontAssetManager : public IAssetService<FontView, FontInfo>
     public:
         explicit FontAssetManager(const std::string& assetDirectory);
 
-        auto Load(const FontInfo& font)              -> bool                          override;
-        auto Load(std::span<const FontInfo> fonts)   -> bool                          override;
-        auto Unload(const FontInfo& font)            -> bool                          override;
-        void UnloadAll()                                                              override;
-        auto Acquire(const FontInfo& font)     const -> FontView                      override;
-        auto Acquire(AssetId)                  const -> FontView                      override { throw NcError{"Not Implemented"};}
-        auto GetAllLoaded()                    const -> std::vector<std::string_view> override;
-        auto IsLoaded(const FontInfo& font)    const -> bool                          override;
-        auto GetPath(AssetId)                  const -> std::string_view              override { throw NcError{"Not Implemented"}; }
-        auto GetAssetType()                    const -> asset::AssetType              override { return asset::AssetType::Font; }
-        auto OnUpdate()                              -> decltype(auto)                         { return (m_onUpdate); }
+        auto Load(const FontInfo& font)                        -> bool                          override;
+        auto Load(std::span<const FontInfo> fonts)             -> bool                          override;
+        auto Unload(const FontInfo& font)                      -> bool                          override;
+        void UnloadAll()                                                                        override;
+        auto Acquire(const FontInfo& font)               const -> FontView                      override;
+        auto Acquire(AssetId)                            const -> FontView                      override { throw NcError{"Not Implemented"};}
+        auto GetAllLoaded(bool serializableOnly = false) const -> std::vector<std::string_view> override;
+        auto IsLoaded(const FontInfo& font)              const -> bool                          override;
+        auto GetPath(AssetId)                            const -> std::string_view              override { throw NcError{"Not Implemented"}; }
+        auto GetAssetType()                              const -> asset::AssetType              override { return asset::AssetType::Font; }
+        auto OnUpdate()                                        -> decltype(auto)                         { return (m_onUpdate); }
 
     private:
         std::unordered_map<FontInfo, FontView, FontHash, FontEqual> m_fonts;

--- a/source/ncengine/asset/manager/MeshAssetManager.cpp
+++ b/source/ncengine/asset/manager/MeshAssetManager.cpp
@@ -174,8 +174,9 @@ auto MeshAssetManager::Acquire(AssetId id) const -> MeshView
     return m_accessors.at(index);
 }
 
-auto MeshAssetManager::GetAllLoaded() const -> std::vector<std::string_view>
+auto MeshAssetManager::GetAllLoaded(bool serializableOnly) const -> std::vector<std::string_view>
 {
+    (void)serializableOnly;
     return GetPaths(m_accessors.keys());
 }
 } // namespace nc::asset

--- a/source/ncengine/asset/manager/MeshAssetManager.h
+++ b/source/ncengine/asset/manager/MeshAssetManager.h
@@ -16,18 +16,18 @@ class MeshAssetManager : public IAssetService<MeshView, std::string>
     public:
         explicit MeshAssetManager(const std::string& assetDirectory);
 
-        auto Load(const std::string& path)            -> bool                          override;
-        auto Load(std::span<const std::string> paths) -> bool                          override;
-        auto Unload(const std::string& path)          -> bool                          override;
-        void UnloadAll() override;
-        auto Acquire(const std::string& path)   const -> MeshView                      override;
-        auto Acquire(AssetId id)                const -> MeshView                      override;
-        auto GetAllLoaded()                     const -> std::vector<std::string_view> override;
-        auto IsLoaded(const std::string& path)  const -> bool                          override { return m_accessors.contains(path); }
-        auto GetPath(AssetId id)                const -> std::string_view              override { return m_accessors.key_at(id); }
-        auto GetAssetType()                     const -> asset::AssetType              override { return asset::AssetType::Mesh; }
-        auto OnBoneUpdate()                           -> decltype(auto)                         { return (m_onBoneUpdate); }
-        auto OnMeshUpdate()                           -> decltype(auto)                         { return (m_onMeshUpdate); }
+        auto Load(const std::string& path)                     -> bool                          override;
+        auto Load(std::span<const std::string> paths)          -> bool                          override;
+        auto Unload(const std::string& path)                   -> bool                          override;
+        void UnloadAll()                                                                        override; 
+        auto Acquire(const std::string& path)            const -> MeshView                      override;
+        auto Acquire(AssetId id)                         const -> MeshView                      override;
+        auto GetAllLoaded(bool serializableOnly = false) const -> std::vector<std::string_view> override;
+        auto IsLoaded(const std::string& path)           const -> bool                          override { return m_accessors.contains(path); }
+        auto GetPath(AssetId id)                         const -> std::string_view              override { return m_accessors.key_at(id); }
+        auto GetAssetType()                              const -> asset::AssetType              override { return asset::AssetType::Mesh; }
+        auto OnBoneUpdate()                                    -> decltype(auto)                         { return (m_onBoneUpdate); }
+        auto OnMeshUpdate()                                    -> decltype(auto)                         { return (m_onMeshUpdate); }
 
     private:
         std::vector<asset::MeshVertex> m_vertexData;

--- a/source/ncengine/asset/manager/MeshColliderAssetManager.cpp
+++ b/source/ncengine/asset/manager/MeshColliderAssetManager.cpp
@@ -104,8 +104,9 @@ auto MeshColliderAssetManager::Acquire(AssetId id) const -> MeshColliderView
     return MeshColliderView{id};
 }
 
-auto MeshColliderAssetManager::GetAllLoaded() const -> std::vector<std::string_view>
+auto MeshColliderAssetManager::GetAllLoaded(bool serializableOnly) const -> std::vector<std::string_view>
 {
+    (void)serializableOnly;
     return GetPaths(m_map.keys());
 }
 } // namespace nc::asset

--- a/source/ncengine/asset/manager/MeshColliderAssetManager.h
+++ b/source/ncengine/asset/manager/MeshColliderAssetManager.h
@@ -17,17 +17,17 @@ class MeshColliderAssetManager : public IAssetService<MeshColliderView, std::str
     public:
         explicit MeshColliderAssetManager(const std::string& meshColliderAssetDirectory);
 
-        auto Load(const std::string& path)            -> bool                          override;
-        auto Load(std::span<const std::string> paths) -> bool                          override;
-        auto Unload(const std::string& path)          -> bool                          override;
-        void UnloadAll()                                                               override;
-        auto Acquire(const std::string& path)   const -> MeshColliderView              override;
-        auto Acquire(AssetId id)                const -> MeshColliderView              override;
-        auto GetAllLoaded()                     const -> std::vector<std::string_view> override;
-        auto IsLoaded(const std::string& path)  const -> bool                          override { return m_map.contains(path); }
-        auto GetPath(AssetId id)                const -> std::string_view              override { return m_map.at(m_map.index(id)); }
-        auto GetAssetType()                     const -> AssetType                     override { return AssetType::MeshCollider; }
-        auto OnUpdate()                               -> decltype(auto)                         { return (m_onUpdate); }
+        auto Load(const std::string& path)                     -> bool                          override;
+        auto Load(std::span<const std::string> paths)          -> bool                          override;
+        auto Unload(const std::string& path)                   -> bool                          override;
+        void UnloadAll()                                                                        override;
+        auto Acquire(const std::string& path)            const -> MeshColliderView              override;
+        auto Acquire(AssetId id)                         const -> MeshColliderView              override;
+        auto GetAllLoaded(bool serializableOnly = false) const -> std::vector<std::string_view> override;
+        auto IsLoaded(const std::string& path)           const -> bool                          override { return m_map.contains(path); }
+        auto GetPath(AssetId id)                         const -> std::string_view              override { return m_map.at(m_map.index(id)); }
+        auto GetAssetType()                              const -> AssetType                     override { return AssetType::MeshCollider; }
+        auto OnUpdate()                                        -> decltype(auto)                         { return (m_onUpdate); }
 
     private:
         StringTable m_map;

--- a/source/ncengine/asset/manager/ShaderAssetManager.cpp
+++ b/source/ncengine/asset/manager/ShaderAssetManager.cpp
@@ -229,8 +229,9 @@ auto ShaderAssetManager::IsLoaded(const std::string& path) const -> bool
     return std::ranges::any_of(m_shaderFlyweights.begin(), m_shaderFlyweights.end(), [path](const auto& view) { return view.uid == path; });
 }
 
-auto ShaderAssetManager::GetAllLoaded() const -> std::vector<std::string_view>
+auto ShaderAssetManager::GetAllLoaded(bool serializableOnly) const -> std::vector<std::string_view>
 {
+    (void)serializableOnly;
     return GetPaths(m_shaderFlyweights, [](const auto& item)
     {
         return std::string_view{item.uid};

--- a/source/ncengine/asset/manager/ShaderAssetManager.h
+++ b/source/ncengine/asset/manager/ShaderAssetManager.h
@@ -20,16 +20,16 @@ class ShaderAssetManager final : public IAssetService<ShaderView, std::string>
     public:
         explicit ShaderAssetManager(const std::string& assetDirectory);
 
-        auto Load(const std::string& path)                 -> bool                          override;
-        auto Load(std::span<const std::string> paths)      -> bool                          override;
-        auto Unload(const std::string& path)               -> bool                          override;
-        void UnloadAll()                                                                    override;
-        auto Acquire(const std::string& path)        const -> ShaderView                    override;
-        auto Acquire(AssetId)                        const -> ShaderView                    override { throw NcError{"Not Implemented"}; }
-        auto IsLoaded(const std::string& path)       const -> bool                          override;
-        auto GetAllLoaded()                          const -> std::vector<std::string_view> override;
-        auto GetPath(AssetId)                        const -> std::string_view              override { throw NcError{"Not Implemented"}; }
-        auto GetAssetType()                          const -> asset::AssetType              override { return asset::AssetType::Shader; }
+        auto Load(const std::string& path)                         -> bool                          override;
+        auto Load(std::span<const std::string> paths)              -> bool                          override;
+        auto Unload(const std::string& path)                       -> bool                          override;
+        void UnloadAll()                                                                            override;
+        auto Acquire(const std::string& path)                const -> ShaderView                    override;
+        auto Acquire(AssetId)                                const -> ShaderView                    override { throw NcError{"Not Implemented"}; }
+        auto IsLoaded(const std::string& path)               const -> bool                          override;
+        auto GetAllLoaded(bool serializableOnly = false)     const -> std::vector<std::string_view> override;
+        auto GetPath(AssetId)                                const -> std::string_view              override { throw NcError{"Not Implemented"}; }
+        auto GetAssetType()                                  const -> asset::AssetType              override { return asset::AssetType::Shader; }
 
     private:
         std::vector<ShaderFlyweight> m_shaderFlyweights;

--- a/source/ncengine/asset/manager/SkeletalAnimationAssetManager.cpp
+++ b/source/ncengine/asset/manager/SkeletalAnimationAssetManager.cpp
@@ -113,8 +113,9 @@ auto SkeletalAnimationAssetManager::Acquire(AssetId id) const -> SkeletalAnimati
     };
 }
 
-auto SkeletalAnimationAssetManager::GetAllLoaded() const -> std::vector<std::string_view>
+auto SkeletalAnimationAssetManager::GetAllLoaded(bool serializableOnly) const -> std::vector<std::string_view>
 {
+    (void)serializableOnly;
     return GetPaths(m_table.keys());
 }
 } // namespace nc::asset

--- a/source/ncengine/asset/manager/SkeletalAnimationAssetManager.h
+++ b/source/ncengine/asset/manager/SkeletalAnimationAssetManager.h
@@ -16,17 +16,17 @@ class SkeletalAnimationAssetManager : public IAssetService<SkeletalAnimationView
         explicit SkeletalAnimationAssetManager(const std::string& skeletalAnimationAssetDirectory,
                                                uint32_t maxSkeletalAnimations);
 
-        auto Load(const std::string& path)               -> bool                          override;
-        auto Load(std::span<const std::string> paths)    -> bool                          override;
-        auto Unload(const std::string& path)             -> bool                          override;
-        void UnloadAll() override;
-        auto Acquire(const std::string& path)      const -> SkeletalAnimationView         override;
-        auto Acquire(AssetId id)                   const -> SkeletalAnimationView         override;
-        auto GetAllLoaded()                        const -> std::vector<std::string_view> override;
-        auto IsLoaded(const std::string& path)     const -> bool                          override { return m_table.contains(path); }
-        auto GetPath(AssetId id)                   const -> std::string_view              override { return m_table.at(m_table.index(id)); }
-        auto GetAssetType()                        const -> asset::AssetType              override { return asset::AssetType::SkeletalAnimation; }
-        auto OnUpdate()                                  -> decltype(auto)                         { return (m_onUpdate); }
+        auto Load(const std::string& path)                       -> bool                          override;
+        auto Load(std::span<const std::string> paths)            -> bool                          override;
+        auto Unload(const std::string& path)                     -> bool                          override;
+        void UnloadAll()                                                                          override;
+        auto Acquire(const std::string& path)              const -> SkeletalAnimationView         override;
+        auto Acquire(AssetId id)                           const -> SkeletalAnimationView         override;
+        auto GetAllLoaded(bool serializableOnly = false)   const -> std::vector<std::string_view> override;
+        auto IsLoaded(const std::string& path)             const -> bool                          override { return m_table.contains(path); }
+        auto GetPath(AssetId id)                           const -> std::string_view              override { return m_table.at(m_table.index(id)); }
+        auto GetAssetType()                                const -> asset::AssetType              override { return asset::AssetType::SkeletalAnimation; }
+        auto OnUpdate()                                          -> decltype(auto)                         { return (m_onUpdate); }
 
     private:
         StringTable m_table;

--- a/source/ncengine/asset/manager/TextureAssetManager.cpp
+++ b/source/ncengine/asset/manager/TextureAssetManager.cpp
@@ -5,8 +5,25 @@
 
 #include "ncasset/Import.h"
 
+#include <algorithm>
+#include <cstring>
 #include <ranges>
+#include <string>
 
+namespace
+{
+template<class T, class Proj>
+auto GetSerializableAssetPaths(const std::vector<T>& vec, Proj&& proj) -> std::vector<std::string_view>
+{
+    auto out = std::vector<std::string_view>{};
+    out.reserve(vec.size());
+
+    auto view = vec | std::ranges::views::filter([](const auto& item) { return !item.contains(nc::asset::RuntimeKey); })
+                    | std::ranges::views::transform(std::forward<Proj>(proj));
+
+    return std::vector<std::string_view>(view.begin(), view.end());
+}
+}
 namespace nc::asset
 {
 TextureAssetManager::TextureAssetManager(const std::string& texturesAssetDirectory, uint32_t maxTextures)
@@ -74,6 +91,7 @@ auto TextureAssetManager::Load(std::span<const std::string> paths) -> bool
 
 auto TextureAssetManager::LoadFromMemory(const std::string& key, Texture texture) -> bool
 {
+    auto runtimeTextureKey = RuntimeKey + key;
     if (m_table.size() + 1 >= m_maxTextureCount)
     {
         throw NcError("Cannot exceed max texture count.");
@@ -84,8 +102,8 @@ auto TextureAssetManager::LoadFromMemory(const std::string& key, Texture texture
         return false;
     }
 
-    auto textureWithId = TextureWithId{std::move(texture), m_table.hash(key)};
-    m_table.emplace(key);
+    auto textureWithId = TextureWithId{std::move(texture), m_table.hash(runtimeTextureKey)};
+    m_table.emplace(runtimeTextureKey);
     m_onUpdate.Emit(TextureUpdateEventData{
         UpdateAction::Load,
         std::span<const TextureWithId>{&textureWithId, 1}
@@ -111,7 +129,9 @@ auto TextureAssetManager::LoadFromRGBA(const std::string& key,
 
 auto TextureAssetManager::Unload(const std::string& path) -> bool
 {
-    if (!m_table.erase(path))
+    auto runtimeTextureKey = RuntimeKey + path;
+
+    if (!m_table.erase(path) && !m_table.erase(runtimeTextureKey))
         return false;
 
     m_onUpdate.Emit(TextureUpdateEventData{
@@ -133,7 +153,15 @@ void TextureAssetManager::UnloadAll()
 
 auto TextureAssetManager::Acquire(const std::string& path) const -> TextureView
 {
-    NC_ASSERT(m_table.contains(path), fmt::format("Texture is not loaded: '{}'", path));
+    auto runtimeTextureKey = RuntimeKey + path;
+    if (!m_table.contains(path))
+    {
+        if (!m_table.contains(runtimeTextureKey))
+        {
+            throw nc::NcError("Texture is not loaded: '{}'", path);
+        }
+        return Acquire(m_table.hash(runtimeTextureKey));
+    }
     return Acquire(m_table.hash(path));
 }
 
@@ -147,11 +175,29 @@ auto TextureAssetManager::Acquire(AssetId id) const -> TextureView
     };
 }
 
-auto TextureAssetManager::GetAllLoaded() const -> std::vector<std::string_view>
+auto TextureAssetManager::GetAllLoaded(bool serializableOnly) const -> std::vector<std::string_view>
 {
+    if (serializableOnly)
+    {
+        return GetSerializableAssetPaths(m_table.keys(), [](const auto& data)
+        {
+            return std::string_view{data};
+        });
+    }
+
     return GetPaths(m_table.keys(), [](const auto& data)
     {
         return std::string_view{data};
     });
+}
+
+auto TextureAssetManager::GetPath(AssetId id) const -> std::string_view
+{
+    auto path = m_table.at(m_table.index(id));
+    if (path.starts_with(RuntimeKey))
+    {
+        path.remove_prefix(RuntimeKeyLength);
+    }
+    return path;
 }
 } // namespace nc::asset

--- a/source/ncengine/asset/manager/TextureAssetManager.cpp
+++ b/source/ncengine/asset/manager/TextureAssetManager.cpp
@@ -72,6 +72,43 @@ auto TextureAssetManager::Load(std::span<const std::string> paths) -> bool
     return true;
 }
 
+auto TextureAssetManager::LoadFromMemory(const std::string& key, Texture texture) -> bool
+{
+    if (m_table.size() + 1 >= m_maxTextureCount)
+    {
+        throw NcError("Cannot exceed max texture count.");
+    }
+
+    if (IsLoaded(key))
+    {
+        return false;
+    }
+
+    auto textureWithId = TextureWithId{std::move(texture), m_table.hash(key)};
+    m_table.emplace(key);
+    m_onUpdate.Emit(TextureUpdateEventData{
+        UpdateAction::Load,
+        std::span<const TextureWithId>{&textureWithId, 1}
+    });
+
+    return true;
+}
+
+auto TextureAssetManager::LoadFromRGBA(const std::string& key,
+                                       std::span<const uint8_t> rgbaData,
+                                       uint32_t width,
+                                       uint32_t height,
+                                       TextureFormat format) -> bool
+{
+    auto texture = Texture{
+        .format = format,
+        .width = width,
+        .height = height,
+        .pixelData = std::vector<unsigned char>(rgbaData.begin(), rgbaData.end())
+    };
+    return LoadFromMemory(key, std::move(texture));
+}
+
 auto TextureAssetManager::Unload(const std::string& path) -> bool
 {
     if (!m_table.erase(path))

--- a/source/ncengine/asset/manager/TextureAssetManager.h
+++ b/source/ncengine/asset/manager/TextureAssetManager.h
@@ -16,6 +16,9 @@ struct Texture;
 struct TextureWithId;
 struct TextureUpdateEventData;
 
+constexpr auto RuntimeKey = "RuntimeKey::";
+constexpr std::size_t RuntimeKeyLength = std::char_traits<char>::length(RuntimeKey);
+
 class TextureAssetManager : public IAssetService<TextureView, std::string>,
                             public IRuntimeTextureLoader
 {
@@ -23,23 +26,23 @@ class TextureAssetManager : public IAssetService<TextureView, std::string>,
         explicit TextureAssetManager(const std::string& texturesAssetDirectory,
                                      uint32_t maxTextures);
 
-        auto Load(const std::string& path)                           -> bool               override;
-        auto Load(std::span<const std::string> paths)                -> bool               override;
-        auto LoadFromMemory(const std::string& key, Texture texture) -> bool               override;
+        auto Load(const std::string& path)                                   -> bool                          override;
+        auto Load(std::span<const std::string> paths)                        -> bool                          override;
+        auto LoadFromMemory(const std::string& key, Texture texture)         -> bool                          override;
         auto LoadFromRGBA(const std::string& key,
                           std::span<const uint8_t> rgbaData,
                           uint32_t width,
                           uint32_t height,
-                          TextureFormat format = TextureFormat::RGBA8_UNORM) -> bool       override;
-        auto Unload(const std::string& path)              -> bool                          override;
-        void UnloadAll()                                                                   override;
-        auto Acquire(const std::string& path)       const -> TextureView                   override;
-        auto Acquire(AssetId id)                    const -> TextureView                   override;
-        auto GetAllLoaded()                         const -> std::vector<std::string_view> override;
-        auto IsLoaded(const std::string& path)      const -> bool                          override { return m_table.contains(path); }
-        auto GetPath(AssetId id)                    const -> std::string_view              override { return m_table.at(m_table.index(id)); }
-        auto GetAssetType()                         const -> AssetType                     override { return AssetType::Texture; }
-        auto OnUpdate()                                   -> decltype(auto)                         { return (m_onUpdate); }
+                          TextureFormat format = TextureFormat::RGBA8_UNORM) -> bool                          override;
+        auto Unload(const std::string& path)                                 -> bool                          override;
+        void UnloadAll()                                                                                      override;
+        auto Acquire(const std::string& path)                          const -> TextureView                   override;
+        auto Acquire(AssetId id)                                       const -> TextureView                   override;
+        auto GetAllLoaded(bool serializableOnly = false)               const -> std::vector<std::string_view> override;
+        auto IsLoaded(const std::string& path)                         const -> bool                          override { return m_table.contains(path) || m_table.contains(RuntimeKey + path); }
+        auto GetPath(AssetId id)                                       const -> std::string_view              override;
+        auto GetAssetType()                                            const -> AssetType                     override { return AssetType::Texture; }
+        auto OnUpdate()                                                      -> decltype(auto)                         { return (m_onUpdate); }
 
     private:
         StringTable m_table;

--- a/source/ncengine/asset/manager/TextureAssetManager.h
+++ b/source/ncengine/asset/manager/TextureAssetManager.h
@@ -1,24 +1,36 @@
 #pragma once
 
 #include "asset/AssetService.h"
+#include "asset/RuntimeTextureLoader.h"
 #include "utility/StringMap.h"
 #include "ncengine/utility/Signal.h"
 
+#include "ncasset/AssetType.h"
+
+#include <span>
 #include <string>
 
 namespace nc::asset
 {
+struct Texture;
 struct TextureWithId;
 struct TextureUpdateEventData;
 
-class TextureAssetManager : public IAssetService<TextureView, std::string>
+class TextureAssetManager : public IAssetService<TextureView, std::string>,
+                            public IRuntimeTextureLoader
 {
     public:
         explicit TextureAssetManager(const std::string& texturesAssetDirectory,
                                      uint32_t maxTextures);
 
-        auto Load(const std::string& path)                -> bool                          override;
-        auto Load(std::span<const std::string> paths)     -> bool                          override;
+        auto Load(const std::string& path)                           -> bool               override;
+        auto Load(std::span<const std::string> paths)                -> bool               override;
+        auto LoadFromMemory(const std::string& key, Texture texture) -> bool               override;
+        auto LoadFromRGBA(const std::string& key,
+                          std::span<const uint8_t> rgbaData,
+                          uint32_t width,
+                          uint32_t height,
+                          TextureFormat format = TextureFormat::RGBA8_UNORM) -> bool       override;
         auto Unload(const std::string& path)              -> bool                          override;
         void UnloadAll()                                                                   override;
         auto Acquire(const std::string& path)       const -> TextureView                   override;

--- a/source/ncengine/ui/editor/impl/EditorUI.cpp
+++ b/source/ncengine/ui/editor/impl/EditorUI.cpp
@@ -150,7 +150,7 @@ auto EditorUI::ProcessInput(const EditorHotkeys& hotkeys, asset::NcAsset& ncAsse
     if (KeyDown(hotkeys.openNewSceneDialog))
         m_newSceneDialog.Open();
     else if (KeyDown(hotkeys.openSaveSceneDialog))
-        m_saveSceneDialog.Open(ncAsset.GetLoadedAssets());
+        m_saveSceneDialog.Open(ncAsset.GetLoadedAssets(true));
     else if (KeyDown(hotkeys.openLoadSceneDialog))
         m_loadSceneDialog.Open();
 
@@ -188,7 +188,7 @@ void EditorUI::DrawMenu(EditorContext& ctx)
             if (ImGui::MenuItem("New"))
                 m_newSceneDialog.Open();
             if (ImGui::MenuItem("Save"))
-                m_saveSceneDialog.Open(ctx.modules.Get<asset::NcAsset>()->GetLoadedAssets());
+                m_saveSceneDialog.Open(ctx.modules.Get<asset::NcAsset>()->GetLoadedAssets(true));
             if (ImGui::MenuItem("Load"))
                 m_loadSceneDialog.Open();
 

--- a/source/ncengine/ui/editor/impl/EditorUI.cpp
+++ b/source/ncengine/ui/editor/impl/EditorUI.cpp
@@ -45,6 +45,19 @@ void ToolbarLayout()
     const auto pos = ImVec2{xPadding + screenExtent.x * g_pivotCenter.x, yPadding};
     ImGui::SetNextWindowPos(pos, ImGuiCond_FirstUseEver, g_pivotCenter);
 }
+
+// For runtime texture test
+void LoadBlackTexture()
+{
+    std::vector<uint8_t> blackPixels;
+    blackPixels.reserve(64);
+    for (int i = 0; i < 16; ++i)
+    {
+        blackPixels.insert(blackPixels.end(), {0, 0, 0, 255});
+    }
+
+    nc::asset::LoadTextureFromRGBA("editor::black", blackPixels, 4, 4);
+}
 } // anonymous namespace
 
 namespace nc::ui::editor
@@ -58,10 +71,19 @@ EditorUI::EditorUI(EditorContext& ctx)
       m_postProcessDialog{},
       m_environmentDialog{}
 {
+    LoadBlackTexture();
 }
 
 void EditorUI::Draw(EditorContext& ctx)
 {
+    if (!m_runtimeTextureLoaded)
+    {
+        auto& ncGraphics = *ctx.modules.Get<NcGraphics>();
+        auto blackTextureAsset = nc::asset::AcquireTextureAsset("editor::black");
+        m_runtimeTextureTest = static_cast<ImTextureRef>(ncGraphics.GetTextureView(nc::TextureViewType::Asset, blackTextureAsset.index));
+        m_runtimeTextureLoaded = true;
+    }
+
     ctx.dimensions = ImVec2{window::GetDimensions()};
     DrawOverlays(ctx.dimensions);
     auto& ncAsset = *ctx.modules.Get<asset::NcAsset>();
@@ -188,6 +210,7 @@ void EditorUI::DrawMenu(EditorContext& ctx)
             }
             if (ImGui::BeginMenu("NcGraphics"))
             {
+                ImGui::Image(m_runtimeTextureTest, ImVec2{5, 5});
                 if (ImGui::MenuItem("Post Process FX"))
                 {
                     m_postProcessDialog.Open(ctx.modules.Get<NcGraphics>(), ctx.modules.Get<asset::NcAsset>());

--- a/source/ncengine/ui/editor/impl/EditorUI.h
+++ b/source/ncengine/ui/editor/impl/EditorUI.h
@@ -31,6 +31,8 @@ class EditorUI
         SceneGraph m_sceneGraph;
         Inspector m_inspector;
         bool m_open = false;
+        ImTextureRef m_runtimeTextureTest;
+        bool m_runtimeTextureLoaded = false;
 
         // overlays
         FpsOverlay m_fpsOverlay;

--- a/test/ncengine/AssetServiceStub.h
+++ b/test/ncengine/AssetServiceStub.h
@@ -11,21 +11,21 @@
  * Example usage:
  *   DEFINE_ASSET_SERVICE_STUB(stubService, nc::asset::AssetType::AudioClip, nc::AudioClipView, std::string);
  */
-
-#define DEFINE_ASSET_SERVICE_STUB(className, assetType, viewType, inputType)                               \
-struct className : public nc::asset::IAssetService<viewType, inputType>                                    \
-{                                                                                                          \
-    viewType view;                                                                                         \
-    const char* path = "test_path";                                                                        \
-                                                                                                           \
-    bool Load(const inputType&)                                                  override { return true; } \
-    bool Load(std::span<const inputType>)                                        override { return true; } \
-    bool Unload(const inputType&)                                                override { return true; } \
-    void UnloadAll()                                                             override {}               \
-    bool IsLoaded(const inputType&)       const                                  override { return true; } \
-    auto GetPath(nc::asset::AssetId)      const -> std::string_view              override { return path; } \
-    auto GetAllLoaded()                   const -> std::vector<std::string_view> override { return {}; }   \
-    auto GetAssetType()                   const -> nc::asset::AssetType override { return assetType; }     \
-    auto Acquire(const inputType&)        const -> viewType override { return view; }                      \
-    auto Acquire(nc::asset::AssetId)      const -> viewType override { return view; }                      \
+   
+#define DEFINE_ASSET_SERVICE_STUB(className, assetType, viewType, inputType)                                    \
+struct className : public nc::asset::IAssetService<viewType, inputType>                                         \
+{                                                                                                               \
+    viewType view;                                                                                              \
+    const char* path = "test_path";                                                                             \
+                                                                                                                \
+    bool Load(const inputType&)                                                  override { return true; }      \
+    bool Load(std::span<const inputType>)                                        override { return true; }      \
+    bool Unload(const inputType&)                                                override { return true; }      \
+    void UnloadAll()                                                             override {}                    \
+    bool IsLoaded(const inputType&)       const                                  override { return true; }      \
+    auto GetPath(nc::asset::AssetId)      const -> std::string_view              override { return path; }      \
+    auto GetAllLoaded(bool)               const -> std::vector<std::string_view> override { return {}; }        \
+    auto GetAssetType()                   const -> nc::asset::AssetType          override { return assetType; } \
+    auto Acquire(const inputType&)        const -> viewType                      override { return view; }      \
+    auto Acquire(nc::asset::AssetId)      const -> viewType                      override { return view; }      \
 }; className className##Instance;

--- a/test/ncengine/asset/TextureAssetManager_tests.cpp
+++ b/test/ncengine/asset/TextureAssetManager_tests.cpp
@@ -2,8 +2,11 @@
 #include "asset/AssetData.h"
 #include "asset/manager/TextureAssetManager.h"
 
+#include "ncasset/Assets.h"
+
 #include <array>
 #include <string>
+#include <vector>
 
 using namespace nc::asset;
 
@@ -160,4 +163,116 @@ TEST_F(TextureAssetManager_tests, GetPath_NotLoaded_Throws)
     const auto view = assetManager->Acquire(expected);
     assetManager->UnloadAll();
     EXPECT_THROW(assetManager->GetPath(view.id), nc::NcError);
+}
+
+TEST_F(TextureAssetManager_tests, LoadFromMemory_NotLoaded_ReturnsTrue)
+{
+    auto texture = Texture{
+        .format = TextureFormat::RGBA8_UNORM,
+        .width = 2,
+        .height = 2,
+        .pixelData = std::vector<unsigned char>(16, 255)
+    };
+    auto actual = assetManager->LoadFromMemory("test_key", std::move(texture));
+    EXPECT_TRUE(actual);
+}
+
+TEST_F(TextureAssetManager_tests, LoadFromMemory_IsLoaded_ReturnsFalse)
+{
+    auto texture1 = Texture{
+        .format = TextureFormat::RGBA8_UNORM,
+        .width = 2,
+        .height = 2,
+        .pixelData = std::vector<unsigned char>(16, 255)
+    };
+    auto texture2 = Texture{
+        .format = TextureFormat::RGBA8_UNORM,
+        .width = 2,
+        .height = 2,
+        .pixelData = std::vector<unsigned char>(16, 128)
+    };
+    assetManager->LoadFromMemory("test_key", std::move(texture1));
+    auto actual = assetManager->LoadFromMemory("test_key", std::move(texture2));
+    EXPECT_FALSE(actual);
+}
+
+TEST_F(TextureAssetManager_tests, LoadFromMemory_CanAcquire)
+{
+    auto texture = Texture{
+        .format = TextureFormat::RGBA8_UNORM,
+        .width = 2,
+        .height = 2,
+        .pixelData = std::vector<unsigned char>(16, 255)
+    };
+    assetManager->LoadFromMemory("test_key", std::move(texture));
+    auto view = assetManager->Acquire("test_key");
+    EXPECT_NE(view.id, NullAssetId);
+    EXPECT_EQ(view.index, 0u);
+}
+
+TEST_F(TextureAssetManager_tests, LoadFromRGBA_NotLoaded_ReturnsTrue)
+{
+    std::vector<uint8_t> rgbaData(16, 255);
+    auto actual = assetManager->LoadFromRGBA("test_key", rgbaData, 2, 2);
+    EXPECT_TRUE(actual);
+}
+
+TEST_F(TextureAssetManager_tests, LoadFromRGBA_IsLoaded_ReturnsFalse)
+{
+    std::vector<uint8_t> rgbaData(16, 255);
+    assetManager->LoadFromRGBA("test_key", rgbaData, 2, 2);
+    auto actual = assetManager->LoadFromRGBA("test_key", rgbaData, 2, 2);
+    EXPECT_FALSE(actual);
+}
+
+TEST_F(TextureAssetManager_tests, LoadFromRGBA_CanAcquire)
+{
+    std::vector<uint8_t> rgbaData(16, 255);
+    assetManager->LoadFromRGBA("test_key", rgbaData, 2, 2);
+    auto view = assetManager->Acquire("test_key");
+    EXPECT_NE(view.id, NullAssetId);
+    EXPECT_EQ(view.index, 0u);
+}
+
+TEST_F(TextureAssetManager_tests, LoadFromRGBA_WithFormat_CanAcquire)
+{
+    std::vector<uint8_t> rgbaData(16, 255);
+    assetManager->LoadFromRGBA("test_key", rgbaData, 2, 2, TextureFormat::RGBA8_UNORM_SRGB);
+    auto view = assetManager->Acquire("test_key");
+    EXPECT_NE(view.id, NullAssetId);
+}
+
+TEST_F(TextureAssetManager_tests, LoadFromMemory_CanUnload)
+{
+    auto texture = Texture{
+        .format = TextureFormat::RGBA8_UNORM,
+        .width = 2,
+        .height = 2,
+        .pixelData = std::vector<unsigned char>(16, 255)
+    };
+    assetManager->LoadFromMemory("test_key", std::move(texture));
+    auto actual = assetManager->Unload("test_key");
+    EXPECT_TRUE(actual);
+    EXPECT_FALSE(assetManager->IsLoaded("test_key"));
+}
+
+TEST_F(TextureAssetManager_tests, LoadFromMemory_MixedWithFileLoad_CorrectIndices)
+{
+    assetManager->Load(Texture_base);
+    auto texture = Texture{
+        .format = TextureFormat::RGBA8_UNORM,
+        .width = 2,
+        .height = 2,
+        .pixelData = std::vector<unsigned char>(16, 255)
+    };
+    assetManager->LoadFromMemory("memory_texture", std::move(texture));
+    assetManager->Load(Texture_normal);
+
+    auto view1 = assetManager->Acquire(Texture_base);
+    auto view2 = assetManager->Acquire("memory_texture");
+    auto view3 = assetManager->Acquire(Texture_normal);
+
+    EXPECT_EQ(view1.index, 0u);
+    EXPECT_EQ(view2.index, 1u);
+    EXPECT_EQ(view3.index, 2u);
 }

--- a/test/ncengine/asset/TextureAssetManager_tests.cpp
+++ b/test/ncengine/asset/TextureAssetManager_tests.cpp
@@ -276,3 +276,107 @@ TEST_F(TextureAssetManager_tests, LoadFromMemory_MixedWithFileLoad_CorrectIndice
     EXPECT_EQ(view2.index, 1u);
     EXPECT_EQ(view3.index, 2u);
 }
+
+TEST_F(TextureAssetManager_tests, GetAllLoaded_Default_IncludesRuntimeTextures)
+{
+    assetManager->Load(Texture_base);
+    std::vector<uint8_t> rgbaData(16, 255);
+    assetManager->LoadFromRGBA("runtime_tex", rgbaData, 2, 2);
+
+    auto all = assetManager->GetAllLoaded();
+    EXPECT_EQ(all.size(), 2u);
+}
+
+TEST_F(TextureAssetManager_tests, GetAllLoaded_SerializableOnly_ExcludesRuntimeTextures)
+{
+    assetManager->Load(Texture_base);
+    std::vector<uint8_t> rgbaData(16, 255);
+    assetManager->LoadFromRGBA("runtime_tex", rgbaData, 2, 2);
+
+    auto serializable = assetManager->GetAllLoaded(true);
+    EXPECT_EQ(serializable.size(), 1u);
+    EXPECT_EQ(serializable[0], Texture_base);
+}
+
+TEST_F(TextureAssetManager_tests, GetAllLoaded_OnlyRuntimeTextures_SerializableReturnsEmpty)
+{
+    std::vector<uint8_t> rgbaData(16, 255);
+    assetManager->LoadFromRGBA("runtime1", rgbaData, 2, 2);
+    assetManager->LoadFromRGBA("runtime2", rgbaData, 2, 2);
+
+    auto serializable = assetManager->GetAllLoaded(true);
+    auto all = assetManager->GetAllLoaded(false);
+
+    EXPECT_EQ(serializable.size(), 0u);
+    EXPECT_EQ(all.size(), 2u);
+}
+
+TEST_F(TextureAssetManager_tests, IsLoaded_RuntimeTexture_ReturnsTrueWithOriginalKey)
+{
+    std::vector<uint8_t> rgbaData(16, 255);
+    assetManager->LoadFromRGBA("my_runtime_tex", rgbaData, 2, 2);
+
+    EXPECT_TRUE(assetManager->IsLoaded("my_runtime_tex"));
+}
+
+TEST_F(TextureAssetManager_tests, GetPath_RuntimeTexture_ReturnsUnprefixedKey)
+{
+    std::vector<uint8_t> rgbaData(16, 255);
+    assetManager->LoadFromRGBA("test_runtime", rgbaData, 2, 2);
+
+    auto view = assetManager->Acquire("test_runtime");
+    auto path = assetManager->GetPath(view.id);
+
+    EXPECT_FALSE(path.starts_with(RuntimeKey));
+    EXPECT_NE(path.find("test_runtime"), std::string_view::npos);
+}
+
+TEST_F(TextureAssetManager_tests, UnloadAll_ClearsRuntimeTextures)
+{
+    assetManager->Load(Texture_base);
+    std::vector<uint8_t> rgbaData(16, 255);
+    assetManager->LoadFromRGBA("runtime_tex", rgbaData, 2, 2);
+
+    assetManager->UnloadAll();
+
+    EXPECT_FALSE(assetManager->IsLoaded(Texture_base));
+    EXPECT_FALSE(assetManager->IsLoaded("runtime_tex"));
+}
+
+TEST_F(TextureAssetManager_tests, Unload_RuntimeTexture_DoesNotAffectFileTextures)
+{
+    assetManager->Load(Texture_base);
+    std::vector<uint8_t> rgbaData(16, 255);
+    assetManager->LoadFromRGBA("runtime_tex", rgbaData, 2, 2);
+
+    assetManager->Unload("runtime_tex");
+
+    EXPECT_TRUE(assetManager->IsLoaded(Texture_base));
+    EXPECT_FALSE(assetManager->IsLoaded("runtime_tex"));
+}
+
+TEST_F(TextureAssetManager_tests, Unload_FileTexture_DoesNotAffectRuntimeTextures)
+{
+    assetManager->Load(Texture_base);
+    std::vector<uint8_t> rgbaData(16, 255);
+    assetManager->LoadFromRGBA("runtime_tex", rgbaData, 2, 2);
+
+    assetManager->Unload(Texture_base);
+
+    EXPECT_FALSE(assetManager->IsLoaded(Texture_base));
+    EXPECT_TRUE(assetManager->IsLoaded("runtime_tex"));
+}
+
+TEST_F(TextureAssetManager_tests, LoadFromMemory_ExceedsMaxTextures_Throws)
+{
+    auto smallManager = std::make_unique<TextureAssetManager>(NC_TEST_COLLATERAL_DIRECTORY, 2);
+    smallManager->Load(Texture_base);
+
+    std::vector<uint8_t> rgbaData(16, 255);
+    EXPECT_THROW(smallManager->LoadFromRGBA("runtime_tex", rgbaData, 2, 2), nc::NcError);
+}
+
+TEST_F(TextureAssetManager_tests, Acquire_NotLoaded_Throws)
+{
+    EXPECT_THROW(assetManager->Acquire("nonexistent"), nc::NcError);
+}

--- a/test/ncengine/serialize/SceneSerialization_unit_tests.cpp
+++ b/test/ncengine/serialize/SceneSerialization_unit_tests.cpp
@@ -30,8 +30,9 @@ class NcAssetMock : public NcAsset
             m_assets.insert(std::cbegin(assets), std::cend(assets));
         }
 
-        auto GetLoadedAssets() const noexcept -> AssetMap override
+        auto GetLoadedAssets(bool serializableOnly) const noexcept -> AssetMap override
         {
+            (void)serializableOnly;
             return m_assets;
         }
 


### PR DESCRIPTION
SteamAPI integration in the game has revealed a need for loading runtime texture data into `TextureAssetManager`.
These new functions allow for passing in either raw texture data directly or creating a `Texture` from same and passing it into `TextureAssetManager`.