### PR TITLE
fix quats + tests

### DIFF
--- a/include/ncengine/ui/editor/EditorContext.h
+++ b/include/ncengine/ui/editor/EditorContext.h
@@ -48,6 +48,7 @@ struct EditorContext
 
     // Mutable state (for internal use)
     Entity selectedEntity = Entity::Null();
+    Vector3 eulerRotation = Vector3::Zero();
     OpenState openState = OpenState::Closed;
     ImVec2 dimensions = ImVec2{};
     bool rebuildStaticsOnTransformWrite = true;

--- a/include/ncmath/Quaternion.h
+++ b/include/ncmath/Quaternion.h
@@ -1,6 +1,6 @@
 /**
  * @file Quaternion.h
- * @copyright Jaremie Romer and McCallister Romer 2025
+ * @copyright Jaremie Romer and McCallister Romer 2026
  */
 #pragma once
 

--- a/source/ncengine/ui/editor/impl/ComponentWidgets.cpp
+++ b/source/ncengine/ui/editor/impl/ComponentWidgets.cpp
@@ -1005,7 +1005,6 @@ void TransformUIWidget(Transform& transform, EditorContext& ctx, const std::any&
     auto scl = ToVector3(decomposedMatrix.scale);
     const auto prevScl = scl;
     auto pos = ToVector3(decomposedMatrix.position);
-    const auto prevRot = ctx.eulerRotation;
     auto wasUpdated = false;
 
     if (ui::InputPosition(pos, "position"))

--- a/source/ncengine/ui/editor/impl/ComponentWidgets.cpp
+++ b/source/ncengine/ui/editor/impl/ComponentWidgets.cpp
@@ -1005,8 +1005,7 @@ void TransformUIWidget(Transform& transform, EditorContext& ctx, const std::any&
     auto scl = ToVector3(decomposedMatrix.scale);
     const auto prevScl = scl;
     auto pos = ToVector3(decomposedMatrix.position);
-    auto curRot = ToQuaternion(decomposedMatrix.rotation).ToEulerAngles();
-    const auto prevRot = curRot;
+    const auto prevRot = ctx.eulerRotation;
     auto wasUpdated = false;
 
     if (ui::InputPosition(pos, "position"))
@@ -1023,18 +1022,10 @@ void TransformUIWidget(Transform& transform, EditorContext& ctx, const std::any&
         }
     }
 
-    if (ui::InputAngles(curRot, "rotation"))
+    if (ui::InputAngles(ctx.eulerRotation, "rotation"))
     {
         wasUpdated = true;
-        const auto rotationNeeded = [&]()
-        {
-            if      (!FloatEqual(curRot.x, prevRot.x)) return DirectX::XMQuaternionRotationAxis(DirectX::g_XMIdentityR0, curRot.x - prevRot.x);
-            else if (!FloatEqual(curRot.y, prevRot.y)) return DirectX::XMQuaternionRotationAxis(DirectX::g_XMIdentityR1, curRot.y - prevRot.y);
-            else if (!FloatEqual(curRot.z, prevRot.z)) return DirectX::XMQuaternionRotationAxis(DirectX::g_XMIdentityR2, curRot.z - prevRot.z);
-            return DirectX::XMQuaternionIdentity();
-        }();
-
-        const auto newRotation = ToQuaternion(DirectX::XMQuaternionMultiply(decomposedMatrix.rotation, rotationNeeded));
+        const auto newRotation = Quaternion::FromEulerAngles(ctx.eulerRotation);
         if (ctx.world.Contains<RigidBody>(self))
         {
             auto& body = ctx.world.Get<RigidBody>(self);

--- a/source/ncengine/ui/editor/impl/windows/SceneGraph.cpp
+++ b/source/ncengine/ui/editor/impl/windows/SceneGraph.cpp
@@ -79,6 +79,12 @@ void SceneGraph::OnClose(EditorContext& ctx)
 
 void SceneGraph::SetEntitySelection(EditorContext& ctx, Entity entity)
 {
+    if (entity.Valid())
+    {
+        const auto& transform = ctx.world.Get<Transform>(entity);
+        ctx.eulerRotation = transform.LocalRotation().ToEulerAngles();
+    }
+
     ctx.selectedEntity = entity;
     ctx.world.Get<WireframeRenderer>(m_selectedEntityWireframe).target = entity;
     ctx.world.Get<WireframeRenderer>(m_selectedColliderWireframe).target =

--- a/source/ncmath/Quaternion.cpp
+++ b/source/ncmath/Quaternion.cpp
@@ -1,7 +1,29 @@
 #include "ncmath/Quaternion.h"
+#include "ncmath/MatrixUtilities.h"
 #include "ncutility/NcError.h"
 
 #include "DirectXMath.h"
+
+using namespace DirectX;
+
+namespace
+{
+auto GetRotation4x4(FXMVECTOR quat) -> XMFLOAT4X4
+{
+    const auto matrixXM = XMMatrixRotationQuaternion(quat);
+    auto matrix = XMFLOAT4X4{};
+    XMStoreFloat4x4(&matrix, matrixXM);
+    return matrix;
+}
+
+auto IsPitchNear90(float pitch) -> bool
+{
+    constexpr auto epsilon = 5.0e-5f;
+    constexpr auto pi_2 = std::numbers::pi_v<float> / 2.0f;
+    const auto absPitch = std::fabs(pitch);
+    return std::fabs(absPitch - pi_2) <= epsilon;
+}
+} // anonymous namespace
 
 namespace nc
 {
@@ -15,91 +37,89 @@ Quaternion::Quaternion(float X, float Y, float Z, float W)
     );
 }
 
-Vector3 Quaternion::ToEulerAngles() const noexcept
+auto Quaternion::ToEulerAngles() const noexcept -> Vector3
 {
-    float roll = std::atan2(2.0f * (w * x + y * z), 1.0f - 2.0f * (x * x + y * y));
-    float sinp = 2.0f * (w * y - z * x);
-    float pitch = std::abs(sinp) >= 1.0f ? std::copysign(std::numbers::pi_v<float> / 2.0f, sinp) : std::asin(sinp);
-    float yaw = std::atan2(2.0f * (w * z + x * y), 1.0f - 2.0f * (y * y + z * z));
-    return Vector3{roll, pitch, yaw};
+    const auto m = GetRotation4x4(ToXMVector(*this));
+    auto out = Vector3{};
+    auto& [pitch, yaw, roll] = out;
+
+    pitch = -std::asin(Clamp(m._32, -1.0f, 1.0f));
+    if (!IsPitchNear90(pitch))
+    {
+        yaw = std::atan2(m._31, m._33);
+        roll = std::atan2(m._12, m._22);
+    }
+    else
+    {
+        // Gimbal lock case
+        yaw = std::atan2(-m._13, m._11);
+        roll = 0.0f;
+    }
+
+    return out;
 }
 
 void Quaternion::ToAxisAngle(Vector3* axisOut, float* angleOut) const noexcept
 {
-    DirectX::XMVECTOR axis_v;
-    DirectX::XMQuaternionToAxisAngle(&axis_v, angleOut, DirectX::XMVectorSet(x, y, z, w));
-    DirectX::XMStoreVector3(axisOut, axis_v);
+    auto axis_v = XMVECTOR{};
+    XMQuaternionToAxisAngle(&axis_v, angleOut, ToXMVector(*this));
+    axis_v = XMVector3Normalize(axis_v);
+    XMStoreVector3(axisOut, axis_v);
 }
 
-Quaternion Quaternion::FromEulerAngles(const Vector3& angles)
+auto Quaternion::FromEulerAngles(const Vector3& angles) -> Quaternion
 {
-    auto quat_v = DirectX::XMQuaternionRotationRollPitchYaw(angles.x, angles.y, angles.z);
-    auto out = Quaternion::Identity();
-    DirectX::XMStoreQuaternion(&out, quat_v);
-    return out;
+    return FromEulerAngles(angles.x, angles.y, angles.z);
 }
 
-Quaternion Quaternion::FromEulerAngles(float x, float y, float z)
+auto Quaternion::FromEulerAngles(float x, float y, float z) -> Quaternion
 {
-    auto quat_v = DirectX::XMQuaternionRotationRollPitchYaw(x, y, z);
-    auto out = Quaternion::Identity();
-    DirectX::XMStoreQuaternion(&out, quat_v);
-    return out;
+    const auto quat_v = XMQuaternionRotationRollPitchYaw(x, y, z);
+    return ToQuaternion(quat_v);
 }
 
-Quaternion Quaternion::FromAxisAngle(const Vector3& axis, float radians)
+auto Quaternion::FromAxisAngle(const Vector3& axis, float radians) -> Quaternion
 {
-    NC_ASSERT(axis != Vector3::Zero(), "Axis cannot be zero");
-    auto axis_v = DirectX::XMVectorSet(axis.x, axis.y, axis.z, 0.0f);
-    auto quat_v = DirectX::XMQuaternionRotationAxis(axis_v, radians);
-    auto out = Quaternion::Identity();
-    DirectX::XMStoreQuaternion(&out, quat_v);
-    return out;
+    NC_ASSERT(axis != Vector3::Zero(), "Invalid Rotation Axis");
+
+    const auto quat_v = XMQuaternionRotationAxis(ToXMVector(axis), radians);
+    return ToQuaternion(quat_v);
 }
 
-Quaternion Normalize(const Quaternion& quat)
+auto Normalize(const Quaternion& quat) -> Quaternion
 {
-    float magInv = 1.0f / sqrt(quat.x * quat.x + quat.y * quat.y + quat.z * quat.z + quat.w * quat.w);
+    const auto magInv = 1.0f / sqrt(quat.x * quat.x + quat.y * quat.y + quat.z * quat.z + quat.w * quat.w);
     return Quaternion{magInv * quat.x, magInv * quat.y, magInv * quat.z, magInv * quat.w};
 }
 
-Quaternion Multiply(const Quaternion& lhs, const Quaternion& rhs)
+auto Multiply(const Quaternion& lhs, const Quaternion& rhs) -> Quaternion
 {
-    auto lhs_v = DirectX::XMVectorSet(lhs.x, lhs.y, lhs.z, lhs.w);
-    auto rhs_v = DirectX::XMVectorSet(rhs.x, rhs.y, rhs.z, rhs.w);
-    auto out_v = DirectX::XMQuaternionMultiply(lhs_v, rhs_v); // returns rhs_v * lhs_v
-    auto out = Quaternion::Identity();
-    DirectX::XMStoreQuaternion(&out, out_v);
-    return out;
+    const auto lhs_v = ToXMVector(lhs);
+    const auto rhs_v = ToXMVector(rhs);
+    const auto out_v = XMQuaternionMultiply(lhs_v, rhs_v); // returns rhs_v * lhs_s
+    return ToQuaternion(out_v);
 }
 
-Quaternion Difference(const Quaternion& lhs, const Quaternion& rhs)
+auto Difference(const Quaternion& lhs, const Quaternion& rhs) -> Quaternion
 {
-    auto lhs_v = DirectX::XMVectorSet(lhs.x, lhs.y, lhs.z, lhs.w);
-    auto rhs_v = DirectX::XMVectorSet(rhs.x, rhs.y, rhs.z, rhs.w);
-    lhs_v = DirectX::XMQuaternionConjugate(lhs_v);
-    auto out_v = DirectX::XMQuaternionMultiply(lhs_v, rhs_v);
-    auto out = Quaternion::Identity();
-    DirectX::XMStoreQuaternion(&out, out_v);
-    return out;
+    const auto lhs_v = XMQuaternionConjugate(ToXMVector(lhs));
+    const auto rhs_v = ToXMVector(rhs);
+    const auto out_v = XMQuaternionMultiply(lhs_v, rhs_v);
+    return ToQuaternion(out_v);
 }
 
-Quaternion Slerp(const Quaternion& lhs, const Quaternion& rhs, float factor)
+auto Slerp(const Quaternion& lhs, const Quaternion& rhs, float factor) -> Quaternion
 {
-    auto lhs_v = DirectX::XMVectorSet(lhs.x, lhs.y, lhs.z, lhs.w);
-    auto rhs_v = DirectX::XMVectorSet(rhs.x, rhs.y, rhs.z, rhs.w);
-    auto out_v = DirectX::XMQuaternionSlerp(lhs_v, rhs_v, factor);
-    auto out = Quaternion::Identity();
-    DirectX::XMStoreQuaternion(&out, out_v);
-    return out;
+    const auto lhs_v = ToXMVector(lhs);
+    const auto rhs_v = ToXMVector(rhs);
+    const auto out_v = XMQuaternionSlerp(lhs_v, rhs_v, factor);
+    return ToQuaternion(out_v);
 }
 
-Quaternion Scale(const Quaternion& quat, float factor)
+auto Scale(const Quaternion& quat, float factor) -> Quaternion
 {
-    auto quat_v = DirectX::XMVectorSet(quat.x, quat.y, quat.z, quat.w);
-    auto out_v = DirectX::XMQuaternionSlerp(DirectX::g_XMIdentityR3, quat_v, factor);
-    auto out = Quaternion::Identity();
-    DirectX::XMStoreQuaternion(&out, out_v);
-    return out;
+    const auto quat_v = ToXMVector(quat);
+    const auto out_v = XMQuaternionSlerp(g_XMIdentityR3, quat_v, factor);
+    return ToQuaternion(out_v);
 }
 } // namespace nc

--- a/test/ncmath/CMakeLists.txt
+++ b/test/ncmath/CMakeLists.txt
@@ -20,6 +20,31 @@ target_link_libraries(Math_unit_tests
 
 add_test(Math_unit_tests Math_unit_tests)
 
+### Quaternion Tests ###
+add_executable(Quaternion_unit_tests
+    Quaternion_unit_test.cpp
+    ${PROJECT_SOURCE_DIR}/source/ncmath/Quaternion.cpp
+)
+
+target_include_directories(Quaternion_unit_tests
+    PRIVATE
+        ${PROJECT_SOURCE_DIR}/include
+)
+
+target_compile_options(Quaternion_unit_tests
+    PUBLIC
+        ${NC_COMPILER_FLAGS}
+)
+
+target_link_libraries(Quaternion_unit_tests
+    PRIVATE
+        gtest_main
+        fmt::fmt
+        DirectXMath
+)
+
+add_test(Quaternion_unit_tests Quaternion_unit_tests)
+
 ### Vector Tests ###
 add_executable(Vector_unit_tests
     Vector_unit_test.cpp

--- a/test/ncmath/Quaternion_unit_test.cpp
+++ b/test/ncmath/Quaternion_unit_test.cpp
@@ -1,0 +1,322 @@
+#include "gtest/gtest.h"
+#include "ncmath/Quaternion.h"
+
+#include <array>
+
+constexpr float g_epsilon = 1.0e-5f;
+
+void ExpectVectorNear(const nc::Vector3& expected,
+                      const nc::Vector3& actual,
+                      float epsilon = g_epsilon)
+{
+    EXPECT_NEAR(expected.x, actual.x, epsilon);
+    EXPECT_NEAR(expected.y, actual.y, epsilon);
+    EXPECT_NEAR(expected.z, actual.z, epsilon);
+}
+
+void ExpectSameRotation(const nc::Quaternion& lhs,
+                        const nc::Quaternion& rhs,
+                        float epsilon = g_epsilon)
+{
+    const auto same =
+        std::abs(lhs.x - rhs.x) <= epsilon &&
+        std::abs(lhs.y - rhs.y) <= epsilon &&
+        std::abs(lhs.z - rhs.z) <= epsilon &&
+        std::abs(lhs.w - rhs.w) <= epsilon;
+
+    const auto opposite =
+        std::abs(lhs.x + rhs.x) <= epsilon &&
+        std::abs(lhs.y + rhs.y) <= epsilon &&
+        std::abs(lhs.z + rhs.z) <= epsilon &&
+        std::abs(lhs.w + rhs.w) <= epsilon;
+
+    EXPECT_TRUE(same || opposite)
+        << "Quaternions represent different rotations:\n"
+        << "lhs = (" << lhs.x << ", " << lhs.y << ", " << lhs.z << ", " << lhs.w << ")\n"
+        << "rhs = (" << rhs.x << ", " << rhs.y << ", " << rhs.z << ", " << rhs.w << ")";
+}
+
+void ExpectUnitQuaternion(const nc::Quaternion& q, float epsilon = g_epsilon)
+{
+    const float sqrMag =
+        q.x * q.x +
+        q.y * q.y +
+        q.z * q.z +
+        q.w * q.w;
+
+    EXPECT_NEAR(sqrMag, 1.0f, epsilon);
+}
+
+TEST(QuaternionTest, DefaultConstructor_returnsIdentity)
+{
+    const auto uut = nc::Quaternion{};
+
+    EXPECT_FLOAT_EQ(uut.x, 0.0f);
+    EXPECT_FLOAT_EQ(uut.y, 0.0f);
+    EXPECT_FLOAT_EQ(uut.z, 0.0f);
+    EXPECT_FLOAT_EQ(uut.w, 1.0f);
+}
+
+TEST(QuaternionTest, Identity_returnsIdentity)
+{
+    const auto uut = nc::Quaternion::Identity();
+
+    EXPECT_FLOAT_EQ(uut.x, 0.0f);
+    EXPECT_FLOAT_EQ(uut.y, 0.0f);
+    EXPECT_FLOAT_EQ(uut.z, 0.0f);
+    EXPECT_FLOAT_EQ(uut.w, 1.0f);
+}
+
+TEST(QuaternionTest, Normalize_producesUnitQuaternion)
+{
+    const auto q = nc::Normalize(nc::Quaternion{1.0f, 2.0f, 3.0f, 4.0f});
+    const auto length = std::sqrt(1.0f + 4.0f + 9.0f + 16.0f);
+
+    ExpectUnitQuaternion(q);
+    EXPECT_NEAR(q.x, 1.0f / length, g_epsilon);
+    EXPECT_NEAR(q.y, 2.0f / length, g_epsilon);
+    EXPECT_NEAR(q.z, 3.0f / length, g_epsilon);
+    EXPECT_NEAR(q.w, 4.0f / length, g_epsilon);
+}
+
+TEST(QuaternionTest, Normalize_identity_isIdentity)
+{
+    const auto identity = nc::Quaternion::Identity();
+    ExpectSameRotation(nc::Normalize(identity), identity);
+}
+
+TEST(QuaternionTest, FromEulerAngles_overloadsProducesSameResult)
+{
+    const auto angles = nc::Vector3{0.25f, -0.75f, 1.25f};
+    const auto fromVector = nc::Quaternion::FromEulerAngles(angles);
+    const auto fromComponents = nc::Quaternion::FromEulerAngles(angles.x, angles.y, angles.z);
+
+    ExpectSameRotation(fromVector, fromComponents);
+}
+
+TEST(QuaternionTest, FromEulerAngles_ToEulerAngles_roundTrip)
+{
+    const auto expected = nc::Vector3{1.0f, 2.0f, 3.0f};
+    const auto uut = nc::Quaternion::FromEulerAngles(expected);
+    const auto actual = uut.ToEulerAngles();
+
+    ExpectVectorNear(expected, actual);
+}
+
+TEST(QuaternionTest, FromEulerAngles_ToEulerAngles_roundTripSeveralRotations)
+{
+    constexpr auto testAngles = std::array{
+        nc::Vector3{ 0.0f,  0.0f,   0.0f},
+        nc::Vector3{ 0.1f,  0.2f,   0.3f},
+        nc::Vector3{-0.5f,  0.75f, -1.25f},
+        nc::Vector3{ 1.0f,  2.0f,   3.0f},
+        nc::Vector3{-1.0f, -2.0f,  -3.0f},
+        nc::Vector3{ 3.0f, -2.0f,   1.0f},
+    };
+
+    for (const auto& angles : testAngles)
+    {
+        const auto uut = nc::Quaternion::FromEulerAngles(angles);
+        const auto convertedAngles = uut.ToEulerAngles();
+        const auto reconstituted = nc::Quaternion::FromEulerAngles(convertedAngles);
+        ExpectSameRotation(uut, reconstituted);
+    }
+}
+
+TEST(QuaternionTest, FromEulerAngles_usesExpectedConvention)
+{
+    const auto angles = nc::Vector3{1.0f, 2.0f, 3.0f};
+    const auto uut = nc::Quaternion::FromEulerAngles(angles);
+
+    // DirectXMath's expected values
+    EXPECT_NEAR(uut.x,  0.754934f, g_epsilon);
+    EXPECT_NEAR(uut.y, -0.206149f, g_epsilon);
+    EXPECT_NEAR(uut.z,  0.444435f, g_epsilon);
+    EXPECT_NEAR(uut.w,  0.435953f, g_epsilon);
+}
+
+TEST(QuaternionTest, FromAxisAngle_zeroRotation_returnsIdentity)
+{
+    const auto uut = nc::Quaternion::FromAxisAngle(nc::Vector3::Right(), 0.0f);
+    ExpectSameRotation(uut, nc::Quaternion::Identity());
+}
+
+TEST(QuaternionTest, FromAxisAngle_xAxis)
+{
+    const auto uut = nc::Quaternion::FromAxisAngle(nc::Vector3::Right(), 1.0f);
+    const auto halfAngle = 0.5f;
+
+    EXPECT_NEAR(uut.x, std::sin(halfAngle), g_epsilon);
+    EXPECT_NEAR(uut.y, 0.0f,                g_epsilon);
+    EXPECT_NEAR(uut.z, 0.0f,                g_epsilon);
+    EXPECT_NEAR(uut.w, std::cos(halfAngle), g_epsilon);
+}
+
+TEST(QuaternionTest, FromAxisAngle_yYAxis)
+{
+    const auto uut = nc::Quaternion::FromAxisAngle(nc::Vector3::Up(), 1.0f);
+    const auto halfAngle = 0.5f;
+
+    EXPECT_NEAR(uut.x, 0.0f,                g_epsilon);
+    EXPECT_NEAR(uut.y, std::sin(halfAngle), g_epsilon);
+    EXPECT_NEAR(uut.z, 0.0f,                g_epsilon);
+    EXPECT_NEAR(uut.w, std::cos(halfAngle), g_epsilon);
+}
+
+TEST(QuaternionTest, FromAxisAngle_roundTrip)
+{
+    const auto expectedAxis = nc::Normalize(nc::Vector3{1.0f, 2.0f, 3.0f});
+    const auto expectedAngle = 1.25f;
+    const auto uut = nc::Quaternion::FromAxisAngle(expectedAxis, expectedAngle);
+    auto actualAxis = nc::Vector3{};
+    auto actualAngle = 0.0f;
+    uut.ToAxisAngle(&actualAxis, &actualAngle);
+
+    ExpectVectorNear(expectedAxis, actualAxis);
+    EXPECT_NEAR(expectedAngle, actualAngle, g_epsilon);
+
+    const auto reconstituted = nc::Quaternion::FromAxisAngle(actualAxis, actualAngle);
+    ExpectSameRotation(uut, reconstituted);
+}
+
+TEST(QuaternionTest, ToAxisAngle_identity_setsZeroAngle)
+{
+    auto axis = nc::Vector3{};
+    auto angle = 0.0f;
+    auto uut = nc::Quaternion::Identity();
+    uut.ToAxisAngle(&axis, &angle);
+
+    EXPECT_NEAR(angle, 0.0f, g_epsilon);
+}
+
+TEST(QuaternionTest, ToAxisAngle_preservesRotation)
+{
+    const auto expectedAngle = 2.0f;
+    const auto expectedAxis = nc::Normalize(
+        nc::Vector3{1.0f, 2.0f, 3.0f} / 4.0f
+    );
+
+    const auto uut = nc::Quaternion::FromAxisAngle(expectedAxis, expectedAngle);
+    auto actualAxis = nc::Vector3{};
+    auto actualAngle = 0.0f;
+    uut.ToAxisAngle(&actualAxis, &actualAngle);
+
+    EXPECT_EQ(expectedAxis, actualAxis);
+    EXPECT_NEAR(actualAngle, expectedAngle, g_epsilon);
+
+    const auto reconstituted = nc::Quaternion::FromAxisAngle(actualAxis, actualAngle);
+    ExpectSameRotation(uut, reconstituted);
+}
+
+TEST(QuaternionTest, Multiply_identity_preservesRotation)
+{
+    const auto uut = nc::Quaternion::FromEulerAngles(nc::Vector3{0.3f, 0.7f, -1.2f});
+    const auto identityLhs = nc::Multiply(nc::Quaternion::Identity(), uut);
+    const auto identityRhs = nc::Multiply(uut, nc::Quaternion::Identity());
+
+    ExpectSameRotation(identityLhs, uut);
+    ExpectSameRotation(identityRhs, uut);
+}
+
+TEST(QuaternionTest, Multiply_isAssociative)
+{
+    const auto a = nc::Quaternion::FromEulerAngles(nc::Vector3{ 0.2f,  0.3f, 0.4f});
+    const auto b = nc::Quaternion::FromEulerAngles(nc::Vector3{-0.4f,  0.5f, 0.6f});
+    const auto c = nc::Quaternion::FromEulerAngles(nc::Vector3{ 0.7f, -0.2f, 0.1f});
+    const auto lhs = nc::Multiply(Multiply(a, b), c);
+    const auto rhs = nc::Multiply(a, Multiply(b, c));
+
+    ExpectSameRotation(lhs, rhs);
+}
+
+TEST(QuaternionTest, Difference_withIdenticalRotations_returnsIdentity)
+{
+    const auto q = nc::Quaternion::FromEulerAngles(nc::Vector3{0.4f, -0.8f, 1.1f});
+    const auto difference = nc::Difference(q, q);
+
+    ExpectSameRotation(difference, nc::Quaternion::Identity());
+}
+
+TEST(QuaternionTest, Difference_withIdentity_returnsOther)
+{
+    const auto q = nc::Quaternion::FromEulerAngles(nc::Vector3{0.4f, -0.8f, 1.1f});
+    const auto difference = nc::Difference(nc::Quaternion::Identity(), q);
+
+    ExpectSameRotation(difference, q);
+}
+
+TEST(QuaternionTest, Slerp_factorZero_returnsLhs)
+{
+    const auto lhs = nc::Quaternion::FromEulerAngles(nc::Vector3{0.2f, 0.4f, 0.6f});
+    const auto rhs = nc::Quaternion::FromEulerAngles(nc::Vector3{-0.5f, 0.8f, -1.0f});
+    const auto actual = Slerp(lhs, rhs, 0.0f);
+
+    ExpectSameRotation(actual, lhs);
+}
+
+TEST(QuaternionTest, Slerp_factorOne_returnsRhs)
+{
+    const auto lhs = nc::Quaternion::FromEulerAngles(nc::Vector3{0.2f, 0.4f, 0.6f});
+    const auto rhs = nc::Quaternion::FromEulerAngles(nc::Vector3{-0.5f, 0.8f, -1.0f});
+    const auto actual = nc::Slerp(lhs, rhs, 1.0f);
+
+    ExpectSameRotation(actual, rhs);
+}
+
+TEST(QuaternionTest, Slerp_factorOneHalf_returnsMidpoint)
+{
+    const auto rhs = nc::Quaternion::FromAxisAngle(nc::Vector3::Right(), 3.14f);
+    const auto halfway = nc::Slerp(nc::Quaternion::Identity(), rhs, 0.5f);
+    const auto expected = nc::Quaternion::FromAxisAngle(nc::Vector3::Right(), 3.14f * 0.5f);
+
+    ExpectSameRotation(halfway, expected);
+}
+
+TEST(QuaternionTest, Slerp_returnsUnitQuaternion)
+{
+    const auto lhs = nc::Quaternion::FromEulerAngles(nc::Vector3{0.2f, 0.4f, 0.6f});
+    const auto rhs = nc::Quaternion::FromEulerAngles(nc::Vector3{-0.5f, 0.8f, -1.0f});
+    const auto result = nc::Slerp(lhs, rhs, 0.37f);
+
+    ExpectUnitQuaternion(result);
+}
+
+TEST(QuaternionTest, Slerp_equivalentOppositeSignedQuaternions)
+{
+    // q == -q
+    const auto q = nc::Quaternion::FromEulerAngles(nc::Vector3{0.4f, -0.7f, 1.2f});
+    const auto negated = nc::Quaternion{-q.x, -q.y, -q.z, -q.w};
+    const auto actual = nc::Slerp(q, negated, 0.5f);
+
+    ExpectSameRotation(actual, q);
+}
+
+TEST(QuaternionTest, Scale_factorZero_returnsIdentity)
+{
+    const auto uut = nc::Quaternion::FromEulerAngles(nc::Vector3{0.4f, -0.7f, 1.2f});
+    ExpectSameRotation(nc::Scale(uut, 0.0f), nc::Quaternion::Identity());
+}
+
+TEST(QuaternionTest, Scale_factorOne_returnsOriginal)
+{
+    const auto uut = nc::Quaternion::FromEulerAngles(nc::Vector3{0.4f, -0.7f, 1.2f});
+    ExpectSameRotation(nc::Scale(uut, 1.0f), uut);
+}
+
+TEST(QuaternionTest, Scale_factorOneHalf_returnsHalf)
+{
+    const auto uut = nc::Quaternion::FromAxisAngle(nc::Vector3::Up(), 3.14f);
+    const auto actual = nc::Scale(uut, 0.5f);
+    const auto expected = nc::Quaternion::FromAxisAngle(nc::Vector3::Up(), 3.14f * 0.5f);
+
+    ExpectSameRotation(expected, actual);
+}
+
+TEST(QuaternionTest, Scale_producesUnitQuaternion)
+{
+    const auto uut = nc::Quaternion::FromEulerAngles(nc::Vector3{0.4f, -0.7f, 1.2f});
+    for (const auto factor : {0.0f, 0.25f, 0.5f, 0.75f, 1.0f})
+    {
+        ExpectUnitQuaternion(nc::Scale(uut, factor));
+    }
+}


### PR DESCRIPTION
resolves #336

- In editor, we now cache euler angles on object selection so we aren't converting to/from quaternions repeatedly.
- `Quaternion` `ToEulerAngles()` and `FromEulerAngles()` were using different rotation conventions. Both are valid, but incompatible Anything using 'to' AND 'from' was certainly broken. Its possible anything using the 'to' was also broken b/c that should be incompatible with other DX stuff, but there is no other usage in the engine I see. Anyways, updated to operate in DX's terms (roll -> pitch -> yaw, or Z -> X -> Y).
- Added quaternion tests
- General cleanup of Quaternion.cpp